### PR TITLE
chore: update marketplace.json source.sha to v1.4.2 merge commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -45,7 +45,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "2722798aa56799254e27e90626482d0b39f1334f"
+        "sha": "110072f227358418d28af95a2b5e6808c57cd9c9"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
## Summary

- Updates `source.sha` in `.claude-plugin/marketplace.json` to `110072f` (HEAD after PR #10 merge)
- Required before tagging `v1.4.2` so the marketplace SHA points to the correct commit

## Test plan

- [ ] Merge this PR
- [ ] Tag: `git tag -a v1.4.2 -m "Release v1.4.2" && git push origin v1.4.2`
- [ ] Verify release workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)