### PR TITLE
1.3.0 Release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "description": "Practical guidance for developers and DevOps engineers working with Kubernetes, Terraform, GitHub Actions, Flux, Argo CD, AWS, Azure, and secrets management. Get troubleshooting guides, security-first patterns, and working examples for Kubernetes workloads, GitOps workflows, CI/CD pipelines, cloud IAM, RBAC, and infrastructure as code — at any scale.",
       "author": {
         "name": "Nitin Jain"
@@ -37,7 +37,10 @@
         "security",
         "openshift",
         "devops",
-        "platform-engineering"
+        "platform-engineering",
+        "linkerd",
+        "service-mesh",
+        "mtls"
       ],
       "source": {
         "source": "url",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-02
+
 ### Added
-- `references/linkerd.md`: mTLS, proxy injection, authorization policy, traffic management (HTTPRoute, retries, timeouts, canary splits), golden-signal observability (`linkerd viz stat/tap`), Prometheus integration, multi-cluster mirroring, and troubleshooting guide
-- Linkerd routing rule added to SKILL.md
+
+#### Reference Guides
+- `references/linkerd.md`: mTLS, proxy injection, authorization policy, traffic management (HTTPRoute, retries, timeouts, canary splits), golden-signal observability (`linkerd viz stat/tap`), Prometheus PodMonitor integration, multi-cluster mirroring, and 5-scenario troubleshooting guide
+- Linkerd routing rule added to SKILL.md tool classification
 - `references/linkerd.md` added to `tests/validate-skill.sh` required references
+
+### Changed
+- CONTRIBUTING.md: fixed local install commands (`claude plugin install .` → `claude plugin marketplace add $(pwd)` + `claude plugin install platform-skills`); added upgrade flow; updated What We're Looking For to reflect current roadmap priorities
 
 ## [1.2.0] - 2026-04-02
 


### PR DESCRIPTION
## Summary

- Bump `marketplace.json` version to `1.3.0`
- Add `linkerd`, `service-mesh`, `mtls` keywords to marketplace.json
- Move `[Unreleased]` CHANGELOG content into `[1.3.0] - 2026-04-02`

## What's in 1.3.0

- `references/linkerd.md` — full Linkerd service mesh reference guide (mTLS, proxy injection, authorization policy, traffic management, observability, multi-cluster, troubleshooting)
- Linkerd added to SKILL.md tool routing and reference index
- `tests/validate-skill.sh` updated to require `references/linkerd.md`
- CONTRIBUTING.md: correct local install CLI commands and updated roadmap priorities

## After merging

```bash
git checkout main && git pull
git tag -a v1.3.0 -m "Release v1.3.0"
git push origin v1.3.0
```