### PR TITLE
docs: update CONTRIBUTING.md for correct CLI commands and roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `references/linkerd.md`: mTLS, proxy injection, authorization policy, traffic management (HTTPRoute, retries, timeouts, canary splits), golden-signal observability (`linkerd viz stat/tap`), Prometheus integration, multi-cluster mirroring, and troubleshooting guide
+- Linkerd routing rule added to SKILL.md
+- `references/linkerd.md` added to `tests/validate-skill.sh` required references
+
 ## [1.2.0] - 2026-04-02
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,26 +165,26 @@ Reviewers may:
 
 ### High Priority
 
-- **Flux CD troubleshooting patterns** for common reconciliation failures
+- **Linkerd examples** — working `examples/linkerd/` assets (HTTPRoute canary split, authorization policy, PodMonitor) to back up `references/linkerd.md`
 - **IAM policy examples** showing least-privilege patterns
 - **GitHub Actions security fixes** for common vulnerabilities
-- **Multi-cloud networking patterns** for hybrid environments
 - **Disaster recovery runbooks** for platform components
 
 ### Medium Priority
 
-- **Cost optimization patterns** across AWS/Azure
-- **Observability integration** examples
+- **Observability patterns**: Prometheus, Grafana, Loki integration examples
+- **Cost optimization patterns** across AWS and Azure
+- **Multi-cloud networking patterns** for hybrid environments
+- **Policy-as-code**: OPA, Kyverno, or Gatekeeper examples
 - **Testing strategies** for infrastructure changes
 - **Migration guides** between tool versions
-- **Performance tuning** guidelines
 
 ### Lower Priority (But Still Welcome)
 
 - **Alternative approaches** to existing patterns
 - **Edge case handling** for documented patterns
 - **Tool comparisons** with decision frameworks
-- **Historical context** for architectural choices
+- **GCP patterns**: landing zone, GKE, and IAM
 
 ## Documentation Standards
 
@@ -272,14 +272,22 @@ vale references/*.md
 If you have Claude Code installed:
 
 ```bash
-# Install plugin locally
-claude plugin install .
+# Register the local repo as a marketplace and install
+claude plugin marketplace add $(pwd)
+claude plugin install platform-skills
 
-# Test plugin activation
-# (Open Claude Code and try relevant prompts)
+# Verify version and status
+claude plugin list
 
 # Uninstall after testing
 claude plugin uninstall platform-skills
+```
+
+To upgrade after making further changes, re-run:
+
+```bash
+claude plugin marketplace update
+claude plugin install platform-skills
 ```
 
 ## Release Process
@@ -374,8 +382,8 @@ The release workflow provides marketplace publication instructions in the GitHub
 
 After marketplace publication:
 
-- [ ] Verify marketplace installation: `claude plugin install platform-skills`
-- [ ] Verify local installation: `claude plugin install .`
+- [ ] Verify marketplace installation: `claude plugin marketplace update && claude plugin install platform-skills`
+- [ ] Verify local installation: `claude plugin marketplace add $(pwd) && claude plugin install platform-skills`
 - [ ] Update README badges if needed
 - [ ] Announce release (optional)
 - [ ] Monitor issues for feedback

--- a/README.md
+++ b/README.md
@@ -141,9 +141,13 @@ platform-skills/
 
 ## Roadmap
 
+**v1.3.0**
+- [x] Linkerd: mTLS, observability, traffic management, multi-cluster
+
+**Planned**
 - [ ] GCP: landing zone, GKE, and IAM patterns
 - [ ] Observability: Prometheus, Grafana, Loki
-- [ ] Service mesh: Istio, Linkerd
+- [ ] Service mesh: Istio
 - [ ] Policy-as-code: OPA, Kyverno, Gatekeeper
 - [ ] OpenShift operator lifecycle patterns
 - [ ] Argo CD ApplicationSet fleet patterns

--- a/SKILL.md
+++ b/SKILL.md
@@ -17,7 +17,8 @@ Match the task to the right layer:
 4. `Flux` or `Argo CD`: Reconcile in-cluster desired state after bootstrap and manage promotion of workloads or platform add-ons.
 5. `GitHub Actions`: Validate, package, test, and promote changes. Keep workflows declarative and reusable.
 6. `AWS` or `Azure`: Apply provider-specific account, subscription, identity, and governance patterns.
-7. `Cross-platform`: Design repo boundaries, ownership, promotion flows, and security controls first.
+7. `Linkerd`: Apply service mesh for automatic mTLS, golden-signal observability, and traffic management between workloads.
+8. `Cross-platform`: Design repo boundaries, ownership, promotion flows, and security controls first.
 
 If a task spans multiple areas, decide which layer owns the source of truth and keep the other layers consumers of that state.
 
@@ -58,5 +59,6 @@ When asked to generate code, start from the thinnest useful slice that proves th
 - For Azure management groups, identity, and AKS-oriented patterns, read [references/azure.md](references/azure.md).
 - For reusable workflows, OIDC, and delivery controls, read [references/github-actions.md](references/github-actions.md).
 - For secrets strategy, External Secrets Operator, and Sealed Secrets patterns, read [references/secrets.md](references/secrets.md).
+- For Linkerd service mesh, mTLS, observability, traffic management, and multi-cluster, read [references/linkerd.md](references/linkerd.md).
 
 Load only the files needed for the current request.

--- a/references/linkerd.md
+++ b/references/linkerd.md
@@ -1,0 +1,493 @@
+# Linkerd Reference
+
+## Contents
+
+- Scope
+- Architecture
+- Installation
+- Mesh injection
+- mTLS
+- Traffic management
+- Observability
+- Multi-cluster
+- Troubleshooting
+
+## Scope
+
+Use Linkerd for:
+
+- Automatic mutual TLS between workloads without application code changes
+- L7 observability: golden signals (success rate, latency, RPS) per route and deployment
+- Traffic management: retries, timeouts, canary splits via HTTPRoute
+- Multi-cluster service mirroring with encrypted cross-cluster traffic
+
+Do not expect Linkerd to replace:
+
+- Ingress controllers (Linkerd handles east-west mesh traffic, not north-south ingress)
+- Network policies (Linkerd authorization policy complements, not replaces, Kubernetes NetworkPolicy)
+- DNS or service discovery (Linkerd wraps existing Kubernetes DNS)
+
+## Architecture
+
+### Control plane
+
+| Component | Role |
+|-----------|------|
+| `destination` | Resolves service endpoints, traffic policies, and route configurations |
+| `identity` | Issues short-lived workload certificates (default 24h) for mTLS |
+| `proxy-injector` | Webhook that injects the sidecar proxy into pods at admission time |
+
+### Data plane
+
+Each meshed pod gets a `linkerd-proxy` sidecar (written in Rust). The proxy intercepts all inbound and outbound traffic transparently using `iptables` rules added by the `linkerd-init` init container.
+
+The proxy handles:
+- mTLS negotiation and certificate validation
+- Retries, timeouts, and circuit breaking
+- Metrics export on `:4191/metrics` (scraped by Prometheus)
+
+## Installation
+
+### Prerequisites
+
+- Kubernetes 1.22+
+- `linkerd` CLI matching the control plane version
+- A trust anchor certificate (self-signed or cert-manager)
+
+### Control plane install
+
+```bash
+# Pre-flight checks
+linkerd check --pre
+
+# Install CRDs
+linkerd install --crds | kubectl apply -f -
+
+# Install control plane
+linkerd install | kubectl apply -f -
+
+# Verify all components are healthy
+linkerd check
+```
+
+### Using cert-manager for the identity CA
+
+Back the Linkerd identity issuer with cert-manager so the intermediate CA rotates automatically:
+
+```yaml
+# Certificate issued by cert-manager for Linkerd identity
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: linkerd-identity-issuer
+  namespace: linkerd
+spec:
+  secretName: linkerd-identity-issuer
+  duration: 48h
+  renewBefore: 25h
+  issuerRef:
+    name: linkerd-trust-anchor    # ClusterIssuer backed by your root CA
+    kind: ClusterIssuer
+  commonName: identity.linkerd.cluster.local
+  dnsNames:
+    - identity.linkerd.cluster.local
+  isCA: true
+  privateKey:
+    algorithm: ECDSA
+  usages:
+    - cert sign
+    - crl sign
+    - server auth
+    - client auth
+```
+
+Then install Linkerd pointing at cert-manager's output:
+
+```bash
+linkerd install \
+  --identity-external-issuer \
+  | kubectl apply -f -
+```
+
+### Linkerd Viz (observability extension)
+
+```bash
+linkerd viz install | kubectl apply -f -
+linkerd viz check
+```
+
+## Mesh injection
+
+### Namespace-level injection
+
+Annotate a namespace to auto-inject the proxy into every new pod:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: payments
+  annotations:
+    linkerd.io/inject: enabled
+```
+
+Existing pods are not re-injected automatically. Rollout the deployment after annotating:
+
+```bash
+kubectl rollout restart deployment -n payments
+```
+
+### Pod-level override
+
+Opt a specific pod out of injection inside an injected namespace:
+
+```yaml
+spec:
+  template:
+    metadata:
+      annotations:
+        linkerd.io/inject: disabled
+```
+
+### Verify injection
+
+```bash
+# Check which pods in a namespace are meshed
+linkerd check --namespace payments
+
+# Show proxy version and injection status per pod
+kubectl get pods -n payments -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.linkerd\.io/inject}{"\n"}{end}'
+```
+
+### What not to inject
+
+- `kube-system` and `kube-public` — control plane components will break
+- Linkerd's own `linkerd` namespace — already meshed differently
+- Jobs and CronJobs that use `hostNetwork: true`
+- Daemonsets that must run before the proxy is ready (e.g., CNI plugins)
+
+## mTLS
+
+Linkerd automatically establishes mTLS between all meshed pods. No certificate management or application changes are needed.
+
+### How it works
+
+1. `proxy-injector` injects the sidecar at pod admission
+2. On startup, the proxy fetches a short-lived SPIFFE-compatible certificate from the `identity` component
+3. The certificate encodes the pod's Kubernetes ServiceAccount as the identity
+4. All proxies validate peer certificates before forwarding traffic
+
+### Verify mTLS is active
+
+```bash
+# Show secured/unsecured edges between deployments
+linkerd viz edges deployment -n payments
+
+# Output includes: SRC, DST, SECURED (yes/no)
+# If a pod is unmeshed, the edge shows "no" — traffic is plaintext
+```
+
+### Authorization policy
+
+Restrict which identities can call a service (replaces or supplements NetworkPolicy):
+
+```yaml
+apiVersion: policy.linkerd.io/v1beta3
+kind: Server
+metadata:
+  name: payments-api
+  namespace: payments
+spec:
+  podSelector:
+    matchLabels:
+      app: payments-api
+  port: 8080
+  proxyProtocol: HTTP/2
+---
+apiVersion: policy.linkerd.io/v1beta3
+kind: AuthorizationPolicy
+metadata:
+  name: payments-api-allow-checkout
+  namespace: payments
+spec:
+  targetRef:
+    group: policy.linkerd.io
+    kind: Server
+    name: payments-api
+  requiredAuthenticationRefs:
+    - name: checkout-sa
+      kind: MeshTLSAuthentication
+      group: policy.linkerd.io
+---
+apiVersion: policy.linkerd.io/v1beta3
+kind: MeshTLSAuthentication
+metadata:
+  name: checkout-sa
+  namespace: payments
+spec:
+  identities:
+    - "checkout.payments.serviceaccount.identity.linkerd.cluster.local"
+```
+
+## Traffic management
+
+Linkerd uses the Kubernetes Gateway API (`HTTPRoute`) for traffic splitting and routing rules.
+
+### Canary traffic split
+
+Route 90% of traffic to stable, 10% to canary:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: payments-api-canary
+  namespace: payments
+spec:
+  parentRefs:
+    - name: payments-api
+      kind: Service
+      group: core
+      port: 8080
+  rules:
+    - backendRefs:
+        - name: payments-api-stable
+          port: 8080
+          weight: 90
+        - name: payments-api-canary
+          port: 8080
+          weight: 10
+```
+
+### Retries
+
+```yaml
+apiVersion: policy.linkerd.io/v1alpha1
+kind: HTTPLocalRateLimitPolicy
+metadata:
+  name: payments-retry
+  namespace: payments
+```
+
+For retries, use annotations on the HTTPRoute or configure via the Linkerd `retry` annotation on the Service:
+
+```yaml
+# Retry on 5xx responses, up to 2 retries
+metadata:
+  annotations:
+    retry.linkerd.io/http: "5xx"
+    retry.linkerd.io/limit: "2"
+```
+
+### Timeouts
+
+```yaml
+# Per-route timeout via HTTPRoute
+spec:
+  rules:
+    - timeouts:
+        request: 10s
+        backendRequest: 5s
+```
+
+## Observability
+
+### Golden signals per deployment
+
+```bash
+# Success rate, RPS, and latency for all deployments in a namespace
+linkerd viz stat deploy -n payments
+
+# Drill into a specific deployment
+linkerd viz stat deploy/payments-api -n payments
+
+# Per-route breakdown
+linkerd viz stat httproute -n payments
+```
+
+### Live request tracing
+
+```bash
+# Tap live traffic to a deployment (shows headers, status codes, latency)
+linkerd viz tap deploy/payments-api -n payments
+
+# Filter to specific path
+linkerd viz tap deploy/payments-api -n payments --path /api/v1/charge
+```
+
+### Prometheus integration
+
+Linkerd proxies expose metrics on port `4191`. Scrape them with a `PodMonitor` (Prometheus Operator):
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: linkerd-proxy
+  namespace: monitoring
+spec:
+  namespaceSelector:
+    any: true
+  podMetricsEndpoints:
+    - port: linkerd-admin
+      path: /metrics
+  selector:
+    matchLabels:
+      linkerd.io/control-plane-ns: linkerd
+```
+
+Key metrics to alert on:
+
+| Metric | Alert threshold |
+|--------|----------------|
+| `request_total{direction="inbound", classification="failure"}` | > 1% of total |
+| `response_latency_ms_bucket{le="1000"}` | p99 > 1000ms |
+| `tcp_open_connections` | sustained spike vs. baseline |
+
+## Multi-cluster
+
+Linkerd multi-cluster mirrors services from one cluster into another using a gateway and a `ServiceMirror` controller.
+
+### Requirements
+
+- Both clusters must share the same trust anchor (root CA)
+- Clusters must have network connectivity to each other's gateway LoadBalancer IPs
+
+### Link clusters
+
+On the target cluster (where the service lives):
+
+```bash
+# Install multi-cluster extension
+linkerd multicluster install | kubectl apply -f -
+linkerd multicluster check
+
+# Generate link credentials for the source cluster
+linkerd multicluster link --cluster-name production > link-production.yaml
+```
+
+On the source cluster (where you want to consume the service):
+
+```bash
+kubectl apply -f link-production.yaml
+linkerd multicluster check
+```
+
+### Mirror a service
+
+Label the service in the target cluster to make it available cross-cluster:
+
+```yaml
+metadata:
+  labels:
+    mirror.linkerd.io/exported: "true"
+```
+
+The `ServiceMirror` controller creates a mirrored service in the source cluster named `<service>-<cluster-name>` (e.g., `payments-api-production`). Traffic to that service is tunnelled over mTLS to the target cluster's gateway.
+
+### Verify mirroring
+
+```bash
+# On source cluster — should see mirrored services
+kubectl get svc -n payments | grep "production"
+
+# Check mirroring is healthy
+linkerd multicluster gateways
+```
+
+## Troubleshooting
+
+### Structure
+
+For every Linkerd issue: identify the layer (control plane / data plane / policy / multi-cluster), collect evidence, form a hypothesis, then fix.
+
+---
+
+**Symptom:** Pods not getting proxies injected
+
+Evidence to collect:
+```bash
+kubectl describe namespace <ns> | grep -i inject
+kubectl get mutatingwebhookconfigurations linkerd-proxy-injector -o yaml | grep -A5 namespaceSelector
+linkerd check
+```
+
+Likely causes:
+- Namespace missing `linkerd.io/inject: enabled` annotation
+- Pod has `linkerd.io/inject: disabled` override
+- `proxy-injector` webhook is failing — check `linkerd check` output
+
+---
+
+**Symptom:** mTLS edges showing `no` (plaintext)
+
+Evidence to collect:
+```bash
+linkerd viz edges deployment -n <namespace>
+kubectl get pods -n <namespace> -o wide  # check both src and dst are meshed
+linkerd check --namespace <namespace>
+```
+
+Likely causes:
+- One side of the connection is not meshed (check both pods)
+- Pod was running before namespace was annotated and hasn't been rolled
+
+Fix:
+```bash
+kubectl rollout restart deployment/<name> -n <namespace>
+```
+
+---
+
+**Symptom:** `linkerd check` reports certificate expiry or identity errors
+
+Evidence to collect:
+```bash
+linkerd check
+kubectl get secret linkerd-identity-issuer -n linkerd -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -dates
+```
+
+Likely causes:
+- Issuer certificate expired (cert-manager rotation failed)
+- Trust anchor mismatch after manual rotation
+
+Fix: rotate using cert-manager renewal or `linkerd upgrade --identity-external-issuer`.
+
+---
+
+**Symptom:** High latency after enabling Linkerd
+
+Evidence to collect:
+```bash
+linkerd viz stat deploy -n <namespace>
+linkerd viz tap deploy/<name> --max-rps 10
+kubectl top pods -n <namespace>  # check proxy CPU
+```
+
+Likely causes:
+- Proxy CPU limit too low (default is 1 CPU) — under heavy load the proxy queues requests
+- Retry storms amplifying load
+
+Fix: increase proxy resource limits via annotation:
+
+```yaml
+annotations:
+  config.linkerd.io/proxy-cpu-limit: "2"
+  config.linkerd.io/proxy-memory-limit: "256Mi"
+```
+
+---
+
+**Symptom:** Multi-cluster mirrored service unreachable
+
+Evidence to collect:
+```bash
+linkerd multicluster gateways          # check gateway status
+kubectl get svc -n linkerd-multicluster  # check gateway LB IP is assigned
+linkerd check --multicluster
+```
+
+Likely causes:
+- Gateway LoadBalancer IP not yet assigned
+- Firewall blocking port 4143 between cluster networks
+- Trust anchor mismatch between clusters

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -42,6 +42,7 @@ REQUIRED_REFERENCES=(
   references/azure.md
   references/github-actions.md
   references/secrets.md
+  references/linkerd.md
 )
 
 for ref in "${REQUIRED_REFERENCES[@]}"; do


### PR DESCRIPTION
## Summary

- **Fix local install commands**: `claude plugin install .` does not support local paths — replaced with `claude plugin marketplace add $(pwd)` + `claude plugin install platform-skills` in Testing Changes Locally and post-release checklist
- **Add upgrade flow**: `claude plugin marketplace update` reminder added for iterative local testing
- **Update What We're Looking For**: Linkerd examples promoted to High Priority (reference guide exists, examples needed); Observability and Policy-as-code added to Medium; GCP moved to Lower Priority to match current roadmap

## Test plan

- [ ] Read through Testing Changes Locally — commands are copy-pasteable and match actual CLI behaviour
- [ ] Read through Post-Release checklist — verify steps use correct install flow
- [ ] What We're Looking For reflects README roadmap priorities