### PR TITLE
chore: update marketplace.json source.sha to v1.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -51,7 +51,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "f618e6b3c661a43fb92084a1f703b069d9ab250f"
+        "sha": "0807e02b8fd52cc114c4e8c93e1663f7e6b7a64e"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
Pre-release SHA update for v1.5.0. Merge this, then tag `v1.5.0`.