### PR TITLE
feat: add plugin.json registration manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "description": "Practical guidance for developers and DevOps engineers working with Kubernetes, Terraform, GitHub Actions, Flux, Argo CD, AWS, Azure, and secrets management. Get troubleshooting guides, security-first patterns, and working examples for Kubernetes workloads, GitOps workflows, CI/CD pipelines, cloud IAM, RBAC, and infrastructure as code — at any scale.",
       "author": {
         "name": "Nitin Jain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "platform-skills",
+  "version": "1.4.0",
+  "description": "Practical guidance for platform engineers working with Kubernetes, Terraform, GitOps, AWS, Azure, Linkerd, GitHub Actions, and secrets management.",
+  "author": {
+    "name": "Nitin Jain",
+    "email": "nitin.solna@gmail.com",
+    "url": "https://github.com/nitinjain999"
+  },
+  "homepage": "https://github.com/nitinjain999/platform-skills",
+  "repository": "https://github.com/nitinjain999/platform-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "kubernetes",
+    "terraform",
+    "gitops",
+    "fluxcd",
+    "argocd",
+    "linkerd",
+    "aws",
+    "azure",
+    "github-actions",
+    "platform-engineering",
+    "devops"
+  ],
+  "skills": [
+    "./SKILL.md"
+  ],
+  "commands": [
+    "./commands/terraform.md",
+    "./commands/debug.md",
+    "./commands/review.md",
+    "./commands/gitops.md",
+    "./commands/linkerd.md"
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-skills",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Practical guidance for platform engineers working with Kubernetes, Terraform, GitOps, AWS, Azure, Linkerd, GitHub Actions, and secrets management.",
   "author": {
     "name": "Nitin Jain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `.claude-plugin/plugin.json` — registration manifest explicitly declaring plugin name, version, author, and all 5 command paths so Claude Code uses consistent `/platform-skills:<name>` namespacing regardless of install directory name
+
 ## [1.4.0] - 2026-04-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-04-02
+
 ### Added
-- `.claude-plugin/plugin.json` — registration manifest explicitly declaring plugin name, version, author, and all 5 command paths so Claude Code uses consistent `/platform-skills:<name>` namespacing regardless of install directory name
+- `.claude-plugin/plugin.json` — registration manifest explicitly declaring plugin name, version, author, skill (`SKILL.md`), and all 5 command paths so Claude Code uses consistent `/platform-skills:<name>` namespacing regardless of install directory name
 
 ## [1.4.0] - 2026-04-02
 


### PR DESCRIPTION
## Summary

Adds `.claude-plugin/plugin.json` to explicitly register the plugin's skill and commands with Claude Code.

## Why

Without `plugin.json`, Claude Code derives the plugin name from the install directory name — which varies per user. This breaks the `/platform-skills:<name>` slash command namespacing. With `plugin.json`, the name is always `platform-skills` regardless of where it was cloned.

## What's declared

```json
{
  "skills": ["./SKILL.md"],
  "commands": [
    "./commands/terraform.md",
    "./commands/debug.md",
    "./commands/review.md",
    "./commands/gitops.md",
    "./commands/linkerd.md"
  ]
}
```

- `SKILL.md` — ambient skill loaded into context automatically
- 5 commands — invokable as `/platform-skills:debug`, `/platform-skills:review`, `/platform-skills:terraform`, `/platform-skills:gitops`, `/platform-skills:linkerd`