### PR TITLE
fix: exclude examples/ from secret scanner in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,8 +135,10 @@ jobs:
           POTENTIAL_SECRETS=$(grep -rE '(password|secret|key|token|apikey).*=.*["\x27][^"\x27]{8,}["\x27]' \
              --exclude-dir=.git \
              --exclude-dir=node_modules \
+             --exclude-dir=examples \
              --exclude="*.md" \
-             --exclude="CHANGELOG.md" . | \
+             --exclude="CHANGELOG.md" \
+             --exclude="release.yml" . | \
              grep -v 'matrix\.' | \
              grep -v 'vars\.' | \
              grep -v 'secrets\.' | \


### PR DESCRIPTION
## Summary

- Adds `--exclude-dir=examples` and `--exclude="release.yml"` to the secret scanner grep in the **release** workflow
- Identical fix to commit `6dab1f8` which applied this to `validate.yml`

## Root cause

The v1.6.0 release workflow failed at **Validate no secrets in code** because Terraform variable assignments in `examples/compliance/` (e.g. `key = "CLASSIFICATION"`, `token.actions.githubusercontent.com:aud = "sts.amazonaws.com"`) matched the regex pattern for credentials. These are not secrets — they are example infrastructure code.

## After merge

Delete and recreate the `v1.6.0` tag pointing to the merge commit so the release workflow reruns with this fix:

```bash
git tag -d v1.6.0
git push origin :refs/tags/v1.6.0
git tag v1.6.0 <merge-commit-sha>
git push origin v1.6.0
```

## Test plan
- [ ] Validate workflow passes on this PR
- [ ] After merge + retag, release workflow passes the "Validate no secrets" step
- [ ] GitHub Release for v1.6.0 is created