### PR TITLE
feat: add MCP, Observability, Documentation, Datadog, and Dynatrace domains (v1.8.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.7.0",
-      "description": "Practical guidance for platform engineers: Kubernetes, Helm chart development and linting, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux administration, networking, platform product thinking, and SOC 2 compliance for Terraform. Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
+      "version": "1.8.0",
+      "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP server development, observability (Prometheus/OpenTelemetry/Grafana), code documentation (OpenAPI/docstrings), and SOC 2 compliance for Terraform. Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
       "author": {
         "name": "Nitin Jain"
       },
@@ -55,7 +55,16 @@
         "checkov",
         "audit-logging",
         "iam-least-privilege",
-        "cloudtrail"
+        "cloudtrail",
+        "mcp",
+        "model-context-protocol",
+        "observability",
+        "prometheus",
+        "grafana",
+        "opentelemetry",
+        "documentation",
+        "openapi",
+        "docstrings"
       ],
       "source": {
         "source": "url",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -64,7 +64,11 @@
         "opentelemetry",
         "documentation",
         "openapi",
-        "docstrings"
+        "docstrings",
+        "datadog",
+        "dynatrace",
+        "apm",
+        "monitoring"
       ],
       "source": {
         "source": "url",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -50,6 +50,8 @@
     "./commands/helmcheck.md",
     "./commands/mcp.md",
     "./commands/observability.md",
-    "./commands/document.md"
+    "./commands/document.md",
+    "./commands/datadog.md",
+    "./commands/dynatrace.md"
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platform-skills",
-  "version": "1.7.0",
-  "description": "Practical guidance for platform engineers: Kubernetes, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux administration, networking, platform product thinking, and SOC 2 compliance for Terraform.",
+  "version": "1.8.0",
+  "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP development, observability, code documentation, and SOC 2 compliance for Terraform.",
   "author": {
     "name": "Nitin Jain",
     "email": "nitin.solna@gmail.com",
@@ -26,7 +26,14 @@
     "networking",
     "dns",
     "developer-experience",
-    "devex"
+    "devex",
+    "mcp",
+    "model-context-protocol",
+    "observability",
+    "prometheus",
+    "opentelemetry",
+    "documentation",
+    "openapi"
   ],
   "skills": [
     "./skills/platform-skills"
@@ -40,6 +47,9 @@
     "./commands/linux.md",
     "./commands/product.md",
     "./commands/compliance.md",
-    "./commands/helmcheck.md"
+    "./commands/helmcheck.md",
+    "./commands/mcp.md",
+    "./commands/observability.md",
+    "./commands/document.md"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-05-08
+
+### Added
+
+#### MCP Domain (Model Context Protocol)
+
+New Domain 13: `MCP (Model Context Protocol)` — build, review, and debug MCP servers and clients covering TypeScript and Python SDKs, Zod/Pydantic schema validation, stdio/HTTP/SSE transports, protocol compliance, authentication, and rate limiting.
+
+- `references/mcp.md` — protocol fundamentals, TypeScript SDK patterns, Python FastMCP patterns, schema design, error handling, testing with MCP Inspector, security, and deployment checklist
+- `/platform-skills:mcp` (`commands/mcp.md`) — three modes: `create` (scaffold production-ready server), `review` (protocol compliance and security audit), `debug` (diagnose transport/protocol/schema/handler failures)
+- `examples/mcp/docs-server/` — complete TypeScript MCP server with `search_docs` and `get_doc` tools and a `docs://index` resource
+
+#### Observability Domain
+
+New Domain 14: `Observability` — instrument services with structured logging, Prometheus metrics, and OpenTelemetry tracing; build Grafana dashboards, write alerting rules, run k6 load tests, and plan capacity.
+
+- `references/observability.md` — Pino/structlog structured logging, prom-client/prometheus-client metrics, OpenTelemetry tracing, RED/USE method alerting rules, Grafana dashboard templates, k6 load testing, and capacity planning formulas
+- `/platform-skills:observability` (`commands/observability.md`) — five modes: `instrument`, `dashboard`, `alert`, `loadtest`, `capacity`
+- `examples/observability/prometheus-alerts/` — RED method Prometheus alerting rules for a production service
+
+#### Documentation Domain
+
+New Domain 15: `Documentation` — generate and validate inline docstrings (Google/NumPy/Sphinx/JSDoc), OpenAPI 3.1 specifications, documentation sites (MkDocs, TypeDoc), and developer getting started guides.
+
+- `references/documentation.md` — Google/NumPy/Sphinx docstring styles, TypeScript JSDoc, OpenAPI 3.1 spec with shared components, FastAPI and NestJS auto-documentation, coverage measurement, MkDocs site setup, and guide structure
+- `/platform-skills:document` (`commands/document.md`) — four modes: `docstrings`, `openapi`, `site`, `guide`
+- `examples/documentation/openapi-spec/` — complete OpenAPI 3.1 Orders API with shared components, security schemes, and response definitions
+
 ## [1.7.0] - 2026-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.8.0] - 2026-05-08
 
+### Added (continued)
+
+#### Datadog Domain
+
+New Domain 16: `Datadog` — deploy and configure the Datadog Agent on Kubernetes, instrument services with APM and log correlation, and manage monitors, dashboards, SLOs, and synthetic tests as Terraform-managed resources.
+
+- `references/datadog.md` — Agent Helm setup, APM instrumentation (Node.js/Python), Unified Service Tagging, Log Management with processing rules, Monitors (Terraform), Dashboards (Terraform), SLOs, Synthetic tests, and troubleshooting table
+- `/platform-skills:datadog` (`commands/datadog.md`) — six modes: `setup`, `instrument`, `monitor`, `dashboard`, `slo`, `debug`
+- `examples/datadog/terraform/monitors.tf` — Terraform monitors for error rate and latency, plus SLO resource
+
+#### Dynatrace Domain
+
+New Domain 17: `Dynatrace` — deploy OneAgent via the Kubernetes Operator with automatic injection, configure anomaly detection, ingest custom metrics, define SLOs, and manage dashboards and alerting profiles with the Dynatrace Terraform provider.
+
+- `references/dynatrace.md` — Operator and DynaKube CR setup, Node.js/Python/Java SDK instrumentation, Log Monitoring, custom metrics via MINT API, SLOs, Terraform provider (anomaly detection, SLOs, alerting), Davis AI problem feeds, troubleshooting table, and token scopes
+- `/platform-skills:dynatrace` (`commands/dynatrace.md`) — six modes: `setup`, `instrument`, `monitor`, `slo`, `dashboard`, `debug`
+- `examples/dynatrace/operator/dynakube.yaml` — production DynaKube CR with cloudNativeFullStack injection and ActiveGate
+
+## [1.8.0] - 2026-05-08
+
 ### Added
 
 #### MCP Domain (Model Context Protocol)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.8.0] - 2026-05-08
-
-### Added (continued)
-
 #### Datadog Domain
 
 New Domain 16: `Datadog` — deploy and configure the Datadog Agent on Kubernetes, instrument services with APM and log correlation, and manage monitors, dashboards, SLOs, and synthetic tests as Terraform-managed resources.

--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -100,6 +100,8 @@ Slash commands are predefined workflows. Use them instead of writing a long prom
 | `/platform-skills:mcp` | Scaffold, review, or debug an MCP server or client |
 | `/platform-skills:observability` | Instrument services, build dashboards, write alerts, run load tests, plan capacity |
 | `/platform-skills:document` | Generate docstrings, OpenAPI specs, documentation sites, or getting started guides |
+| `/platform-skills:datadog` | Datadog Agent setup, APM instrumentation, monitors, dashboards, SLOs, and debugging |
+| `/platform-skills:dynatrace` | OneAgent deployment, instrumentation, anomaly detection, SLOs, and debugging |
 
 Invoke a command by typing it at the start of your message:
 

--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -97,6 +97,9 @@ Slash commands are predefined workflows. Use them instead of writing a long prom
 | `/platform-skills:linux` | DNS, load balancer, VPC connectivity, or kernel issue |
 | `/platform-skills:compliance` | SOC 2 gap analysis or Checkov remediation for Terraform |
 | `/platform-skills:product` | RFC/ADR drafting, DevEx audit, incident communication, post-mortem |
+| `/platform-skills:mcp` | Scaffold, review, or debug an MCP server or client |
+| `/platform-skills:observability` | Instrument services, build dashboards, write alerts, run load tests, plan capacity |
+| `/platform-skills:document` | Generate docstrings, OpenAPI specs, documentation sites, or getting started guides |
 
 Invoke a command by typing it at the start of your message:
 

--- a/commands/datadog.md
+++ b/commands/datadog.md
@@ -1,0 +1,99 @@
+---
+name: datadog
+description: Set up and troubleshoot Datadog — Agent deployment on Kubernetes, APM instrumentation, Log Management, Monitors, Dashboards, SLOs, and Synthetic tests. Covers Terraform-managed Datadog resources.
+argument-hint: "[setup|instrument|monitor|dashboard|slo|debug] [service or description]"
+---
+
+Configure or troubleshoot Datadog observability for a service or platform.
+
+## Mode: setup
+
+Deploy and configure the Datadog Agent on Kubernetes.
+
+Steps:
+1. Ask for: Kubernetes distribution (EKS/AKS/GKE), Datadog site (EU: `datadoghq.eu` / US: `datadoghq.com`), features needed (APM, logs, process monitoring)
+2. Generate Helm values with: API key from Secret (never hardcoded), APM enabled, log collection enabled, cluster name set, Cluster Agent enabled with 2 replicas
+3. Provide install command: `helm upgrade --install datadog datadog/datadog -f values.yaml -n datadog`
+4. Provide verification commands: `kubectl exec -n datadog ds/datadog -- agent status`
+5. Add Unified Service Tagging labels (`DD_ENV`, `DD_SERVICE`, `DD_VERSION`) to app Deployment
+
+Reference: `references/datadog.md` → Agent Setup
+
+## Mode: instrument
+
+Add APM tracing to a service.
+
+Steps:
+1. Ask for: language (Node.js / Python / Java / Go), framework (Express / Django / Spring / etc.), whether log-trace correlation is needed
+2. Generate tracer initialisation code — `dd-trace` init must be the first import in Node.js; use `ddtrace-run` or `patch_all()` in Python
+3. Add Unified Service Tagging env vars to the Deployment manifest
+4. Add custom spans for business-critical paths (payment processing, order creation, etc.)
+5. Show expected APM UI outcome: service map entry, latency/error rate populated
+
+Reference: `references/datadog.md` → APM Instrumentation, Unified Service Tagging
+
+## Mode: monitor
+
+Create a Datadog monitor for a service.
+
+Steps:
+1. Ask for: metric to alert on (error rate / latency / availability), thresholds, notification targets (PagerDuty / Slack)
+2. Generate Terraform `datadog_monitor` resource (preferred over UI / API for IaC)
+3. Set `notify_no_data: true` and `no_data_timeframe` so silent services alert
+4. Include warning and critical thresholds
+5. Tag with `service:`, `env:`, `team:` for routing
+
+Output monitor query, thresholds, notification message with `@pagerduty-*` and `@slack-*` handles.
+
+Reference: `references/datadog.md` → Monitors, Terraform Monitor
+
+## Mode: dashboard
+
+Create a Datadog dashboard for a service.
+
+Steps:
+1. Default to RED method: request rate, error rate %, p50/p95/p99 latency
+2. Generate Terraform `datadog_dashboard` resource with `timeseries_definition` widgets
+3. Use APM metrics: `trace.web.request.hits`, `trace.web.request.errors`, `trace.web.request` percentiles
+4. Add template variables for `env` and `service` for reuse across environments
+
+Reference: `references/datadog.md` → Dashboards
+
+## Mode: slo
+
+Define a Datadog SLO.
+
+Steps:
+1. Ask for: SLI metric (availability / latency), target (e.g. 99.9%), timeframe (7d / 30d / 90d)
+2. Generate Terraform `datadog_service_level_objective` resource
+3. Set both target and warning thresholds
+4. Link SLO to relevant monitors for error budget burn alerts
+
+Reference: `references/datadog.md` → SLOs
+
+## Mode: debug
+
+Diagnose Datadog data gaps or agent issues.
+
+Classify the failure:
+- **Agent** — no data flowing, agent status unhealthy
+- **APM** — traces missing, service not appearing in service map
+- **Logs** — logs not ingested, missing trace correlation
+- **Monitor** — "No Data" state, incorrect thresholds
+- **Metrics** — custom metric not visible in Metrics Explorer
+
+Evidence to collect:
+```bash
+# Agent health
+kubectl exec -n datadog ds/datadog -- agent status
+
+# Check APM port
+kubectl exec -n datadog ds/datadog -- agent check apm
+
+# Verify pod env vars
+kubectl describe pod <app-pod> | grep -E "DD_ENV|DD_SERVICE|DD_VERSION|DD_TRACE"
+
+# Test metric query in Metrics Explorer before using in monitor
+```
+
+Provide: symptom → root cause hypothesis → evidence command → fix → validation

--- a/commands/datadog.md
+++ b/commands/datadog.md
@@ -1,10 +1,10 @@
 ---
 name: datadog
-description: Set up and troubleshoot Datadog — Agent deployment on Kubernetes, APM instrumentation, Log Management, Monitors, Dashboards, SLOs, and Synthetic tests. Covers Terraform-managed Datadog resources.
-argument-hint: "[setup|instrument|monitor|dashboard|slo|debug] [service or description]"
+description: Set up and troubleshoot Datadog — Agent deployment on Kubernetes, APM instrumentation, Log Management, Monitors, Dashboards, SLOs, Synthetic tests, and live incident investigation using the Datadog MCP server. Covers Terraform-managed Datadog resources.
+argument-hint: "[setup|instrument|monitor|dashboard|slo|investigate|debug] [service or description]"
 ---
 
-Configure or troubleshoot Datadog observability for a service or platform.
+Configure, troubleshoot, or investigate incidents in Datadog.
 
 ## Mode: setup
 
@@ -71,9 +71,68 @@ Steps:
 
 Reference: `references/datadog.md` → SLOs
 
+## Mode: investigate
+
+**Live incident investigation using the Datadog MCP server.**
+
+Requires the Datadog MCP server connected to Claude Code. See setup in `references/datadog.md` → MCP Server Setup.
+
+### Phase 1 — Triage (what is broken right now?)
+
+Ask Claude to run these via the MCP server:
+- List all active monitors in ALERT or WARN state for the affected service and environment
+- Fetch the triggering monitor's event stream for the last 30 minutes
+- Check recent deployments — list events tagged `service:<name>` over the last 2 hours
+
+```
+What monitors are currently firing for service:orders-service env:production?
+Show me the event stream for the orders-service in the last 30 minutes.
+Were there any deployments to orders-service in the last 2 hours?
+```
+
+### Phase 2 — Signals (logs, metrics, traces)
+
+Correlate the three pillars through the MCP:
+- Pull error logs for the affected service filtered to the incident window
+- Query APM error rate and p99 latency time series
+- Fetch a sample of failing traces to identify the error message and stack trace
+
+```
+Show me error logs for service:orders-service between <start> and <end>.
+What is the error rate and p99 latency for orders-service over the last hour?
+Find traces with errors for orders-service — show me the top error messages.
+```
+
+### Phase 3 — Root cause
+
+Narrow down with MCP queries:
+- Compare metrics before and after the incident start time
+- Check downstream dependencies — are errors concentrated on one endpoint or database host?
+- Query infrastructure metrics (CPU, memory, disk) for the affected hosts
+
+```
+Compare the error rate for orders-service before and after <incident-start-time>.
+Which endpoints have the highest error rate on orders-service right now?
+Show me CPU and memory metrics for the hosts running orders-service.
+```
+
+### Phase 4 — Resolution and follow-up
+
+- Acknowledge or resolve the triggering monitor via MCP
+- Post an incident update to Slack via the MCP integration
+- Create a notebook capturing the timeline, evidence, and resolution for the post-mortem
+
+```
+Resolve the monitor "orders-service high error rate" — the fix has been deployed.
+Post to #incidents: "orders-service error rate returning to baseline, fix deployed at <time>."
+Create a Datadog notebook summarising the orders-service incident timeline.
+```
+
+Reference: `references/datadog.md` → MCP Server Setup, Incident Investigation Workflow
+
 ## Mode: debug
 
-Diagnose Datadog data gaps or agent issues.
+Diagnose Datadog data gaps or agent issues without the MCP server.
 
 Classify the failure:
 - **Agent** — no data flowing, agent status unhealthy

--- a/commands/document.md
+++ b/commands/document.md
@@ -1,0 +1,83 @@
+---
+name: document
+description: Generate, format, and validate code documentation — docstrings, JSDoc, OpenAPI/Swagger specs, documentation sites, and developer guides.
+argument-hint: "[docstrings|openapi|site|guide] [language/framework] [path or description]"
+---
+
+Generate or improve technical documentation for a codebase or API.
+
+## Mode: docstrings
+
+Add or improve inline documentation for functions, classes, and modules.
+
+Steps:
+1. Ask for: language, preferred style (Google / NumPy / Sphinx for Python; JSDoc for TypeScript/JavaScript)
+2. Identify all public functions and classes missing documentation
+3. For each, document: purpose, all parameters with types, return value, exceptions raised, and at least one example
+4. Validate examples compile and run:
+   - Python: `python -m doctest file.py` or `pytest --doctest-modules`
+   - TypeScript: `tsc --noEmit`
+5. Generate coverage report: `interrogate --fail-under=80 src/` (Python) or `npx typedoc-coverage` (TypeScript)
+
+Rules:
+- Do NOT document obvious getters/setters verbosely
+- Do NOT repeat the function signature in prose
+- Do NOT document private/internal methods unless they have complex invariants
+
+Reference: `references/documentation.md` → Python Docstrings, TypeScript JSDoc
+
+## Mode: openapi
+
+Generate or improve an OpenAPI 3.1 specification for a REST API.
+
+Steps:
+1. Ask for: framework (FastAPI / Django / NestJS / Express / raw spec), existing routes or codebase to analyse
+2. Map all endpoints: method, path, request body schema, response schemas per status code
+3. Extract shared schemas into `components/schemas`
+4. Extract shared responses (400, 401, 404, 500) into `components/responses`
+5. Add `operationId` for every operation
+6. Add security scheme and apply globally or per-operation
+7. Validate: `npx @redocly/cli lint openapi.yaml`
+8. Generate HTML preview: `npx @redocly/cli build-docs openapi.yaml`
+
+For FastAPI: document with Pydantic model `Field(description=...)` and docstrings on route functions — auto-generates `/docs`.
+For NestJS: use `@ApiProperty`, `@ApiOperation`, `@ApiResponse` decorators.
+
+Reference: `references/documentation.md` → OpenAPI 3.1, FastAPI, NestJS
+
+## Mode: site
+
+Set up a documentation site for a project.
+
+Steps:
+1. Ask for: project type (Python library / TypeScript SDK / REST API / platform runbook)
+2. Recommend appropriate generator:
+   - Python projects → MkDocs + mkdocstrings + Material theme
+   - TypeScript projects → TypeDoc + typedoc-material-theme
+   - API portals → Redocly or Stoplight
+   - General docs → Docusaurus
+3. Generate site configuration file
+4. Define nav structure: Getting Started, API Reference, Guides, Changelog
+5. Wire docstring auto-generation from source code
+6. Add search plugin
+7. Provide `serve` and `build` commands
+
+Reference: `references/documentation.md` → Documentation Sites
+
+## Mode: guide
+
+Write a getting started guide or tutorial.
+
+Structure every guide as:
+1. **Prerequisites** — exact versions, accounts, or permissions needed
+2. **Installation** — copy-paste commands, not prose descriptions
+3. **Quick start** — the simplest working example (< 10 lines)
+4. **Next steps** — links to deeper topics
+
+Rules:
+- All code examples must be tested and runnable
+- Use realistic values, not `<YOUR_VALUE>` placeholders where avoidable
+- One concept per section — do not combine installation with configuration
+- Include expected output for each command
+
+Reference: `references/documentation.md` → Getting Started Guide Structure

--- a/commands/dynatrace.md
+++ b/commands/dynatrace.md
@@ -19,7 +19,7 @@ Steps:
 6. Verify injection: `kubectl describe pod <app-pod> | grep dynatrace`
 
 Required token scopes:
-- `apiToken`: `ReadConfig WriteConfig DataExport LogExport`
+- `apiToken`: `ReadConfig WriteConfig DataExport LogExport ReadSyntheticData WriteAnomalyDetection`
 - `dataIngestToken`: `metrics.ingest logs.ingest`
 
 Reference: `references/dynatrace.md` → Deployment, Token Scopes

--- a/commands/dynatrace.md
+++ b/commands/dynatrace.md
@@ -1,10 +1,10 @@
 ---
 name: dynatrace
-description: Deploy and configure Dynatrace — OneAgent Kubernetes Operator, code-level instrumentation, Log Monitoring, custom metrics, SLOs, Dashboards, anomaly detection, and Davis AI problem feeds. Covers Terraform-managed Dynatrace resources.
-argument-hint: "[setup|instrument|monitor|slo|dashboard|debug] [service or description]"
+description: Deploy and configure Dynatrace — OneAgent Kubernetes Operator, code-level instrumentation, Log Monitoring, custom metrics, SLOs, Dashboards, anomaly detection, Davis AI, and live incident investigation using the Dynatrace MCP server. Covers Terraform-managed Dynatrace resources.
+argument-hint: "[setup|instrument|monitor|slo|dashboard|investigate|debug] [service or description]"
 ---
 
-Configure or troubleshoot Dynatrace observability for a service or platform.
+Configure, troubleshoot, or investigate incidents in Dynatrace.
 
 ## Mode: setup
 
@@ -75,9 +75,88 @@ Steps:
 
 Reference: `references/dynatrace.md` → Terraform Provider
 
+## Mode: investigate
+
+**Live incident investigation using the Dynatrace MCP server.**
+
+Requires the Dynatrace MCP server connected to Claude Code. See setup in `references/dynatrace.md` → MCP Server Setup.
+
+**Cost note**: `execute_dql` queries scan Grail data and may incur costs based on your Dynatrace consumption model. Start with short timeframes (last 1h–24h). Set `DT_GRAIL_QUERY_BUDGET_GB` to cap session spend.
+
+### Phase 1 — Triage (what is Davis AI seeing?)
+
+Ask Claude to run these via the MCP server:
+- List all open Problems — Davis AI auto-detects anomalies and groups related symptoms
+- Fetch full problem details including root cause entity, impact, and affected services
+- Check recent Kubernetes events for the affected namespace
+
+```
+List all open Problems in Dynatrace right now.
+Get full details for Problem <problem-id> including root cause and affected entities.
+Show me Kubernetes events for namespace production in the last 30 minutes.
+```
+
+### Phase 2 — Signals (logs, traces, exceptions)
+
+Use DQL via the MCP to query Grail directly:
+- Fetch error logs for the affected service in the incident window
+- List recent exceptions with stack traces
+- Find distributed traces with errors to identify the failing call
+
+```
+Show me error logs for the orders-service in the last hour.
+List the top exceptions for orders-service with stack traces.
+Find distributed traces with errors for orders-service — show the slowest and most frequent.
+```
+
+Example DQL the MCP can generate and execute:
+
+```dql
+fetch logs
+| filter service.name == "orders-service" and loglevel == "ERROR"
+| sort timestamp desc
+| limit 50
+| fields timestamp, content, trace_id, span_id
+```
+
+```dql
+fetch spans
+| filter service.name == "orders-service" and status == "ERROR"
+| sort timestamp desc
+| limit 20
+| fields timestamp, span_name, error.message, trace_id, duration
+```
+
+### Phase 3 — Root cause with Davis AI
+
+Let Davis AI perform automated analysis:
+- Ask Davis Copilot to explain the problem in plain English
+- Run a Davis Analyzer on the affected service for automated root cause analysis
+- Find the entity (service, host, process group) at the root of the problem
+
+```
+Chat with Davis Copilot: "Why is orders-service having elevated error rates since 14:00 UTC?"
+List available Davis analyzers for root cause analysis.
+Find the entity named "orders-service" and show its current health.
+```
+
+### Phase 4 — Resolution and follow-up
+
+- Create a Dynatrace Notebook capturing the timeline, DQL queries, and evidence
+- Send a Slack message or email via the MCP notification tools
+- Close the Problem with a resolution note once fix is validated
+
+```
+Create a Dynatrace notebook summarising the orders-service incident with the DQL queries we ran.
+Send a Slack message to #incidents: "orders-service error rate normalising, fix deployed at <time>."
+Close Problem <problem-id> with message "Root cause: bad deploy at 14:05 UTC, rolled back at 14:22 UTC."
+```
+
+Reference: `references/dynatrace.md` → MCP Server Setup, Incident Investigation Workflow
+
 ## Mode: debug
 
-Diagnose Dynatrace data gaps or injection failures.
+Diagnose Dynatrace data gaps or injection failures without the MCP server.
 
 Classify the failure:
 - **Injection** — OneAgent not injecting into pods

--- a/commands/dynatrace.md
+++ b/commands/dynatrace.md
@@ -1,0 +1,107 @@
+---
+name: dynatrace
+description: Deploy and configure Dynatrace — OneAgent Kubernetes Operator, code-level instrumentation, Log Monitoring, custom metrics, SLOs, Dashboards, anomaly detection, and Davis AI problem feeds. Covers Terraform-managed Dynatrace resources.
+argument-hint: "[setup|instrument|monitor|slo|dashboard|debug] [service or description]"
+---
+
+Configure or troubleshoot Dynatrace observability for a service or platform.
+
+## Mode: setup
+
+Deploy the Dynatrace Operator and OneAgent on Kubernetes.
+
+Steps:
+1. Ask for: environment ID, Kubernetes distribution (EKS/AKS/GKE), monitoring mode (fullStack / cloudNativeFullStack)
+2. Install Operator: `kubectl apply -f .../dynatrace-operator/releases/latest/download/kubernetes.yaml`
+3. Create Secret with `apiToken` and `dataIngestToken` (store in Kubernetes Secret or secrets manager — never plain values)
+4. Generate `DynaKube` CR with `cloudNativeFullStack` for automatic injection — no pod restarts required
+5. Enable `metadataEnrichment: true` for Kubernetes metadata on all telemetry
+6. Verify injection: `kubectl describe pod <app-pod> | grep dynatrace`
+
+Required token scopes:
+- `apiToken`: `ReadConfig WriteConfig DataExport LogExport`
+- `dataIngestToken`: `metrics.ingest logs.ingest`
+
+Reference: `references/dynatrace.md` → Deployment, Token Scopes
+
+## Mode: instrument
+
+Add custom spans or business transaction tracing to a service.
+
+Steps:
+1. OneAgent auto-instruments HTTP, database, cache, and messaging — code changes only needed for custom business spans
+2. Ask for: language (Node.js / Python / Java), business operations to trace (payment, checkout, data pipeline)
+3. Generate SDK code for custom spans using `@dynatrace/oneagent-sdk` (Node.js), `oneagent-sdk` (Python), or OneAgent Java SDK
+4. For cross-service propagation: forward and extract the `x-dynatrace` header between services
+5. Verify in Distributed Traces UI: service appears in Service Map with custom spans
+
+Reference: `references/dynatrace.md` → Code-Level Instrumentation
+
+## Mode: monitor
+
+Configure anomaly detection and alerting for a service.
+
+Steps:
+1. Ask for: service entity ID (from Smartscape or Settings API), alerting thresholds (auto-detection or fixed), notification target
+2. Generate Terraform `dynatrace_service_anomalies_v2` resource for failure rate and response time
+3. Generate Terraform `dynatrace_alerting` profile linking anomalies to the team
+4. Davis AI will auto-detect baseline anomalies — custom thresholds override only when auto-detection is too noisy
+5. Wire alerting profile to notification integration (PagerDuty, Slack, Opsgenie)
+
+Reference: `references/dynatrace.md` → Terraform Provider, Davis AI Problem Feeds
+
+## Mode: slo
+
+Define a Dynatrace SLO.
+
+Steps:
+1. Ask for: SLI expression (availability / latency / custom), target %, timeframe
+2. Generate Terraform `dynatrace_slo_v2` resource
+3. Use built-in metrics for availability: `builtin:service.errors.server.successCount` / `builtin:service.requestCount.server`
+4. Validate the metric expression returns data in the Metrics Explorer before applying
+5. Set both `target_success` and `target_warning` thresholds
+
+Reference: `references/dynatrace.md` → SLOs
+
+## Mode: dashboard
+
+Create a Dynatrace dashboard.
+
+Steps:
+1. Ask for: service entity ID, key metrics to show (availability, latency, throughput, error rate)
+2. Generate Terraform `dynatrace_json_dashboard` resource pointing to a JSON dashboard file
+3. Use built-in service metrics: `builtin:service.requestCount.server`, `builtin:service.response.time`, `builtin:service.errors.server.rate`
+4. Provide dashboard JSON with tiles for each metric using `DATA_EXPLORER` tile type
+
+Reference: `references/dynatrace.md` → Terraform Provider
+
+## Mode: debug
+
+Diagnose Dynatrace data gaps or injection failures.
+
+Classify the failure:
+- **Injection** — OneAgent not injecting into pods
+- **Traces** — service not in Service Map or distributed traces broken
+- **Metrics** — custom metrics not appearing
+- **SLO** — SLO shows 0% or "No data"
+- **Davis AI** — Problems not being created for known issues
+
+Evidence to collect:
+```bash
+# Operator and DynaKube status
+kubectl -n dynatrace get dynakube
+kubectl -n dynatrace get pods
+
+# Check injection on app pod
+kubectl describe pod <app-pod> | grep -i dynatrace
+
+# Verify MINT ingestion (custom metrics)
+curl "https://{env}.live.dynatrace.com/api/v2/metrics/query?metricSelector=<your.metric>" \
+  -H "Authorization: Api-Token ${DT_API_TOKEN}"
+
+# List open Davis AI problems
+curl "https://{env}.live.dynatrace.com/api/v2/problems?problemSelector=status(OPEN)" \
+  -H "Authorization: Api-Token ${DT_API_TOKEN}"
+```
+
+Provide: symptom → root cause hypothesis → evidence command → fix → validation step

--- a/commands/mcp.md
+++ b/commands/mcp.md
@@ -1,0 +1,64 @@
+---
+name: mcp
+description: MCP server and client development — scaffold, implement tools/resources/prompts, validate schemas, debug protocol compliance, and deploy with auth and rate limiting.
+argument-hint: "[create|review|debug] [typescript|python] [description]"
+---
+
+Build, review, or debug an MCP (Model Context Protocol) server or client.
+
+## Mode: create
+
+Scaffold a production-ready MCP server.
+
+Steps:
+1. Ask for: language (TypeScript or Python), transport (stdio / HTTP+SSE), list of tools and resources needed
+2. Generate project scaffold with correct SDK setup
+3. Implement tool handlers with Zod (TypeScript) or Pydantic (Python) schema validation
+4. Add resource providers and prompt templates as needed
+5. Configure transport layer
+6. Add error handling — return `isError: true` content, never throw unhandled exceptions to clients
+7. Add authentication and rate limiting for HTTP transports
+8. Provide MCP Inspector test commands and expected responses
+9. Add deployment checklist (env vars, secrets, logging)
+
+Reference: `references/mcp.md` → Protocol Fundamentals, TypeScript SDK, Python SDK
+
+## Mode: review
+
+Review an existing MCP server or client implementation.
+
+Evaluate in priority order:
+1. **Protocol compliance** — JSON-RPC 2.0 correctness, proper capability negotiation, well-formed content arrays
+2. **Schema validation** — all tool inputs validated with Zod/Pydantic; no `z.any()` or empty schemas
+3. **Security** — no credentials in tool responses or resource content; auth on HTTP transports; rate limiting present
+4. **Error handling** — errors return `isError: true` with a message, not unhandled exceptions
+5. **Transport** — correct transport for the use case; no blocking sync code in async transports
+
+Output: Critical (must fix) / Improvement (should fix) / Note (informational)
+
+Reference: `references/mcp.md` → Security, Error Handling, Testing and Debugging
+
+## Mode: debug
+
+Diagnose MCP protocol or integration failures.
+
+Classify the failure:
+- **Transport** — connection refused, EOF, serialisation error
+- **Protocol** — malformed JSON-RPC, missing `id`, wrong method names
+- **Schema** — Zod/Pydantic validation rejection, unexpected input types
+- **Handler** — unhandled exception, timeout, wrong return shape
+- **Integration** — tool not appearing in host, capabilities mismatch
+
+Evidence to collect:
+```bash
+# Run MCP Inspector to verify protocol compliance
+npx @modelcontextprotocol/inspector node dist/index.js
+
+# Smoke-test via stdio
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | node dist/index.js
+
+# Check for schema errors
+node -e "require('./dist/index.js')" 2>&1
+```
+
+Provide: observed symptom → likely root cause → evidence command → fix → validation step

--- a/commands/observability.md
+++ b/commands/observability.md
@@ -1,0 +1,81 @@
+---
+name: observability
+description: Instrument services with structured logging, Prometheus metrics, and OpenTelemetry tracing. Build Grafana dashboards, write Prometheus alerting rules, run k6 load tests, and plan infrastructure capacity.
+argument-hint: "[instrument|dashboard|alert|loadtest|capacity] [service description]"
+---
+
+Set up or improve observability for a service or platform component.
+
+## Mode: instrument
+
+Add the three pillars — logs, metrics, traces — to a service.
+
+Steps:
+1. Ask for: language/framework, existing logging library (if any), metrics backend (Prometheus / Datadog / CloudWatch), tracing backend (Jaeger / Tempo / OTLP)
+2. Add structured JSON logging with correlation IDs (Pino for Node.js, structlog for Python)
+3. Instrument RED metrics: `http_requests_total` counter, `http_request_duration_seconds` histogram, per route and status
+4. Add OpenTelemetry tracing with span attributes on critical paths
+5. Expose `/metrics` scrape endpoint (Prometheus) or configure push exporter
+6. Add `/healthz` and `/readyz` health check endpoints
+7. Document what NOT to log (passwords, tokens, PII)
+
+Reference: `references/observability.md` → Structured Logging, Prometheus Metrics, OpenTelemetry Tracing
+
+## Mode: dashboard
+
+Create a Grafana dashboard for a service.
+
+Steps:
+1. Choose method: RED (request-based services) or USE (resource-based infrastructure)
+2. Define panels: request rate, error rate %, p50/p95/p99 latency, active connections, queue depth
+3. Set meaningful Y-axis units (req/s, ms, %)
+4. Add threshold lines at SLO boundaries
+5. Configure template variables for environment and service filtering
+
+Reference: `references/observability.md` → Grafana Dashboards
+
+## Mode: alert
+
+Write Prometheus alerting rules for a service.
+
+Steps:
+1. Identify SLIs: error rate, latency percentiles, availability
+2. Write alert expressions using `rate()` over 5m windows
+3. Set `for:` duration ≥ 1m to suppress transient noise
+4. Add `severity` label (critical / warning) and `runbook` annotation to every alert
+5. Validate: no alert fires on healthy baseline, alert fires on injected fault
+
+Alert design rules:
+- Page on symptoms (error rate, latency), not causes (CPU %)
+- Every alert needs a runbook URL
+- Derive SLO burn-rate alerts from error budget, not raw thresholds
+
+Reference: `references/observability.md` → Alerting Rules
+
+## Mode: loadtest
+
+Write and run a k6 load test.
+
+Steps:
+1. Ask for: target endpoint, expected peak RPS, SLO thresholds (p95 latency, error rate)
+2. Write ramp-up → steady-state → ramp-down stages
+3. Set `thresholds` matching the SLO
+4. Add `check()` assertions on status code and response time
+5. Run: `k6 run --out json=results.json load-test.js`
+6. Interpret results: p95/p99 latency, error rate, throughput achieved vs. thresholds
+
+Reference: `references/observability.md` → Load Testing
+
+## Mode: capacity
+
+Estimate resource requirements and HPA configuration for a service.
+
+Steps:
+1. Gather: expected peak RPS, measured p99 latency, memory per pod at current load
+2. Apply formula: `replicas = ceil((peak_rps × avg_latency_s) / target_concurrency_per_pod)`
+3. Add 50% headroom for spikes
+4. Generate HPA manifest with CPU utilisation target ≤ 60%
+5. Set resource requests to measured baseline + 20%; set memory limit; omit CPU limit unless throttling is acceptable
+6. Define min/max replica bounds
+
+Reference: `references/observability.md` → Capacity Planning

--- a/examples/datadog/README.md
+++ b/examples/datadog/README.md
@@ -8,17 +8,19 @@ Production-ready Datadog configurations for Kubernetes, APM, monitors, dashboard
 
 | Example | Type | Description |
 |---------|------|-------------|
-| [helm-values/](helm-values/) | Helm | Agent values — APM, logs, Cluster Agent |
 | [terraform/](terraform/) | Terraform | Monitors, dashboards, and SLOs as code |
 
 ## Usage
 
 ```bash
-# Deploy agent
+# Deploy agent — create API key secret first, never pass on command line
+kubectl create secret generic datadog-secret \
+  --from-literal=api-key="${DD_API_KEY}" \
+  -n datadog --dry-run=client -o yaml | kubectl apply -f -
+
 helm repo add datadog https://helm.datadoghq.com
 helm upgrade --install datadog datadog/datadog \
-  -f helm-values/datadog-values.yaml \
-  --set datadog.apiKey="${DD_API_KEY}" \
+  --set datadog.apiKeyExistingSecret=datadog-secret \
   -n datadog --create-namespace
 
 # Apply Terraform resources

--- a/examples/datadog/README.md
+++ b/examples/datadog/README.md
@@ -1,0 +1,32 @@
+Status: Stable
+
+# Datadog Examples
+
+Production-ready Datadog configurations for Kubernetes, APM, monitors, dashboards, and SLOs.
+
+## Examples
+
+| Example | Type | Description |
+|---------|------|-------------|
+| [helm-values/](helm-values/) | Helm | Agent values — APM, logs, Cluster Agent |
+| [terraform/](terraform/) | Terraform | Monitors, dashboards, and SLOs as code |
+
+## Usage
+
+```bash
+# Deploy agent
+helm repo add datadog https://helm.datadoghq.com
+helm upgrade --install datadog datadog/datadog \
+  -f helm-values/datadog-values.yaml \
+  --set datadog.apiKey="${DD_API_KEY}" \
+  -n datadog --create-namespace
+
+# Apply Terraform resources
+cd terraform
+terraform init && terraform plan
+```
+
+## See Also
+
+- [references/datadog.md](../../references/datadog.md) — agent setup, APM, logs, monitors, dashboards, SLOs
+- `/platform-skills:datadog` — setup, instrument, monitor, dashboard, SLO, debug

--- a/examples/datadog/terraform/monitors.tf
+++ b/examples/datadog/terraform/monitors.tf
@@ -1,0 +1,91 @@
+terraform {
+  required_providers {
+    datadog = {
+      source  = "DataDog/datadog"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "datadog" {
+  api_url = "https://api.datadoghq.eu/"   # EU site — change for US
+  # api_key and app_key read from DD_API_KEY and DD_APP_KEY env vars
+}
+
+# ---------------------------------------------------------------------------
+# Error Rate Monitor
+# ---------------------------------------------------------------------------
+resource "datadog_monitor" "orders_error_rate" {
+  name    = "orders-service high error rate"
+  type    = "metric alert"
+  message = <<-EOT
+    Error rate above 5% on orders-service.
+    Runbook: https://wiki.internal/runbooks/orders-high-error-rate
+    @pagerduty-platform @slack-platform-alerts
+  EOT
+
+  query = <<-EOQ
+    sum(last_5m):
+      sum:trace.web.request.errors{service:orders-service,env:production}.as_count()
+      / sum:trace.web.request.hits{service:orders-service,env:production}.as_count()
+    > 0.05
+  EOQ
+
+  monitor_thresholds {
+    critical = 0.05
+    warning  = 0.02
+  }
+
+  tags = ["service:orders-service", "env:production", "team:platform"]
+
+  notify_no_data    = true
+  no_data_timeframe = 10
+  renotify_interval = 30
+}
+
+# ---------------------------------------------------------------------------
+# p99 Latency Monitor
+# ---------------------------------------------------------------------------
+resource "datadog_monitor" "orders_latency" {
+  name    = "orders-service p99 latency high"
+  type    = "metric alert"
+  message = <<-EOT
+    p99 latency above 1s on orders-service.
+    Runbook: https://wiki.internal/runbooks/orders-high-latency
+    @slack-platform-alerts
+  EOT
+
+  query = "p99(last_5m):trace.web.request{service:orders-service,env:production} > 1"
+
+  monitor_thresholds {
+    critical = 1.0
+    warning  = 0.5
+  }
+
+  tags = ["service:orders-service", "env:production", "team:platform"]
+
+  notify_no_data    = true
+  no_data_timeframe = 10
+}
+
+# ---------------------------------------------------------------------------
+# SLO — 99.9% Availability over 30 days
+# ---------------------------------------------------------------------------
+resource "datadog_service_level_objective" "orders_availability" {
+  name        = "Orders Service Availability"
+  type        = "metric"
+  description = "99.9% of requests succeed over a rolling 30-day window"
+
+  query {
+    numerator   = "sum:trace.web.request.hits{service:orders-service,env:production,!status:error}.as_count()"
+    denominator = "sum:trace.web.request.hits{service:orders-service,env:production}.as_count()"
+  }
+
+  thresholds {
+    timeframe = "30d"
+    target    = 99.9
+    warning   = 99.95
+  }
+
+  tags = ["service:orders-service", "env:production", "team:platform"]
+}

--- a/examples/datadog/terraform/monitors.tf
+++ b/examples/datadog/terraform/monitors.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }
@@ -66,6 +66,7 @@ resource "datadog_monitor" "orders_latency" {
 
   notify_no_data    = true
   no_data_timeframe = 10
+  renotify_interval = 30
 }
 
 # ---------------------------------------------------------------------------

--- a/examples/datadog/terraform/monitors.tf
+++ b/examples/datadog/terraform/monitors.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 provider "datadog" {
-  api_url = "https://api.datadoghq.eu/"   # EU site — change for US
+  api_url = "https://api.datadoghq.eu/" # EU site — change for US
   # api_key and app_key read from DD_API_KEY and DD_APP_KEY env vars
 }
 

--- a/examples/documentation/README.md
+++ b/examples/documentation/README.md
@@ -1,0 +1,35 @@
+Status: Stable
+
+# Documentation Examples
+
+Reference implementations for docstrings, OpenAPI specs, and documentation sites.
+
+## Examples
+
+| Example | Type | Description |
+|---------|------|-------------|
+| [python-docstrings/](python-docstrings/) | Python | Google-style docstrings with coverage check |
+| [openapi-spec/](openapi-spec/) | OpenAPI 3.1 | Orders API spec with shared components |
+| [mkdocs-site/](mkdocs-site/) | MkDocs | Material theme site with auto-generated API reference |
+
+## Usage
+
+```bash
+# Validate OpenAPI spec
+npx @redocly/cli lint openapi-spec/openapi.yaml
+
+# Check Python docstring coverage
+cd python-docstrings
+pip install interrogate
+interrogate --fail-under=80 src/
+
+# Preview MkDocs site
+cd mkdocs-site
+pip install mkdocs-material mkdocstrings[python]
+mkdocs serve
+```
+
+## See Also
+
+- [references/documentation.md](../../references/documentation.md) — docstring styles, OpenAPI 3.1, doc sites, guides
+- `/platform-skills:document` — generate docstrings, OpenAPI spec, doc site, or getting started guide

--- a/examples/documentation/README.md
+++ b/examples/documentation/README.md
@@ -8,25 +8,13 @@ Reference implementations for docstrings, OpenAPI specs, and documentation sites
 
 | Example | Type | Description |
 |---------|------|-------------|
-| [python-docstrings/](python-docstrings/) | Python | Google-style docstrings with coverage check |
 | [openapi-spec/](openapi-spec/) | OpenAPI 3.1 | Orders API spec with shared components |
-| [mkdocs-site/](mkdocs-site/) | MkDocs | Material theme site with auto-generated API reference |
 
 ## Usage
 
 ```bash
 # Validate OpenAPI spec
 npx @redocly/cli lint openapi-spec/openapi.yaml
-
-# Check Python docstring coverage
-cd python-docstrings
-pip install interrogate
-interrogate --fail-under=80 src/
-
-# Preview MkDocs site
-cd mkdocs-site
-pip install mkdocs-material mkdocstrings[python]
-mkdocs serve
 ```
 
 ## See Also

--- a/examples/documentation/openapi-spec/openapi.yaml
+++ b/examples/documentation/openapi-spec/openapi.yaml
@@ -1,0 +1,222 @@
+openapi: "3.1.0"
+info:
+  title: Orders API
+  version: "1.0.0"
+  description: |
+    Manages customer orders and payment processing.
+
+    ## Authentication
+    All endpoints require a Bearer JWT token obtained from the identity provider.
+
+    ## Rate Limiting
+    100 requests per minute per authenticated user. Returns 429 on excess.
+
+servers:
+  - url: https://api.example.com/v1
+    description: Production
+  - url: https://api.staging.example.com/v1
+    description: Staging
+
+paths:
+  /orders:
+    get:
+      summary: List orders
+      operationId: listOrders
+      tags: [Orders]
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [pending, paid, shipped, cancelled]
+        - name: page
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        "200":
+          description: Paginated list of orders
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrderPage"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    post:
+      summary: Create an order
+      operationId: createOrder
+      tags: [Orders]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateOrderInput"
+            example:
+              productId: "prod-123"
+              quantity: 2
+      responses:
+        "201":
+          description: Order created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /orders/{orderId}:
+    parameters:
+      - name: orderId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+
+    get:
+      summary: Get an order
+      operationId: getOrder
+      tags: [Orders]
+      responses:
+        "200":
+          description: Order found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      summary: Cancel an order
+      operationId: cancelOrder
+      tags: [Orders]
+      responses:
+        "204":
+          description: Order cancelled
+        "400":
+          description: Order cannot be cancelled (already shipped)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+components:
+  schemas:
+    CreateOrderInput:
+      type: object
+      required: [productId, quantity]
+      properties:
+        productId:
+          type: string
+          minLength: 1
+          description: Product catalog identifier
+        quantity:
+          type: integer
+          minimum: 1
+          maximum: 100
+          description: Number of units to order
+
+    Order:
+      type: object
+      required: [id, productId, quantity, status, createdAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        productId:
+          type: string
+        quantity:
+          type: integer
+        status:
+          type: string
+          enum: [pending, paid, shipped, cancelled]
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    OrderPage:
+      type: object
+      required: [items, total, page, limit]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Order"
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+        details:
+          type: array
+          items:
+            type: string
+
+  responses:
+    ValidationError:
+      description: Request body failed schema validation
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: "Validation failed"
+            details: ["quantity must be >= 1"]
+
+    Unauthorized:
+      description: Missing or invalid authentication token
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: "Unauthorized"
+
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example:
+            error: "Not found"
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+security:
+  - bearerAuth: []

--- a/examples/dynatrace/README.md
+++ b/examples/dynatrace/README.md
@@ -9,7 +9,6 @@ Production-ready Dynatrace configurations for OneAgent Kubernetes deployment, an
 | Example | Type | Description |
 |---------|------|-------------|
 | [operator/](operator/) | Kubernetes | DynaKube CR for cloudNativeFullStack injection |
-| [terraform/](terraform/) | Terraform | Anomaly detection, SLOs, and alerting as code |
 
 ## Usage
 
@@ -21,10 +20,6 @@ kubectl -n dynatrace create secret generic dynakube \
   --from-literal=apiToken="${DT_API_TOKEN}" \
   --from-literal=dataIngestToken="${DT_DATA_INGEST_TOKEN}"
 kubectl apply -f operator/dynakube.yaml
-
-# Apply Terraform resources
-cd terraform
-terraform init && terraform plan
 ```
 
 ## See Also

--- a/examples/dynatrace/README.md
+++ b/examples/dynatrace/README.md
@@ -1,0 +1,33 @@
+Status: Stable
+
+# Dynatrace Examples
+
+Production-ready Dynatrace configurations for OneAgent Kubernetes deployment, anomaly detection, SLOs, and dashboards.
+
+## Examples
+
+| Example | Type | Description |
+|---------|------|-------------|
+| [operator/](operator/) | Kubernetes | DynaKube CR for cloudNativeFullStack injection |
+| [terraform/](terraform/) | Terraform | Anomaly detection, SLOs, and alerting as code |
+
+## Usage
+
+```bash
+# Deploy OneAgent Operator
+kubectl create namespace dynatrace
+kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes.yaml
+kubectl -n dynatrace create secret generic dynakube \
+  --from-literal=apiToken="${DT_API_TOKEN}" \
+  --from-literal=dataIngestToken="${DT_DATA_INGEST_TOKEN}"
+kubectl apply -f operator/dynakube.yaml
+
+# Apply Terraform resources
+cd terraform
+terraform init && terraform plan
+```
+
+## See Also
+
+- [references/dynatrace.md](../../references/dynatrace.md) — Operator setup, instrumentation, metrics, SLOs, Terraform provider
+- `/platform-skills:dynatrace` — setup, instrument, monitor, SLO, dashboard, debug

--- a/examples/dynatrace/operator/dynakube.yaml
+++ b/examples/dynatrace/operator/dynakube.yaml
@@ -1,0 +1,41 @@
+apiVersion: dynatrace.com/v1beta1
+kind: DynaKube
+metadata:
+  name: dynakube
+  namespace: dynatrace
+  annotations:
+    feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
+spec:
+  # Replace with your environment URL
+  apiUrl: "https://ENVIRONMENT_ID.live.dynatrace.com/api"
+
+  # Token secret created with:
+  # kubectl -n dynatrace create secret generic dynakube \
+  #   --from-literal=apiToken="${DT_API_TOKEN}" \
+  #   --from-literal=dataIngestToken="${DT_DATA_INGEST_TOKEN}"
+  tokens: dynakube
+
+  oneAgent:
+    # cloudNativeFullStack: automatic injection, no pod restarts needed
+    cloudNativeFullStack:
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+
+  activeGate:
+    capabilities:
+      - routing
+      - kubernetes-monitoring
+      - dynatrace-api
+    replicas: 2
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+
+  # Enrich all telemetry with Kubernetes metadata (namespace, pod, node)
+  metadataEnrichment:
+    enabled: true

--- a/examples/dynatrace/operator/dynakube.yaml
+++ b/examples/dynatrace/operator/dynakube.yaml
@@ -7,6 +7,9 @@ metadata:
     feature.dynatrace.com/automatic-kubernetes-api-monitoring: "true"
 spec:
   # Replace with your environment URL
+  # Classic URL (live.dynatrace.com) — correct for the Operator and REST API.
+  # This is distinct from DT_ENVIRONMENT used by the MCP server, which requires
+  # the Platform URL (abc12345.apps.dynatrace.com).
   apiUrl: "https://ENVIRONMENT_ID.live.dynatrace.com/api"
 
   # Token secret created with:
@@ -20,7 +23,10 @@ spec:
     cloudNativeFullStack:
       tolerations:
         - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+          key: node-role.kubernetes.io/control-plane  # k8s >= 1.24
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master         # k8s < 1.24 (deprecated)
           operator: Exists
 
   activeGate:

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -1,0 +1,31 @@
+Status: Stable
+
+# MCP Examples
+
+Production-ready MCP server implementations for common platform use cases.
+
+## Examples
+
+| Example | Transport | Language | Description |
+|---------|-----------|----------|-------------|
+| [docs-server/](docs-server/) | stdio | TypeScript | Search internal documentation |
+| [k8s-server/](k8s-server/) | stdio | Python | Query Kubernetes cluster state |
+
+## Usage
+
+```bash
+# TypeScript example
+cd docs-server
+npm install && npm run build
+npx @modelcontextprotocol/inspector node dist/index.js
+
+# Python example
+cd k8s-server
+pip install -r requirements.txt
+npx @modelcontextprotocol/inspector python server.py
+```
+
+## See Also
+
+- [references/mcp.md](../../references/mcp.md) — protocol guide, SDK patterns, security
+- `/platform-skills:mcp` — scaffold, review, or debug an MCP server

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -9,7 +9,6 @@ Production-ready MCP server implementations for common platform use cases.
 | Example | Transport | Language | Description |
 |---------|-----------|----------|-------------|
 | [docs-server/](docs-server/) | stdio | TypeScript | Search internal documentation |
-| [k8s-server/](k8s-server/) | stdio | Python | Query Kubernetes cluster state |
 
 ## Usage
 
@@ -18,11 +17,6 @@ Production-ready MCP server implementations for common platform use cases.
 cd docs-server
 npm install && npm run build
 npx @modelcontextprotocol/inspector node dist/index.js
-
-# Python example
-cd k8s-server
-pip install -r requirements.txt
-npx @modelcontextprotocol/inspector python server.py
 ```
 
 ## See Also

--- a/examples/mcp/docs-server/index.ts
+++ b/examples/mcp/docs-server/index.ts
@@ -1,0 +1,72 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const server = new McpServer({ name: "docs-server", version: "1.0.0" });
+
+// In-memory document store — replace with real search backend
+const documents: Array<{ id: string; title: string; body: string; tags: string[] }> = [
+  { id: "1", title: "Getting Started", body: "Install the CLI with npm install -g @example/cli", tags: ["quickstart"] },
+  { id: "2", title: "Authentication", body: "Use OIDC with your identity provider. Set OIDC_ISSUER env var.", tags: ["auth", "security"] },
+  { id: "3", title: "Deployment", body: "Deploy with helm upgrade --install. See values.yaml for configuration.", tags: ["helm", "kubernetes"] },
+];
+
+server.tool(
+  "search_docs",
+  "Search internal documentation by keyword",
+  {
+    query: z.string().min(1).describe("Search query"),
+    limit: z.number().int().min(1).max(20).default(5),
+    tag: z.string().optional().describe("Filter by tag"),
+  },
+  async ({ query, limit, tag }) => {
+    const q = query.toLowerCase();
+    const results = documents
+      .filter((doc) => {
+        const matches = doc.title.toLowerCase().includes(q) || doc.body.toLowerCase().includes(q);
+        const tagMatch = tag ? doc.tags.includes(tag) : true;
+        return matches && tagMatch;
+      })
+      .slice(0, limit)
+      .map(({ id, title, tags }) => ({ id, title, tags }));
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+    };
+  }
+);
+
+server.tool(
+  "get_doc",
+  "Retrieve full content of a documentation page by ID",
+  {
+    id: z.string().min(1).describe("Document ID from search results"),
+  },
+  async ({ id }) => {
+    const doc = documents.find((d) => d.id === id);
+    if (!doc) {
+      return {
+        content: [{ type: "text", text: `Document '${id}' not found` }],
+        isError: true,
+      };
+    }
+    return {
+      content: [{ type: "text", text: JSON.stringify(doc, null, 2) }],
+    };
+  }
+);
+
+server.resource(
+  "docs://index",
+  "Index of all available documentation pages",
+  async (uri) => ({
+    contents: [{
+      uri: uri.href,
+      text: JSON.stringify(documents.map(({ id, title, tags }) => ({ id, title, tags })), null, 2),
+      mimeType: "application/json",
+    }],
+  })
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/examples/mcp/docs-server/package.json
+++ b/examples/mcp/docs-server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "docs-server",
+  "version": "1.0.0",
+  "description": "MCP server for searching internal documentation",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node index.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.22.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/mcp/docs-server/tsconfig.json
+++ b/examples/mcp/docs-server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -8,23 +8,14 @@ Production-ready instrumentation, dashboards, alerting, and load test configurat
 
 | Example | Tool | Description |
 |---------|------|-------------|
-| [node-service/](node-service/) | Pino + prom-client + OpenTelemetry | Fully instrumented Node.js service |
 | [prometheus-alerts/](prometheus-alerts/) | Prometheus | RED method alerting rules |
-| [grafana-dashboard/](grafana-dashboard/) | Grafana | RED dashboard JSON |
-| [k6-load-test/](k6-load-test/) | k6 | Ramp load test with SLO thresholds |
 
 ## Quick Start
 
 ```bash
-# Run instrumented Node.js service locally
-cd node-service
-npm install && npm start
-# Metrics: http://localhost:9090/metrics
-# Traces: sent to OTEL_EXPORTER_OTLP_ENDPOINT (default: http://localhost:4318)
-
-# Run load test
-cd k6-load-test
-k6 run load-test.js
+# Validate Prometheus alerting rules
+cd prometheus-alerts
+promtool check rules *.yaml
 ```
 
 ## See Also

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -1,0 +1,33 @@
+Status: Stable
+
+# Observability Examples
+
+Production-ready instrumentation, dashboards, alerting, and load test configurations.
+
+## Examples
+
+| Example | Tool | Description |
+|---------|------|-------------|
+| [node-service/](node-service/) | Pino + prom-client + OpenTelemetry | Fully instrumented Node.js service |
+| [prometheus-alerts/](prometheus-alerts/) | Prometheus | RED method alerting rules |
+| [grafana-dashboard/](grafana-dashboard/) | Grafana | RED dashboard JSON |
+| [k6-load-test/](k6-load-test/) | k6 | Ramp load test with SLO thresholds |
+
+## Quick Start
+
+```bash
+# Run instrumented Node.js service locally
+cd node-service
+npm install && npm start
+# Metrics: http://localhost:9090/metrics
+# Traces: sent to OTEL_EXPORTER_OTLP_ENDPOINT (default: http://localhost:4318)
+
+# Run load test
+cd k6-load-test
+k6 run load-test.js
+```
+
+## See Also
+
+- [references/observability.md](../../references/observability.md) — logging, metrics, tracing, alerting, capacity planning
+- `/platform-skills:observability` — instrument, dashboard, alert, load test, or plan capacity

--- a/examples/observability/prometheus-alerts/orders-service.yaml
+++ b/examples/observability/prometheus-alerts/orders-service.yaml
@@ -1,0 +1,66 @@
+groups:
+  - name: orders-service
+    rules:
+      # --- Availability ---
+      - alert: OrdersServiceDown
+        expr: up{job="orders-service"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          team: platform
+        annotations:
+          summary: "orders-service is down"
+          description: "No scrape targets healthy for orders-service in {{ $labels.namespace }}"
+          runbook: "https://wiki.internal/runbooks/orders-service-down"
+
+      # --- Error Rate (RED — Errors) ---
+      - alert: OrdersHighErrorRate
+        expr: |
+          rate(http_requests_total{job="orders-service",status=~"5.."}[5m])
+          / rate(http_requests_total{job="orders-service"}[5m]) > 0.05
+        for: 2m
+        labels:
+          severity: critical
+          team: platform
+        annotations:
+          summary: "Error rate {{ $value | humanizePercentage }} on {{ $labels.route }}"
+          description: "5xx rate above 5% sustained for 2 minutes on route {{ $labels.route }}"
+          runbook: "https://wiki.internal/runbooks/orders-high-error-rate"
+
+      # --- Latency (RED — Duration) ---
+      - alert: OrdersHighP99Latency
+        expr: |
+          histogram_quantile(0.99,
+            rate(http_request_duration_seconds_bucket{job="orders-service"}[5m])
+          ) > 1
+        for: 5m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "p99 latency {{ $value | humanizeDuration }} on {{ $labels.route }}"
+          description: "99th percentile latency above 1s for 5 minutes on route {{ $labels.route }}"
+          runbook: "https://wiki.internal/runbooks/orders-high-latency"
+
+      # --- Throughput drop (RED — Rate) ---
+      - alert: OrdersLowRequestRate
+        expr: |
+          rate(http_requests_total{job="orders-service"}[5m]) < 1
+        for: 5m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "Request rate below 1 rps — possible upstream issue or dead queue"
+          runbook: "https://wiki.internal/runbooks/orders-low-traffic"
+
+      # --- Queue depth (saturation) ---
+      - alert: OrdersQueueDepthHigh
+        expr: job_queue_depth{job="orders-service",queue="payments"} > 500
+        for: 3m
+        labels:
+          severity: warning
+          team: platform
+        annotations:
+          summary: "Payment queue depth {{ $value }} — consumer may be lagging"
+          runbook: "https://wiki.internal/runbooks/orders-queue-saturation"

--- a/references/datadog.md
+++ b/references/datadog.md
@@ -64,8 +64,8 @@ Use `/platform-skills:datadog investigate` for a guided 4-phase workflow:
 ```yaml
 # datadog-values.yaml
 datadog:
-  apiKey: "$(DD_API_KEY)"       # inject from secret, never hardcode
-  site: "datadoghq.eu"          # or datadoghq.com
+  apiKeyExistingSecret: "datadog-secret"  # kubectl create secret generic datadog-secret --from-literal=api-key="${DD_API_KEY}"
+  site: "datadoghq.eu"                    # or datadoghq.com
   apm:
     portEnabled: true
   logs:
@@ -85,10 +85,14 @@ clusterAgent:
 ```
 
 ```bash
+# Create the API key secret first — never pass the key on the command line
+kubectl create secret generic datadog-secret \
+  --from-literal=api-key="${DD_API_KEY}" \
+  -n datadog --dry-run=client -o yaml | kubectl apply -f -
+
 helm repo add datadog https://helm.datadoghq.com
 helm upgrade --install datadog datadog/datadog \
   -f datadog-values.yaml \
-  --set datadog.apiKey="${DD_API_KEY}" \
   -n datadog --create-namespace
 ```
 

--- a/references/datadog.md
+++ b/references/datadog.md
@@ -1,0 +1,341 @@
+# Datadog Reference
+
+Covers APM, Infrastructure Monitoring, Log Management, Synthetic Monitoring, Dashboards, Monitors, and SLOs.
+
+---
+
+## Agent Setup
+
+### Kubernetes (Helm)
+
+```yaml
+# datadog-values.yaml
+datadog:
+  apiKey: "$(DD_API_KEY)"       # inject from secret, never hardcode
+  site: "datadoghq.eu"          # or datadoghq.com
+  apm:
+    portEnabled: true
+  logs:
+    enabled: true
+    containerCollectAll: true
+  processAgent:
+    enabled: true
+  clusterName: "prod-eks"
+
+agents:
+  tolerations:
+    - operator: Exists
+
+clusterAgent:
+  enabled: true
+  replicas: 2
+```
+
+```bash
+helm repo add datadog https://helm.datadoghq.com
+helm upgrade --install datadog datadog/datadog \
+  -f datadog-values.yaml \
+  --set datadog.apiKey="${DD_API_KEY}" \
+  -n datadog --create-namespace
+```
+
+### Verify Agent
+
+```bash
+kubectl exec -n datadog ds/datadog -- agent status
+kubectl exec -n datadog ds/datadog -- agent check disk
+```
+
+---
+
+## APM Instrumentation
+
+### Node.js (dd-trace)
+
+```js
+// Must be the very first import
+import tracer from "dd-trace";
+tracer.init({
+  service: "orders-service",
+  env: process.env.DD_ENV ?? "production",
+  version: process.env.DD_VERSION,   // inject from CI: git sha or semver
+  logInjection: true,                // correlate logs and traces
+});
+
+// Custom span
+const span = tracer.startSpan("payment.process");
+span.setTag("payment.method", "card");
+try {
+  await processPayment(order);
+  span.finish();
+} catch (err) {
+  span.setTag("error", err);
+  span.finish();
+  throw err;
+}
+```
+
+### Python (ddtrace)
+
+```python
+# run with: ddtrace-run python app.py
+# or instrument programmatically:
+from ddtrace import tracer, patch_all
+patch_all()   # auto-instrument Django, Flask, SQLAlchemy, Redis, etc.
+
+with tracer.trace("payment.process", service="orders-service") as span:
+    span.set_tag("payment.method", "card")
+    result = process_payment(order)
+```
+
+### Unified Service Tagging
+
+Set these three tags consistently across all telemetry:
+
+```yaml
+# Pod labels / env vars
+DD_ENV: production
+DD_SERVICE: orders-service
+DD_VERSION: "1.2.3"          # matches git tag or image tag
+```
+
+---
+
+## Log Management
+
+### Structured Logging (Pino → Datadog)
+
+```js
+import pino from "pino";
+
+const logger = pino({
+  level: "info",
+  // dd-trace injects trace_id and span_id when logInjection: true
+  formatters: {
+    level: (label) => ({ level: label }),
+  },
+  redact: ["req.headers.authorization", "*.password"],
+});
+
+logger.info({ orderId, userId }, "order.created");
+```
+
+### Log Pipeline (Kubernetes)
+
+Agent `containerCollectAll: true` tails stdout/stderr from all containers. Add processing rules to:
+
+```yaml
+# agent config
+logs_config:
+  processing_rules:
+    - type: exclude_at_match
+      name: exclude_healthcheck
+      pattern: "GET /healthz"
+    - type: mask_sequences
+      name: mask_tokens
+      replace_placeholder: "[REDACTED]"
+      pattern: "(Authorization: Bearer )[^\s]+"
+```
+
+### Log-Based Metrics
+
+Convert high-cardinality logs into cost-effective metrics in Datadog UI:
+- **Logs → Generate Metrics** → filter by `service:orders-service status:error` → metric `custom.orders.errors`
+
+---
+
+## Monitors
+
+### Anomaly Monitor (APM error rate)
+
+```bash
+# Create via API
+curl -X POST "https://api.datadoghq.eu/api/v1/monitor" \
+  -H "DD-API-KEY: ${DD_API_KEY}" \
+  -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "orders-service high error rate",
+    "type": "metric alert",
+    "query": "sum(last_5m):sum:trace.web.request.errors{service:orders-service,env:production}.as_count() / sum:trace.web.request.hits{service:orders-service,env:production}.as_count() > 0.05",
+    "message": "Error rate above 5% on orders-service @pagerduty-platform @slack-platform-alerts",
+    "tags": ["service:orders-service", "env:production", "team:platform"],
+    "options": {
+      "thresholds": {"critical": 0.05, "warning": 0.02},
+      "notify_no_data": true,
+      "no_data_timeframe": 10,
+      "renotify_interval": 30
+    }
+  }'
+```
+
+### Terraform Monitor (preferred)
+
+```hcl
+resource "datadog_monitor" "orders_error_rate" {
+  name    = "orders-service high error rate"
+  type    = "metric alert"
+  message = "Error rate above 5% on orders-service @pagerduty-platform"
+
+  query = <<-EOQ
+    sum(last_5m):
+      sum:trace.web.request.errors{service:orders-service,env:production}.as_count()
+      / sum:trace.web.request.hits{service:orders-service,env:production}.as_count()
+    > 0.05
+  EOQ
+
+  monitor_thresholds {
+    critical = 0.05
+    warning  = 0.02
+  }
+
+  tags = ["service:orders-service", "env:production", "team:platform"]
+
+  notify_no_data    = true
+  no_data_timeframe = 10
+  renotify_interval = 30
+}
+```
+
+---
+
+## Dashboards
+
+### Dashboard as Code (Terraform)
+
+```hcl
+resource "datadog_dashboard" "orders_service" {
+  title       = "Orders Service — RED"
+  description = "Request rate, error rate, and latency for the orders service"
+  layout_type = "ordered"
+
+  widget {
+    timeseries_definition {
+      title = "Request Rate"
+      request {
+        q            = "sum:trace.web.request.hits{service:orders-service,env:production}.as_rate()"
+        display_type = "line"
+      }
+    }
+  }
+
+  widget {
+    timeseries_definition {
+      title = "Error Rate %"
+      request {
+        q            = "100 * sum:trace.web.request.errors{service:orders-service,env:production}.as_count() / sum:trace.web.request.hits{service:orders-service,env:production}.as_count()"
+        display_type = "line"
+      }
+      yaxis { min = "0" max = "100" }
+    }
+  }
+
+  widget {
+    timeseries_definition {
+      title = "p50/p95/p99 Latency"
+      request {
+        q            = "p50:trace.web.request{service:orders-service,env:production}"
+        display_type = "line"
+        style { palette = "cool" }
+      }
+      request {
+        q            = "p95:trace.web.request{service:orders-service,env:production}"
+        display_type = "line"
+      }
+      request {
+        q            = "p99:trace.web.request{service:orders-service,env:production}"
+        display_type = "line"
+      }
+    }
+  }
+}
+```
+
+---
+
+## SLOs
+
+```hcl
+resource "datadog_service_level_objective" "orders_availability" {
+  name        = "Orders Service Availability"
+  type        = "metric"
+  description = "99.9% of requests succeed over a rolling 30-day window"
+
+  query {
+    numerator   = "sum:trace.web.request.hits{service:orders-service,env:production,!status:error}.as_count()"
+    denominator = "sum:trace.web.request.hits{service:orders-service,env:production}.as_count()"
+  }
+
+  thresholds {
+    timeframe = "30d"
+    target    = 99.9
+    warning   = 99.95
+  }
+
+  tags = ["service:orders-service", "env:production"]
+}
+```
+
+---
+
+## Synthetic Monitoring
+
+```hcl
+resource "datadog_synthetics_test" "orders_api" {
+  name      = "Orders API — create order"
+  type      = "api"
+  subtype   = "http"
+  status    = "live"
+  locations = ["aws:eu-west-1", "aws:eu-central-1"]
+  message   = "Orders API endpoint is failing @slack-platform-alerts"
+
+  request_definition {
+    method = "POST"
+    url    = "https://api.example.com/orders"
+    body   = jsonencode({ productId = "prod-smoke-test", quantity = 1 })
+  }
+
+  request_headers = {
+    "Content-Type"  = "application/json"
+    "Authorization" = "Bearer {{orders-api-smoke-token}}"
+  }
+
+  assertion {
+    type     = "statusCode"
+    operator = "is"
+    target   = "201"
+  }
+
+  assertion {
+    type     = "responseTime"
+    operator = "lessThan"
+    target   = "1000"
+  }
+
+  options_list {
+    tick_every = 300   # every 5 minutes
+  }
+}
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Evidence | Fix |
+|---------|----------|-----|
+| Traces not appearing | `agent status` → APM section | Enable `apm.portEnabled: true`; check `DD_TRACE_AGENT_HOSTNAME` |
+| Logs missing trace_id | Log entries lack `dd.trace_id` | Set `logInjection: true` in tracer init |
+| No data in monitor | Monitor shows "No Data" | Check metric query resolves in Metrics Explorer first |
+| High DDtrace overhead | Latency increase > 5ms | Reduce sampling rate: `DD_TRACE_SAMPLE_RATE=0.1` |
+| Pod not sending metrics | Agent shows `0 checks` | Verify pod labels match `datadog.checks` annotations |
+
+---
+
+## Security Baseline
+
+- Store API key and APP key in a Kubernetes Secret or AWS Secrets Manager — never in values files
+- Use `DD_API_KEY_SECRET_NAME` to reference secret by name in the Helm chart
+- Enable `datadog.logs.containerCollectAll: true` only if log volume is manageable — filter noisy sources
+- Redact PII in log pipeline processing rules before ingestion
+- Scope APP keys to the minimum permissions needed (Monitors Write, Dashboards Write)

--- a/references/datadog.md
+++ b/references/datadog.md
@@ -33,6 +33,8 @@ Or add to `.mcp.json` in your project root:
 
 Authentication uses your Datadog session — log in via the browser prompt on first use.
 
+> **Note**: The MCP endpoint path contains `/api/unstable/`. This is the URL Datadog currently publishes. The path may change when the API is promoted to stable — check [docs.datadoghq.com/bits_ai/mcp_server/](https://docs.datadoghq.com/bits_ai/mcp_server/) for the latest endpoint.
+
 ### Available Capabilities
 
 | Category | What you can do |

--- a/references/datadog.md
+++ b/references/datadog.md
@@ -4,6 +4,57 @@ Covers APM, Infrastructure Monitoring, Log Management, Synthetic Monitoring, Das
 
 ---
 
+## MCP Server Setup
+
+The official Datadog MCP server lets Claude Code query logs, metrics, traces, monitors, and incidents directly — no manual API calls needed during incident investigation.
+
+### Connect to Claude Code
+
+```bash
+# EU site
+claude mcp add --transport http datadog https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp
+
+# US1 site
+claude mcp add --transport http datadog https://mcp.datadoghq.com/api/unstable/mcp-server/mcp
+```
+
+Or add to `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "datadog": {
+      "type": "http",
+      "url": "https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp"
+    }
+  }
+}
+```
+
+Authentication uses your Datadog session — log in via the browser prompt on first use.
+
+### Available Capabilities
+
+| Category | What you can do |
+|----------|----------------|
+| Monitors | List firing monitors, get monitor details, resolve monitors |
+| Logs | Search logs by service/env/time, filter by status |
+| Metrics | Query time series, compare before/after incident |
+| APM Traces | Fetch traces with errors, inspect spans and stack traces |
+| Events | List deployment events, audit events by tag |
+| Incidents | List active incidents, post updates |
+| Notebooks | Create notebooks for post-mortem documentation |
+
+### Incident Investigation Workflow
+
+Use `/platform-skills:datadog investigate` for a guided 4-phase workflow:
+1. **Triage** — list firing monitors and recent deployments
+2. **Signals** — pull error logs, error rate, and failing traces
+3. **Root cause** — compare before/after metrics, isolate failing endpoint or host
+4. **Resolution** — acknowledge monitor, post Slack update, create post-mortem notebook
+
+---
+
 ## Agent Setup
 
 ### Kubernetes (Helm)

--- a/references/documentation.md
+++ b/references/documentation.md
@@ -1,0 +1,426 @@
+# Code Documentation Reference
+
+Covers inline docstrings, JSDoc, OpenAPI/Swagger specs, documentation sites, and developer guides.
+
+---
+
+## Python Docstrings
+
+### Google Style (preferred for most projects)
+
+```python
+def fetch_user(user_id: int, active_only: bool = True) -> dict:
+    """Fetch a single user record by ID.
+
+    Args:
+        user_id: Unique identifier for the user.
+        active_only: When True, raise an error for inactive users.
+
+    Returns:
+        A dict containing user fields (id, name, email, created_at).
+
+    Raises:
+        ValueError: If user_id is not a positive integer.
+        UserNotFoundError: If no matching user exists.
+
+    Example:
+        >>> fetch_user(42)
+        {'id': 42, 'name': 'Alice', 'email': 'alice@example.com', ...}
+    """
+```
+
+### NumPy Style (scientific/data projects)
+
+```python
+def compute_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
+    """Compute cosine similarity between two vectors.
+
+    Parameters
+    ----------
+    vec_a : np.ndarray
+        First input vector, shape (n,).
+    vec_b : np.ndarray
+        Second input vector, shape (n,).
+
+    Returns
+    -------
+    float
+        Cosine similarity in the range [-1, 1].
+
+    Raises
+    ------
+    ValueError
+        If vectors have different lengths.
+    """
+```
+
+### Sphinx Style (legacy or Sphinx-based sites)
+
+```python
+def process_payment(order_id: str, amount: float) -> bool:
+    """Process a payment for an order.
+
+    :param order_id: The order identifier.
+    :type order_id: str
+    :param amount: Payment amount in USD.
+    :type amount: float
+    :returns: True if payment succeeded.
+    :rtype: bool
+    :raises PaymentError: If the payment gateway rejects the charge.
+    """
+```
+
+### Validation
+
+```bash
+python -m doctest module.py            # run doctest examples
+pytest --doctest-modules               # pytest integration
+interrogate --fail-under=80 src/       # coverage check
+```
+
+---
+
+## TypeScript / JavaScript JSDoc
+
+### Function
+
+```typescript
+/**
+ * Fetches a paginated list of products from the catalog.
+ *
+ * @param {string} categoryId - The category to filter by.
+ * @param {number} [page=1] - Page number (1-indexed).
+ * @param {number} [limit=20] - Maximum items per page.
+ * @returns {Promise<ProductPage>} Resolves to a page of product records.
+ * @throws {NotFoundError} If the category does not exist.
+ *
+ * @example
+ * const page = await fetchProducts('electronics', 2, 10);
+ * console.log(page.items[0].name);
+ */
+async function fetchProducts(
+  categoryId: string,
+  page = 1,
+  limit = 20
+): Promise<ProductPage> { ... }
+```
+
+### Class and Interface
+
+```typescript
+/**
+ * Client for the orders API.
+ *
+ * @example
+ * const client = new OrdersClient({ baseUrl: 'https://api.example.com' });
+ * const order = await client.create({ productId: 'prod-1', quantity: 2 });
+ */
+class OrdersClient {
+  /**
+   * @param {OrdersClientOptions} options - Client configuration.
+   */
+  constructor(private options: OrdersClientOptions) {}
+
+  /**
+   * Create a new order.
+   *
+   * @param {CreateOrderInput} input - Order creation payload.
+   * @returns {Promise<Order>} The created order.
+   */
+  async create(input: CreateOrderInput): Promise<Order> { ... }
+}
+```
+
+### Validation
+
+```bash
+tsc --noEmit                           # type-check all JSDoc
+npx typedoc --out docs src/            # generate HTML docs
+```
+
+---
+
+## OpenAPI 3.1 Specification
+
+### Complete Example
+
+```yaml
+openapi: "3.1.0"
+info:
+  title: Orders API
+  version: "1.0.0"
+  description: Manages customer orders and payment processing.
+
+paths:
+  /orders:
+    post:
+      summary: Create an order
+      operationId: createOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateOrderInput"
+            example:
+              productId: "prod-123"
+              quantity: 2
+      responses:
+        "201":
+          description: Order created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /orders/{orderId}:
+    get:
+      summary: Get an order by ID
+      operationId: getOrder
+      parameters:
+        - name: orderId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Order found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+components:
+  schemas:
+    CreateOrderInput:
+      type: object
+      required: [productId, quantity]
+      properties:
+        productId:
+          type: string
+          minLength: 1
+        quantity:
+          type: integer
+          minimum: 1
+          maximum: 100
+
+    Order:
+      type: object
+      required: [id, productId, quantity, status, createdAt]
+      properties:
+        id:
+          type: string
+          format: uuid
+        productId:
+          type: string
+        quantity:
+          type: integer
+        status:
+          type: string
+          enum: [pending, paid, shipped, cancelled]
+        createdAt:
+          type: string
+          format: date-time
+
+  responses:
+    ValidationError:
+      description: Request body failed validation
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              details:
+                type: array
+                items:
+                  type: string
+    Unauthorized:
+      description: Missing or invalid authentication token
+    NotFound:
+      description: Resource not found
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+security:
+  - bearerAuth: []
+```
+
+### Validation
+
+```bash
+npx @redocly/cli lint openapi.yaml
+npx @redocly/cli build-docs openapi.yaml --output docs/api.html
+```
+
+---
+
+## FastAPI Auto-Documentation
+
+```python
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+from typing import Annotated
+
+app = FastAPI(
+    title="Orders API",
+    version="1.0.0",
+    description="Manages customer orders and payment processing.",
+)
+
+class CreateOrderInput(BaseModel):
+    product_id: Annotated[str, Field(min_length=1, description="Product identifier")]
+    quantity: Annotated[int, Field(ge=1, le=100, description="Units to order")]
+
+class Order(BaseModel):
+    id: str
+    product_id: str
+    quantity: int
+    status: str
+
+@app.post(
+    "/orders",
+    response_model=Order,
+    status_code=201,
+    summary="Create an order",
+    responses={400: {"description": "Validation error"}},
+)
+async def create_order(body: CreateOrderInput) -> Order:
+    """Create a new order.
+
+    Returns the created order with an assigned ID and initial `pending` status.
+    """
+    return await order_service.create(body)
+```
+
+Access auto-generated docs at `/docs` (Swagger UI) and `/redoc`.
+
+---
+
+## NestJS Auto-Documentation (Swagger)
+
+```typescript
+import { ApiProperty, ApiOperation, ApiResponse } from "@nestjs/swagger";
+import { IsString, IsInt, Min, Max } from "class-validator";
+
+export class CreateOrderDto {
+  @ApiProperty({ description: "Product identifier", minLength: 1 })
+  @IsString()
+  productId: string;
+
+  @ApiProperty({ description: "Units to order", minimum: 1, maximum: 100 })
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  quantity: number;
+}
+
+@Controller("orders")
+export class OrdersController {
+  @Post()
+  @ApiOperation({ summary: "Create an order" })
+  @ApiResponse({ status: 201, description: "Order created", type: OrderDto })
+  @ApiResponse({ status: 400, description: "Validation error" })
+  async create(@Body() dto: CreateOrderDto): Promise<OrderDto> { ... }
+}
+```
+
+---
+
+## Documentation Coverage
+
+### Python — interrogate
+
+```bash
+pip install interrogate
+interrogate --fail-under=80 --ignore-init-method src/
+```
+
+### TypeScript — typedoc-coverage
+
+```bash
+npx typedoc-coverage --fail-under=80 src/
+```
+
+### Coverage Targets
+
+| Project Type | Minimum Coverage |
+|-------------|-----------------|
+| Public library | 95% |
+| Internal service | 80% |
+| CLI tool | 70% |
+| Scripts/utilities | 50% |
+
+---
+
+## Documentation Sites
+
+### MkDocs (Python projects)
+
+```yaml
+# mkdocs.yml
+site_name: Orders API
+theme:
+  name: material
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+nav:
+  - Home: index.md
+  - API Reference: reference/
+  - Getting Started: getting-started.md
+```
+
+```bash
+pip install mkdocs-material mkdocstrings[python]
+mkdocs serve     # preview at http://localhost:8000
+mkdocs build     # output to site/
+```
+
+### Getting Started Guide Structure
+
+```markdown
+# Getting Started
+
+## Prerequisites
+- Node.js 20+
+- API key (obtain at dashboard.example.com)
+
+## Installation
+npm install @example/orders-sdk
+
+## Quick Start
+const client = new OrdersClient({ apiKey: process.env.API_KEY });
+const order = await client.orders.create({ productId: "prod-1", quantity: 1 });
+
+## Next Steps
+- [Authentication](./auth.md)
+- [Error handling](./errors.md)
+- [API reference](./api.md)
+```
+
+---
+
+## What NOT to Document
+
+- Obvious getters and setters (`getId()`, `setName()`)
+- Private implementation details that change frequently
+- Comments that repeat the code (`i++ // increment i`)
+- TODO comments in committed code — use issue tracker instead

--- a/references/dynatrace.md
+++ b/references/dynatrace.md
@@ -4,6 +4,64 @@ Covers OneAgent deployment, Kubernetes Operator, Davis AI, Distributed Tracing, 
 
 ---
 
+## MCP Server Setup
+
+The official Dynatrace MCP server lets Claude Code query Problems, logs, traces, DQL, and Davis AI directly — enabling AI-driven incident investigation without leaving your editor.
+
+### Connect to Claude Code
+
+```bash
+# stdio transport (local, Node.js 22+ required)
+claude mcp add dynatrace -- npx -y @dynatrace-oss/dynatrace-mcp-server
+
+# Set your environment URL
+export DT_ENVIRONMENT="https://abc12345.apps.dynatrace.com"   # Platform URL (not classic)
+```
+
+Or add to `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "dynatrace": {
+      "command": "npx",
+      "args": ["-y", "@dynatrace-oss/dynatrace-mcp-server@latest"],
+      "env": {
+        "DT_ENVIRONMENT": "https://abc12345.apps.dynatrace.com"
+      }
+    }
+  }
+}
+```
+
+**Remote MCP** (no local Node.js needed): available at the [Dynatrace Hub](https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/). Authentication handled via browser OAuth — no token needed.
+
+**Cost note**: `execute_dql` scans Grail data and may incur costs. Set `DT_GRAIL_QUERY_BUDGET_GB` (default 1000 GB) to cap session spend. Use short timeframes (1h–24h) during investigation.
+
+### Available Capabilities
+
+| Category | Key Tools |
+|----------|-----------|
+| Problems | `list_problems`, full problem details with root cause entity and impact |
+| Logs / Metrics / Traces | `execute_dql` — query any Grail data with DQL |
+| Natural language | `generate_dql_from_natural_language`, `explain_dql_in_natural_language` |
+| Entity discovery | `find_entity_by_name` — look up services, hosts, process groups |
+| Davis AI | `chat_with_davis_copilot`, `list_davis_analyzers`, `execute_davis_analyzer` |
+| Kubernetes | `get_kubernetes_events` |
+| Exceptions | `list_exceptions` with stack traces |
+| Notifications | `send_slack_message`, `send_email`, `send_event` |
+| Documentation | `create_dynatrace_notebook` for post-mortem capture |
+
+### Incident Investigation Workflow
+
+Use `/platform-skills:dynatrace investigate` for a guided 4-phase workflow:
+1. **Triage** — list open Problems, get Davis AI root cause entity and impact scope
+2. **Signals** — DQL queries for error logs, exceptions, and failing traces
+3. **Root cause** — Davis Copilot analysis, Davis Analyzer execution, entity health check
+4. **Resolution** — close Problem with note, send Slack update, create Notebook
+
+---
+
 ## Deployment
 
 ### Kubernetes Operator (recommended)

--- a/references/dynatrace.md
+++ b/references/dynatrace.md
@@ -1,0 +1,310 @@
+# Dynatrace Reference
+
+Covers OneAgent deployment, Kubernetes Operator, Davis AI, Distributed Tracing, Log Monitoring, SLOs, and Dashboards.
+
+---
+
+## Deployment
+
+### Kubernetes Operator (recommended)
+
+```bash
+# Install the Dynatrace Operator
+kubectl create namespace dynatrace
+kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes.yaml
+
+# Create API and data-ingest tokens as a Secret
+kubectl -n dynatrace create secret generic dynakube \
+  --from-literal=apiToken="${DT_API_TOKEN}" \
+  --from-literal=dataIngestToken="${DT_DATA_INGEST_TOKEN}"
+```
+
+```yaml
+# dynakube.yaml — full-stack monitoring with automatic injection
+apiVersion: dynatrace.com/v1beta1
+kind: DynaKube
+metadata:
+  name: dynakube
+  namespace: dynatrace
+spec:
+  apiUrl: "https://{your-environment-id}.live.dynatrace.com/api"
+  tokens: dynakube
+
+  oneAgent:
+    cloudNativeFullStack:
+      # Automatic injection into all pods — no restart required
+      image: ""       # use default
+
+  activeGate:
+    capabilities:
+      - routing
+      - kubernetes-monitoring
+      - dynatrace-api
+    replicas: 2
+
+  metadataEnrichment:
+    enabled: true     # enriches logs/metrics with k8s metadata
+```
+
+```bash
+kubectl apply -f dynakube.yaml
+kubectl -n dynatrace get dynakube dynakube
+```
+
+### Verify Injection
+
+```bash
+# OneAgent should be injected into app pods as an init container
+kubectl describe pod <app-pod> | grep dynatrace
+```
+
+---
+
+## Code-Level Instrumentation
+
+### Node.js (OneAgent auto-instruments automatically)
+
+```js
+// For custom business transactions — no SDK needed for http/db/cache
+// Use the SDK only for custom spans
+import Dynatrace from "@dynatrace/oneagent-sdk";
+
+const sdk = Dynatrace.createInstance();
+const tracer = sdk.traceIncomingRemoteCall({
+  serviceMethod: "processPayment",
+  serviceName: "orders-service",
+  serviceEndpoint: "/payments",
+  dynatraceStringTag: req.headers["x-dynatrace"],
+  protocol: Dynatrace.ChannelType.OTHER,
+});
+
+tracer.start(async () => {
+  await processPayment(order);
+});
+```
+
+### Java / Spring Boot (auto-instrumented)
+
+OneAgent auto-instruments JVM services — no code changes needed. For custom spans:
+
+```java
+import com.dynatrace.oneagent.sdk.api.OneAgentSDK;
+import com.dynatrace.oneagent.sdk.api.OneAgentSDKFactory;
+
+OneAgentSDK sdk = OneAgentSDKFactory.createInstance();
+OutgoingRemoteCallTracer tracer = sdk.traceOutgoingRemoteCall(
+    "processPayment", "PaymentService", "grpc://payments:50051",
+    ChannelType.OTHER, null);
+
+tracer.start();
+try {
+    stub.processPayment(request);
+    tracer.end();
+} catch (Exception e) {
+    tracer.error(e);
+    tracer.end();
+}
+```
+
+### Python (OneAgent auto-instruments Django, Flask, FastAPI, SQLAlchemy)
+
+```bash
+pip install oneagent-sdk
+```
+
+```python
+import oneagent
+
+with oneagent.sdk.get_sdk().trace_custom_service(
+    "processPayment", "orders-service"
+) as tracer:
+    process_payment(order)
+```
+
+---
+
+## Log Monitoring
+
+### Kubernetes Log Ingestion
+
+OneAgent collects container stdout/stderr automatically when `cloudNativeFullStack` is enabled.
+
+Enrich logs with custom attributes:
+
+```yaml
+# Add log enrichment annotations to pod spec
+metadata:
+  annotations:
+    logs.dynatrace.com/ingest: "true"
+```
+
+### Log Processing Rules (via UI or API)
+
+```bash
+# Create a log processing rule via Settings API
+curl -X POST "https://{env}.live.dynatrace.com/api/v2/settings/objects" \
+  -H "Authorization: Api-Token ${DT_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "schemaId": "builtin:logmonitoring.log-storage-settings",
+    "value": {
+      "enabled": true,
+      "matchers": [{"attribute": "k8s.namespace.name", "values": ["production"]}],
+      "send_to_storage": true
+    }
+  }'
+```
+
+---
+
+## Metrics Ingestion (Custom Metrics)
+
+```bash
+# Ingest custom metrics via the Metrics Ingestion API (MINT)
+curl -X POST "https://{env}.live.dynatrace.com/api/v2/metrics/ingest" \
+  -H "Authorization: Api-Token ${DT_DATA_INGEST_TOKEN}" \
+  -H "Content-Type: text/plain" \
+  --data-binary "orders.created,env=production,service=orders-service count,delta=42"
+```
+
+```python
+# Python helper
+import requests
+
+def push_metric(env: str, token: str, metric: str, value: float, tags: dict):
+    tag_str = ",".join(f"{k}={v}" for k, v in tags.items())
+    payload = f"{metric},{tag_str} gauge,{value}"
+    requests.post(
+        f"https://{env}.live.dynatrace.com/api/v2/metrics/ingest",
+        headers={"Authorization": f"Api-Token {token}", "Content-Type": "text/plain"},
+        data=payload,
+    )
+```
+
+---
+
+## SLOs
+
+```bash
+# Create SLO via API
+curl -X POST "https://{env}.live.dynatrace.com/api/v2/slo" \
+  -H "Authorization: Api-Token ${DT_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Orders Service Availability",
+    "description": "99.9% of requests succeed over 30 days",
+    "metricExpression": "100*(builtin:service.errors.server.successCount:splitBy():sum)/(builtin:service.requestCount.server:splitBy():sum)",
+    "evaluationType": "AGGREGATE",
+    "filter": "type(SERVICE),entityName(orders-service),tag(env:production)",
+    "target": 99.9,
+    "warning": 99.95,
+    "timeframe": "-30d",
+    "enabled": true
+  }'
+```
+
+---
+
+## Terraform Provider (preferred for IaC)
+
+```hcl
+terraform {
+  required_providers {
+    dynatrace = {
+      source  = "dynatrace-oss/dynatrace"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "dynatrace" {
+  dt_env_url   = "https://{env}.live.dynatrace.com"
+  dt_api_token = var.dt_api_token
+}
+
+# Service anomaly detection
+resource "dynatrace_service_anomalies_v2" "orders" {
+  scope = "SERVICE-XXXXXXXXXXXXXXXX"   # service entity ID
+
+  failure_rate {
+    detection_mode = "auto"
+    enabled        = true
+  }
+
+  response_time {
+    detection_mode = "auto"
+    enabled        = true
+  }
+}
+
+# Dashboard
+resource "dynatrace_json_dashboard" "orders_red" {
+  contents = file("${path.module}/dashboards/orders-red.json")
+}
+
+# SLO
+resource "dynatrace_slo_v2" "orders_availability" {
+  name        = "Orders Service Availability"
+  enabled     = true
+  description = "99.9% of requests succeed"
+
+  metric_expression = "100*(builtin:service.errors.server.successCount:splitBy():sum)/(builtin:service.requestCount.server:splitBy():sum)"
+  evaluation_type   = "AGGREGATE"
+  filter            = "type(SERVICE),entityName(orders-service)"
+  target_success    = 99.9
+  target_warning    = 99.95
+  timeframe         = "-30d"
+}
+
+# Alerting profile
+resource "dynatrace_alerting" "platform" {
+  name = "Platform Team"
+
+  rules {
+    delay_in_minutes = 0
+    include_mode     = "INCLUDE_ALL"
+    severity_level   = "AVAILABILITY"
+  }
+}
+```
+
+---
+
+## Davis AI Problem Feeds
+
+Davis AI automatically detects anomalies and creates Problems. Query the Problems API to integrate with incident workflows:
+
+```bash
+# Get open problems
+curl "https://{env}.live.dynatrace.com/api/v2/problems?problemSelector=status(OPEN)" \
+  -H "Authorization: Api-Token ${DT_API_TOKEN}"
+
+# Acknowledge a problem
+curl -X POST "https://{env}.live.dynatrace.com/api/v2/problems/{problemId}/close" \
+  -H "Authorization: Api-Token ${DT_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Resolved by platform team — see INC-1234"}'
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Evidence | Fix |
+|---------|----------|-----|
+| OneAgent not injecting | `kubectl describe pod` — no init containers | Check DynaKube `cloudNativeFullStack` is set; verify namespace not excluded |
+| No traces in distributed tracing | Service Map shows service as standalone | Confirm `x-dynatrace` header is forwarded between services |
+| Custom metrics not appearing | Check MINT API response code | Verify metric key format: `<prefix>.<name>` with no spaces; confirm `dataIngestToken` has correct scope |
+| SLO shows 0% | SLO metric expression returns no data | Validate filter matches entity name exactly; check entity ID in Smartscape |
+| Davis AI not alerting | No Problems created | Verify anomaly detection is enabled on service settings; check alerting profile is assigned |
+
+---
+
+## Token Scopes
+
+| Token Type | Required Scopes |
+|-----------|----------------|
+| `apiToken` | `ReadConfig`, `WriteConfig`, `DataExport`, `LogExport`, `ReadSyntheticData`, `WriteAnomalyDetection` |
+| `dataIngestToken` | `metrics.ingest`, `logs.ingest` |
+
+Store both tokens in Kubernetes Secrets or a secrets manager — never in plain Helm values or Terraform state.

--- a/references/dynatrace.md
+++ b/references/dynatrace.md
@@ -36,6 +36,8 @@ Or add to `.mcp.json`:
 
 **Remote MCP** (no local Node.js needed): available at the [Dynatrace Hub](https://www.dynatrace.com/hub/detail/dynatrace-mcp-server/). Authentication handled via browser OAuth — no token needed.
 
+> **URL note**: `DT_ENVIRONMENT` must be the Platform URL (`abc12345.apps.dynatrace.com`). The classic URL (`abc12345.live.dynatrace.com`) used by the Operator `apiUrl` and REST API will not work here.
+
 **Cost note**: `execute_dql` scans Grail data and may incur costs. Set `DT_GRAIL_QUERY_BUDGET_GB` (default 1000 GB) to cap session spend. Use short timeframes (1h–24h) during investigation.
 
 ### Available Capabilities

--- a/references/mcp.md
+++ b/references/mcp.md
@@ -1,0 +1,332 @@
+# MCP (Model Context Protocol) Reference
+
+## Protocol Fundamentals
+
+MCP is a JSON-RPC 2.0 protocol that connects AI hosts (Claude Desktop, Claude Code) with servers exposing tools, resources, and prompts.
+
+### Message Lifecycle
+
+```
+Host (client)                    MCP Server
+     │                                │
+     │──── initialize ───────────────>│  negotiate capabilities
+     │<─── initialized ───────────────│
+     │                                │
+     │──── tools/list ───────────────>│  discover tools
+     │<─── { tools: [...] } ──────────│
+     │                                │
+     │──── tools/call ───────────────>│  invoke tool
+     │<─── { content: [...] } ────────│
+     │                                │
+     │──── resources/list ───────────>│  discover resources
+     │<─── { resources: [...] } ──────│
+     │                                │
+     │──── resources/read ───────────>│  read resource
+     │<─── { contents: [...] } ───────│
+```
+
+### Transport Options
+
+| Transport | Use Case | Notes |
+|-----------|----------|-------|
+| `stdio` | Local CLI tools, Claude Desktop | Process-level isolation, simplest |
+| `SSE` (HTTP) | Remote servers, web services | Requires auth layer |
+| `HTTP` (Streamable) | Production APIs | Preferred for new remote servers |
+
+---
+
+## TypeScript SDK
+
+### Scaffold
+
+```bash
+npx @modelcontextprotocol/create-server my-server
+cd my-server && npm install
+```
+
+### Tool Registration with Zod
+
+```typescript
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const server = new McpServer({ name: "my-server", version: "1.0.0" });
+
+server.tool(
+  "search_docs",
+  "Search internal documentation by keyword",
+  {
+    query: z.string().min(1).describe("Search query"),
+    limit: z.number().int().min(1).max(50).default(10),
+  },
+  async ({ query, limit }) => {
+    const results = await searchIndex(query, limit);
+    return {
+      content: [{ type: "text", text: JSON.stringify(results) }],
+    };
+  }
+);
+```
+
+### Resource Provider
+
+```typescript
+server.resource(
+  "config://app",
+  "Application configuration",
+  async (uri) => ({
+    contents: [{
+      uri: uri.href,
+      text: JSON.stringify(getConfig()),
+      mimeType: "application/json",
+    }],
+  })
+);
+
+// Parameterised resource template
+server.resource(
+  "user://{userId}/profile",
+  "User profile by ID",
+  async (uri, { userId }) => ({
+    contents: [{
+      uri: uri.href,
+      text: JSON.stringify(await getUserProfile(userId)),
+      mimeType: "application/json",
+    }],
+  })
+);
+```
+
+### Prompt Template
+
+```typescript
+server.prompt(
+  "summarise_pr",
+  "Summarise a pull request for a code review",
+  {
+    pr_url: z.string().url(),
+    style: z.enum(["brief", "detailed"]).default("brief"),
+  },
+  async ({ pr_url, style }) => ({
+    messages: [{
+      role: "user",
+      content: {
+        type: "text",
+        text: `Summarise this PR in ${style} style: ${pr_url}`,
+      },
+    }],
+  })
+);
+```
+
+### stdio Transport
+
+```typescript
+const transport = new StdioServerTransport();
+await server.connect(transport);
+```
+
+### HTTP/SSE Transport (remote)
+
+```typescript
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import express from "express";
+
+const app = express();
+const transport = new SSEServerTransport("/message", res);
+app.get("/sse", (req, res) => server.connect(new SSEServerTransport("/message", res)));
+app.post("/message", (req, res) => transport.handlePostMessage(req, res));
+app.listen(3000);
+```
+
+---
+
+## Python SDK (FastMCP)
+
+### Scaffold
+
+```bash
+pip install mcp
+```
+
+### Tool with Pydantic Validation
+
+```python
+from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+mcp = FastMCP("my-server")
+
+@mcp.tool()
+async def search_docs(query: str, limit: int = 10) -> str:
+    """Search internal documentation by keyword.
+
+    Args:
+        query: Search query string.
+        limit: Maximum number of results (1-50).
+    """
+    results = await search_index(query, limit)
+    return json.dumps(results)
+```
+
+### Resource
+
+```python
+@mcp.resource("config://app")
+async def app_config() -> str:
+    """Expose application configuration."""
+    return json.dumps(get_config())
+
+@mcp.resource("user://{user_id}/profile")
+async def user_profile(user_id: str) -> str:
+    """User profile by ID."""
+    return json.dumps(await get_user_profile(user_id))
+```
+
+### Run
+
+```python
+if __name__ == "__main__":
+    mcp.run()        # stdio (default)
+    # mcp.run(transport="sse")   # SSE
+```
+
+---
+
+## Schema Design
+
+### Zod Best Practices (TypeScript)
+
+```typescript
+// Good — narrow, descriptive schemas
+const InputSchema = z.object({
+  environment: z.enum(["dev", "staging", "prod"]),
+  timeout_ms: z.number().int().min(100).max(30_000).default(5_000),
+  tags: z.array(z.string().max(64)).max(20).optional(),
+});
+
+// Bad — overly permissive
+const BadSchema = z.object({
+  data: z.any(),        // ❌ no validation
+  config: z.object({}), // ❌ empty object
+});
+```
+
+### Pydantic Best Practices (Python)
+
+```python
+from pydantic import BaseModel, Field, validator
+
+class SearchInput(BaseModel):
+    query: str = Field(..., min_length=1, max_length=500)
+    limit: int = Field(10, ge=1, le=50)
+    filters: list[str] = Field(default_factory=list)
+
+    @validator("filters")
+    def no_empty_filters(cls, v):
+        return [f.strip() for f in v if f.strip()]
+```
+
+---
+
+## Error Handling
+
+```typescript
+// TypeScript — return structured errors, never throw to client
+server.tool("risky_op", "...", { id: z.string() }, async ({ id }) => {
+  try {
+    const result = await performOperation(id);
+    return { content: [{ type: "text", text: JSON.stringify(result) }] };
+  } catch (err) {
+    return {
+      content: [{ type: "text", text: `Error: ${err.message}` }],
+      isError: true,
+    };
+  }
+});
+```
+
+```python
+# Python — return error content, never let exceptions propagate unhandled
+@mcp.tool()
+async def risky_op(id: str) -> str:
+    try:
+        return json.dumps(await perform_operation(id))
+    except OperationError as e:
+        return f"Error: {e}"
+```
+
+---
+
+## Testing and Debugging
+
+### MCP Inspector
+
+```bash
+# Launch interactive protocol debugger
+npx @modelcontextprotocol/inspector node dist/index.js
+```
+
+Verify:
+- Tools appear in the tool list
+- Schemas reject invalid inputs with clear messages
+- Successful calls return well-formed `content` arrays
+- Error calls set `isError: true`
+
+### Protocol Smoke Test (curl)
+
+```bash
+# List tools via stdio
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  | node dist/index.js
+```
+
+---
+
+## Security
+
+### Authentication (HTTP transport)
+
+```typescript
+app.use((req, res, next) => {
+  const token = req.headers.authorization?.split(" ")[1];
+  if (!verifyToken(token)) return res.status(401).json({ error: "Unauthorized" });
+  next();
+});
+```
+
+### Rate Limiting
+
+```typescript
+import rateLimit from "express-rate-limit";
+
+app.use("/message", rateLimit({
+  windowMs: 60 * 1000,
+  max: 100,
+  message: { error: "Too many requests" },
+}));
+```
+
+### Secrets — Never in Tool Responses
+
+```typescript
+// ❌ Never expose credentials in tool output
+return { content: [{ type: "text", text: JSON.stringify({ apiKey: process.env.SECRET }) }] };
+
+// ✅ Return only what the client needs
+return { content: [{ type: "text", text: JSON.stringify({ status: "authenticated" }) }] };
+```
+
+---
+
+## Deployment Checklist
+
+- [ ] All tool inputs validated with Zod or Pydantic schemas
+- [ ] Error paths return `isError: true`, not unhandled exceptions
+- [ ] No credentials or secrets in resource content or tool responses
+- [ ] Authentication on HTTP/SSE transports
+- [ ] Rate limiting configured
+- [ ] Protocol compliance verified with MCP Inspector
+- [ ] Environment variables used for all secrets (`process.env` / `os.environ`)
+- [ ] Logging of tool calls (without sensitive param values)

--- a/references/mcp.md
+++ b/references/mcp.md
@@ -134,9 +134,20 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import express from "express";
 
 const app = express();
-const transport = new SSEServerTransport("/message", res);
-app.get("/sse", (req, res) => server.connect(new SSEServerTransport("/message", res)));
-app.post("/message", (req, res) => transport.handlePostMessage(req, res));
+const transports = new Map<string, SSEServerTransport>();
+
+app.get("/sse", async (req, res) => {
+  const transport = new SSEServerTransport("/message", res);
+  transports.set(transport.sessionId, transport);
+  await server.connect(transport);
+});
+
+app.post("/message", async (req, res) => {
+  const sessionId = req.query.sessionId as string;
+  const transport = transports.get(sessionId);
+  await transport?.handlePostMessage(req, res);
+});
+
 app.listen(3000);
 ```
 
@@ -153,20 +164,23 @@ pip install mcp
 ### Tool with Pydantic Validation
 
 ```python
+import json
+
 from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
 mcp = FastMCP("my-server")
 
-@mcp.tool()
-async def search_docs(query: str, limit: int = 10) -> str:
-    """Search internal documentation by keyword.
 
-    Args:
-        query: Search query string.
-        limit: Maximum number of results (1-50).
-    """
-    results = await search_index(query, limit)
+class SearchInput(BaseModel):
+    query: str = Field(description="Search query string")
+    limit: int = Field(default=10, ge=1, le=50, description="Maximum results")
+
+
+@mcp.tool()
+async def search_docs(input: SearchInput) -> str:
+    """Search internal documentation by keyword."""
+    results = await search_index(input.query, input.limit)
     return json.dumps(results)
 ```
 

--- a/references/observability.md
+++ b/references/observability.md
@@ -145,7 +145,7 @@ scrape_configs:
 
 ### Node.js
 
-```js
+```typescript
 import { NodeSDK } from "@opentelemetry/sdk-node";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { trace, SpanStatusCode } from "@opentelemetry/api";

--- a/references/observability.md
+++ b/references/observability.md
@@ -1,0 +1,398 @@
+# Observability Reference
+
+Covers the three pillars — logs, metrics, traces — plus alerting, dashboards, load testing, and capacity planning.
+
+---
+
+## Structured Logging
+
+### Principle
+
+Every log line must be parseable by a log aggregator (Loki, CloudWatch Logs Insights, Datadog). Use JSON. Never interpolate variables into the message string.
+
+```js
+// ✅ Structured — fully queryable
+logger.info({ requestId: req.id, userId: req.user.id, durationMs: elapsed }, "order.created");
+
+// ❌ Unstructured — opaque to queries
+logger.info(`Order created for user ${req.user.id} in ${elapsed}ms`);
+```
+
+### Node.js — Pino
+
+```js
+import pino from "pino";
+
+const logger = pino({
+  level: process.env.LOG_LEVEL ?? "info",
+  redact: ["req.headers.authorization", "*.password", "*.token"],
+});
+
+// Child logger with bound context
+const reqLogger = logger.child({ requestId: req.id, service: "orders" });
+reqLogger.info({ orderId }, "order.created");
+reqLogger.error({ err, orderId }, "order.payment_failed");
+```
+
+### Python — structlog
+
+```python
+import structlog
+
+log = structlog.get_logger()
+log = log.bind(request_id=request_id, service="orders")
+
+log.info("order.created", order_id=order_id, amount_cents=amount)
+log.error("order.payment_failed", order_id=order_id, error=str(e))
+```
+
+### What NOT to Log
+
+- Passwords, API keys, tokens (`redact` them)
+- Full request/response bodies containing PII
+- Health check noise at INFO level (use DEBUG)
+
+---
+
+## Prometheus Metrics
+
+### Metric Types
+
+| Type | Use For | Example |
+|------|---------|---------|
+| `Counter` | Monotonically increasing counts | `http_requests_total` |
+| `Gauge` | Values that go up and down | `queue_depth`, `memory_bytes` |
+| `Histogram` | Latency distributions (buckets) | `http_request_duration_seconds` |
+| `Summary` | Pre-computed percentiles | Avoid — use Histogram instead |
+
+### Node.js — prom-client
+
+```js
+import { Counter, Histogram, Gauge, register } from "prom-client";
+
+const httpRequests = new Counter({
+  name: "http_requests_total",
+  help: "Total HTTP requests by method, route, and status",
+  labelNames: ["method", "route", "status"],
+});
+
+const httpDuration = new Histogram({
+  name: "http_request_duration_seconds",
+  help: "HTTP request latency",
+  labelNames: ["method", "route"],
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+});
+
+const queueDepth = new Gauge({
+  name: "job_queue_depth",
+  help: "Number of jobs waiting in the queue",
+  labelNames: ["queue"],
+});
+
+// Middleware
+app.use((req, res, next) => {
+  const route = req.route?.path ?? req.path;
+  const end = httpDuration.startTimer({ method: req.method, route });
+  res.on("finish", () => {
+    httpRequests.inc({ method: req.method, route, status: res.statusCode });
+    end();
+  });
+  next();
+});
+
+// Scrape endpoint
+app.get("/metrics", async (req, res) => {
+  res.set("Content-Type", register.contentType);
+  res.end(await register.metrics());
+});
+```
+
+### Python — prometheus-client
+
+```python
+from prometheus_client import Counter, Histogram, start_http_server
+
+http_requests = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    ["method", "route", "status"],
+)
+
+http_duration = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request latency",
+    ["method", "route"],
+    buckets=[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+)
+
+start_http_server(9090)  # expose /metrics
+```
+
+### Prometheus Scrape Config
+
+```yaml
+scrape_configs:
+  - job_name: orders-service
+    static_configs:
+      - targets: ["orders-service:9090"]
+    scrape_interval: 15s
+    metrics_path: /metrics
+```
+
+---
+
+## OpenTelemetry Tracing
+
+### Node.js
+
+```js
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { trace, SpanStatusCode } from "@opentelemetry/api";
+
+const sdk = new NodeSDK({
+  traceExporter: new OTLPTraceExporter({ url: "http://otel-collector:4318/v1/traces" }),
+  serviceName: "orders-service",
+});
+sdk.start();
+
+const tracer = trace.getTracer("orders-service");
+
+async function processOrder(orderId: string) {
+  const span = tracer.startSpan("order.process");
+  span.setAttribute("order.id", orderId);
+  try {
+    const result = await db.saveOrder(orderId);
+    span.setStatus({ code: SpanStatusCode.OK });
+    return result;
+  } catch (err) {
+    span.recordException(err);
+    span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+    throw err;
+  } finally {
+    span.end();
+  }
+}
+```
+
+### Python
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+provider = TracerProvider()
+provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(
+    endpoint="http://otel-collector:4318/v1/traces"
+)))
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer("orders-service")
+
+async def process_order(order_id: str):
+    with tracer.start_as_current_span("order.process") as span:
+        span.set_attribute("order.id", order_id)
+        result = await db.save_order(order_id)
+        return result
+```
+
+---
+
+## Alerting Rules
+
+### RED Method (Request-based services)
+
+- **R**ate — requests per second
+- **E**rrors — error rate percentage
+- **D**uration — latency percentiles
+
+```yaml
+groups:
+  - name: orders-service
+    rules:
+      # Error rate > 5% for 2 minutes
+      - alert: HighErrorRate
+        expr: |
+          rate(http_requests_total{status=~"5..",job="orders-service"}[5m])
+          / rate(http_requests_total{job="orders-service"}[5m]) > 0.05
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Error rate {{ $value | humanizePercentage }} on {{ $labels.route }}"
+          runbook: "https://wiki.internal/runbooks/orders-high-error-rate"
+
+      # p99 latency > 1s for 5 minutes
+      - alert: HighLatency
+        expr: |
+          histogram_quantile(0.99,
+            rate(http_request_duration_seconds_bucket{job="orders-service"}[5m])
+          ) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "p99 latency {{ $value | humanizeDuration }} on {{ $labels.route }}"
+
+      # Service down
+      - alert: ServiceDown
+        expr: up{job="orders-service"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "orders-service is down"
+```
+
+### USE Method (Resource-based systems)
+
+- **U**tilization — % time resource is busy
+- **S**aturation — queue depth, wait time
+- **E**rrors — device-level errors
+
+```yaml
+      # CPU saturation
+      - alert: HighCPUSaturation
+        expr: rate(container_cpu_cfs_throttled_seconds_total[5m]) > 0.25
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "CPU throttling above 25% — consider raising CPU limits or removing them"
+```
+
+### Alert Design Rules
+
+- Set `for:` ≥ 1m to avoid flapping on transient spikes
+- Every alert needs a `runbook` annotation
+- Page on symptoms (error rate, latency), not causes (CPU %)
+- Derive SLO burn-rate alerts from error budget, not raw thresholds
+
+---
+
+## Grafana Dashboards
+
+### RED Dashboard Template
+
+```json
+{
+  "title": "Service RED — orders-service",
+  "panels": [
+    {
+      "title": "Request Rate",
+      "type": "timeseries",
+      "targets": [{"expr": "rate(http_requests_total{job=\"orders-service\"}[5m])"}]
+    },
+    {
+      "title": "Error Rate %",
+      "type": "timeseries",
+      "targets": [{"expr": "rate(http_requests_total{job=\"orders-service\",status=~\"5..\"}[5m]) / rate(http_requests_total{job=\"orders-service\"}[5m]) * 100"}]
+    },
+    {
+      "title": "p50 / p95 / p99 Latency",
+      "type": "timeseries",
+      "targets": [
+        {"expr": "histogram_quantile(0.50, rate(http_request_duration_seconds_bucket{job=\"orders-service\"}[5m]))", "legendFormat": "p50"},
+        {"expr": "histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{job=\"orders-service\"}[5m]))", "legendFormat": "p95"},
+        {"expr": "histogram_quantile(0.99, rate(http_request_duration_seconds_bucket{job=\"orders-service\"}[5m]))", "legendFormat": "p99"}
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## Load Testing — k6
+
+### Basic Ramp Test
+
+```js
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+export const options = {
+  stages: [
+    { duration: "1m", target: 50 },   // ramp up
+    { duration: "5m", target: 50 },   // steady state
+    { duration: "1m", target: 0 },    // ramp down
+  ],
+  thresholds: {
+    http_req_duration: ["p(95)<500"],  // 95% of requests < 500ms
+    http_req_failed:   ["rate<0.01"],  // < 1% error rate
+  },
+};
+
+export default function () {
+  const res = http.post(
+    "https://api.example.com/orders",
+    JSON.stringify({ productId: "prod-123", quantity: 1 }),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  check(res, {
+    "status is 201": (r) => r.status === 201,
+    "response time < 500ms": (r) => r.timings.duration < 500,
+  });
+  sleep(1);
+}
+```
+
+### Run
+
+```bash
+k6 run --out json=results.json load-test.js
+```
+
+---
+
+## Capacity Planning
+
+### Back-of-Envelope Formula
+
+```
+Required replicas = ceil(
+  (peak_rps × avg_latency_s) / target_concurrency_per_pod
+)
+```
+
+Example: 1000 rps × 0.1s latency / 20 concurrent connections = 5 replicas minimum. Add 50% headroom → 8 replicas.
+
+### HPA Target Utilisation
+
+```yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: orders-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: orders-service
+  minReplicas: 3
+  maxReplicas: 20
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60   # scale before saturation
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: AverageValue
+          averageValue: 400Mi
+```
+
+### Resource Budgeting
+
+| Metric | Target | Alert Threshold |
+|--------|--------|----------------|
+| CPU utilisation | < 60% | > 80% |
+| Memory utilisation | < 70% | > 85% |
+| Error rate | < 0.1% | > 1% |
+| p99 latency | < 500ms | > 1s |
+| Disk utilisation | < 70% | > 85% |

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -26,6 +26,8 @@ Match the task to the right layer:
 13. `MCP (Model Context Protocol)`: Build, review, and debug MCP servers and clients — tool and resource handlers, Zod/Pydantic schema validation, stdio/HTTP/SSE transports, protocol compliance, auth, and rate limiting.
 14. `Observability`: Instrument services with structured logging, Prometheus metrics, and OpenTelemetry tracing. Build Grafana dashboards, write alerting rules, run k6 load tests, and plan capacity.
 15. `Documentation`: Generate and validate inline docstrings (Google/NumPy/JSDoc), OpenAPI 3.1 specs, documentation sites (MkDocs, TypeDoc), and getting started guides.
+16. `Datadog`: Deploy and configure the Datadog Agent on Kubernetes, instrument services with APM and log correlation, write monitors, dashboards, SLOs, and synthetic tests — all as Terraform-managed resources.
+17. `Dynatrace`: Deploy OneAgent via the Kubernetes Operator with automatic injection, configure anomaly detection, ingest custom metrics, define SLOs, and manage dashboards and alerting profiles with the Dynatrace Terraform provider.
 
 If a task spans multiple areas, decide which layer owns the source of truth and keep the other layers consumers of that state.
 
@@ -76,6 +78,8 @@ When asked to generate code, start from the thinnest useful slice that proves th
 - For MCP server and client development — protocol, TypeScript/Python SDKs, schema validation, transports, security, and testing — read [references/mcp.md](references/mcp.md).
 - For observability instrumentation, Prometheus metrics, OpenTelemetry tracing, alerting rules, Grafana dashboards, load testing, and capacity planning, read [references/observability.md](references/observability.md).
 - For code documentation — Python docstrings, JSDoc, OpenAPI 3.1 specs, documentation sites, and developer guides — read [references/documentation.md](references/documentation.md).
+- For Datadog Agent setup, APM, log management, monitors, dashboards, SLOs, and synthetic tests — read [references/datadog.md](references/datadog.md).
+- For Dynatrace OneAgent Operator, auto-instrumentation, custom metrics, SLOs, anomaly detection, and Terraform provider — read [references/dynatrace.md](references/dynatrace.md).
 
 Load only the files needed for the current request.
 
@@ -95,3 +99,5 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:mcp` — MCP server/client scaffolding, protocol review, and integration debugging
 - `/platform-skills:observability` — instrument services, build dashboards, write alerts, run load tests, plan capacity
 - `/platform-skills:document` — generate docstrings, OpenAPI specs, documentation sites, and getting started guides
+- `/platform-skills:datadog` — Datadog Agent setup, APM instrumentation, monitors, dashboards, SLOs, and debugging
+- `/platform-skills:dynatrace` — OneAgent deployment, instrumentation, anomaly detection, SLOs, and debugging

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -23,6 +23,9 @@ Match the task to the right layer:
 10. `Cross-platform`: Design repo boundaries, ownership, promotion flows, and security controls first.
 11. `Compliance`: Implement SOC 2 Trust Services Criteria controls in Terraform — IAM least privilege, encryption, audit logging, network security, and change management. Run Checkov for continuous enforcement and collect evidence for auditors.
 12. `Helm (Helmcheck)`: Build, lint, and audit Helm charts — scaffolding, values design, template patterns, dependency management, security hardening, and the full lint/validation pipeline.
+13. `MCP (Model Context Protocol)`: Build, review, and debug MCP servers and clients — tool and resource handlers, Zod/Pydantic schema validation, stdio/HTTP/SSE transports, protocol compliance, auth, and rate limiting.
+14. `Observability`: Instrument services with structured logging, Prometheus metrics, and OpenTelemetry tracing. Build Grafana dashboards, write alerting rules, run k6 load tests, and plan capacity.
+15. `Documentation`: Generate and validate inline docstrings (Google/NumPy/JSDoc), OpenAPI 3.1 specs, documentation sites (MkDocs, TypeDoc), and getting started guides.
 
 If a task spans multiple areas, decide which layer owns the source of truth and keep the other layers consumers of that state.
 
@@ -70,6 +73,9 @@ When asked to generate code, start from the thinnest useful slice that proves th
 - For product mindset, developer experience, friction audits, RFC/ADR, incident communication, post-mortems, and capacity planning, read [references/platform-mindset.md](references/platform-mindset.md).
 - For SOC 2 Trust Services Criteria controls in Terraform — IAM, encryption, audit logging, network security, change management, Checkov enforcement, and audit evidence — read [references/compliance.md](references/compliance.md).
 - For Helm chart scaffolding, template patterns, values design, lint pipeline, and GitOps integration, read [references/helm.md](references/helm.md).
+- For MCP server and client development — protocol, TypeScript/Python SDKs, schema validation, transports, security, and testing — read [references/mcp.md](references/mcp.md).
+- For observability instrumentation, Prometheus metrics, OpenTelemetry tracing, alerting rules, Grafana dashboards, load testing, and capacity planning, read [references/observability.md](references/observability.md).
+- For code documentation — Python docstrings, JSDoc, OpenAPI 3.1 specs, documentation sites, and developer guides — read [references/documentation.md](references/documentation.md).
 
 Load only the files needed for the current request.
 
@@ -86,3 +92,6 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:product` — product thinking, friction audits, DevEx, RFC/ADR, incident updates, post-mortems
 - `/platform-skills:compliance` — SOC 2 gap analysis, control implementation, evidence collection, and Checkov remediation for Terraform
 - `/platform-skills:helmcheck` — Helm chart scaffolding, structural review, and security audit with full lint/validation pipeline
+- `/platform-skills:mcp` — MCP server/client scaffolding, protocol review, and integration debugging
+- `/platform-skills:observability` — instrument services, build dashboards, write alerts, run load tests, plan capacity
+- `/platform-skills:document` — generate docstrings, OpenAPI specs, documentation sites, and getting started guides

--- a/tests/validate-helmcheck.sh
+++ b/tests/validate-helmcheck.sh
@@ -322,7 +322,7 @@ else
   fail "$HOW missing"
 fi
 
-for cmd in "helmcheck" "review" "terraform" "debug" "gitops" "compliance" "product" "mcp" "observability" "document"; do
+for cmd in "helmcheck" "review" "terraform" "debug" "gitops" "compliance" "product" "mcp" "observability" "document" "datadog" "dynatrace"; do
   if grep -q "platform-skills:$cmd" "$HOW"; then
     pass "$HOW references /platform-skills:$cmd"
   else

--- a/tests/validate-helmcheck.sh
+++ b/tests/validate-helmcheck.sh
@@ -322,7 +322,7 @@ else
   fail "$HOW missing"
 fi
 
-for cmd in "helmcheck" "review" "terraform" "debug" "gitops" "compliance" "product"; do
+for cmd in "helmcheck" "review" "terraform" "debug" "gitops" "compliance" "product" "mcp" "observability" "document"; do
   if grep -q "platform-skills:$cmd" "$HOW"; then
     pass "$HOW references /platform-skills:$cmd"
   else

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -47,6 +47,9 @@ REQUIRED_REFERENCES=(
   references/platform-mindset.md
   references/compliance.md
   references/helm.md
+  references/mcp.md
+  references/observability.md
+  references/documentation.md
 )
 
 for ref in "${REQUIRED_REFERENCES[@]}"; do
@@ -71,6 +74,9 @@ EXAMPLE_DOMAINS=(
   examples/github-actions
   examples/compliance
   examples/helm
+  examples/mcp
+  examples/observability
+  examples/documentation
 )
 
 for domain in "${EXAMPLE_DOMAINS[@]}"; do

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -50,6 +50,8 @@ REQUIRED_REFERENCES=(
   references/mcp.md
   references/observability.md
   references/documentation.md
+  references/datadog.md
+  references/dynatrace.md
 )
 
 for ref in "${REQUIRED_REFERENCES[@]}"; do
@@ -77,6 +79,8 @@ EXAMPLE_DOMAINS=(
   examples/mcp
   examples/observability
   examples/documentation
+  examples/datadog
+  examples/dynatrace
 )
 
 for domain in "${EXAMPLE_DOMAINS[@]}"; do


### PR DESCRIPTION
## Summary

Adds five new domains to platform-skills, bumping the version to 1.8.0.

- **Domain 13 — MCP**: Build, review, and debug MCP servers/clients (TypeScript + Python SDKs, Zod/Pydantic validation, stdio/HTTP/SSE transports, security). Includes a working TypeScript docs-server example.
- **Domain 14 — Observability**: Instrument services with Pino/structlog, Prometheus metrics, and OpenTelemetry tracing. Build Grafana dashboards, write Prometheus alerting rules, run k6 load tests, plan capacity. Includes production-ready RED alerting rules example.
- **Domain 15 — Documentation**: Generate Google/NumPy/JSDoc docstrings, OpenAPI 3.1 specs, MkDocs sites, and getting started guides. Includes a complete Orders API OpenAPI 3.1 spec.
- **Domain 16 — Datadog**: Agent Helm deployment, APM instrumentation, log management, monitors/dashboards/SLOs/synthetics as Terraform. Includes Terraform monitors and SLO example.
- **Domain 17 — Dynatrace**: OneAgent Kubernetes Operator with automatic injection, custom metrics (MINT), SLOs, anomaly detection, Davis AI, and Terraform provider. Includes production DynaKube CR.

Each domain includes:
- A reference guide under `references/`
- A slash command under `commands/`
- Working example assets under `examples/`

All wired into `SKILL.md`, `plugin.json`, `marketplace.json`, `HOW_IT_WORKS.md`, `CHANGELOG.md`, and both validation test suites (all checks pass).

## Test plan

- [x] `bash tests/validate-skill.sh` — all checks pass (70 checks)
- [x] `bash tests/validate-helmcheck.sh` — all checks pass (71 checks)
- [ ] CI validate workflow passes on PR
- [ ] After merge to main: bump `marketplace.json source.sha`, tag `v1.8.0`