### PR TITLE
feat(commit): add conventional commits domain — v1.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.8.0",
-      "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP server development, observability (Prometheus/OpenTelemetry/Grafana), code documentation (OpenAPI/docstrings), and SOC 2 compliance for Terraform. Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
+      "version": "1.9.0",
+      "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP server development, observability (Prometheus/OpenTelemetry/Grafana), code documentation (OpenAPI/docstrings), SOC 2 compliance for Terraform, Datadog, Dynatrace, and conventional commit message generation. Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
       "author": {
         "name": "Nitin Jain"
       },
@@ -68,7 +68,12 @@
         "datadog",
         "dynatrace",
         "apm",
-        "monitoring"
+        "monitoring",
+        "conventional-commits",
+        "commitlint",
+        "semantic-release",
+        "git",
+        "commit-message"
       ],
       "source": {
         "source": "url",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-skills",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP development, observability, code documentation, and SOC 2 compliance for Terraform.",
   "author": {
     "name": "Nitin Jain",
@@ -52,6 +52,7 @@
     "./commands/observability.md",
     "./commands/document.md",
     "./commands/datadog.md",
-    "./commands/dynatrace.md"
+    "./commands/dynatrace.md",
+    "./commands/commit.md"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-05-09
+
+### Added
+
+#### Conventional Commits Domain
+
+New Domain 18: `Conventional Commits` — analyze git diffs or staged changes, generate commit messages that explain WHY a change was made, intelligently stage files for atomic commits, and validate messages against the Conventional Commits 1.0.0 specification.
+
+- `references/conventional-commits.md` — message structure (subject/body/footer rules), type classification table with decision guidance, scope rules, breaking change patterns with examples, atomic commit strategy with `git add -p`, full examples for fix/feat/chore/breaking/revert, commitlint setup with scope allow-list, husky git hook configuration, GitHub Actions PR title lint workflow, semantic-release configuration with version bump rules, and a validation rules table
+- `/platform-skills:commit` (`commands/commit.md`) — four modes: `analyze` (classify type/scope/breaking from diff), `generate` (produce full conventional commit message), `stage` (intelligently group and stage files for atomic commits), `validate` (check an existing message against the spec)
+- `examples/conventional-commits/commitlint/` — commitlint config with scope allow-list, husky `commit-msg` hook, and `package.json` for installation
+
 #### Datadog Domain
 
 New Domain 16: `Datadog` — deploy and configure the Datadog Agent on Kubernetes, instrument services with APM and log correlation, and manage monitors, dashboards, SLOs, and synthetic tests as Terraform-managed resources.

--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -102,6 +102,7 @@ Slash commands are predefined workflows. Use them instead of writing a long prom
 | `/platform-skills:document` | Generate docstrings, OpenAPI specs, documentation sites, or getting started guides |
 | `/platform-skills:datadog` | Datadog Agent setup, APM instrumentation, monitors, dashboards, SLOs, and debugging |
 | `/platform-skills:dynatrace` | OneAgent deployment, instrumentation, anomaly detection, SLOs, and debugging |
+| `/platform-skills:commit` | Write a commit message, generate a commit, describe staged changes, or validate a message |
 
 Invoke a command by typing it at the start of your message:
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ platform-skills/
 - [x] v1.8.0 — Documentation: docstrings (Google/NumPy/JSDoc), OpenAPI 3.1 specs, doc sites (MkDocs/TypeDoc), developer guides
 - [x] v1.8.0 — Datadog: Agent Helm setup, APM instrumentation, log management, monitors/dashboards/SLOs as Terraform, incident investigation via Datadog MCP
 - [x] v1.8.0 — Dynatrace: OneAgent Kubernetes Operator, custom metrics/SLOs/dashboards via Terraform provider, Davis AI incident investigation via Dynatrace MCP
+- [x] v1.9.0 — Conventional Commits: analyze diffs, generate WHY-focused commit messages, intelligent file staging, commitlint/husky/semantic-release tooling
 
 **Planned**
 - [ ] GCP: landing zone, GKE, Workload Identity, and IAM patterns

--- a/commands/commit.md
+++ b/commands/commit.md
@@ -1,0 +1,102 @@
+---
+name: commit
+description: Analyze git diffs or staged changes and generate conventional commit messages that explain WHY a change was made. Supports auto-detecting type and scope, intelligent file staging, and interactive overrides. Use when asked to "write a commit message", "generate a commit", "describe my changes", "commit this", "summarize my diff", or "/commit".
+argument-hint: "[analyze|generate|stage|validate] [optional: type/scope override or description]"
+---
+
+Analyze changes and generate a Conventional Commits message explaining the motivation behind the change.
+
+## Mode: analyze
+
+Inspect staged or unstaged changes and classify the commit type and scope.
+
+Steps:
+1. Run `git diff --staged` — if empty, run `git diff HEAD` to capture unstaged changes
+2. Group changed files by logical concern (feature, fix, refactor, docs, config, tests, ci)
+3. Identify the type from the change pattern:
+   - `feat` — new capability or behavior added
+   - `fix` — corrects broken or incorrect behavior
+   - `refactor` — restructures code without changing behavior
+   - `perf` — measurably improves performance
+   - `test` — adds or corrects tests only
+   - `docs` — documentation only
+   - `chore` — build tooling, dependency updates, config changes with no production effect
+   - `ci` — changes to CI/CD pipelines or workflow files
+   - `revert` — reverting a prior commit
+4. Infer scope from the most specific common ancestor: module name, service name, directory, or filename
+5. Check for breaking changes: API removals, signature changes, config renames, behavior inversions — flag with `!` and add `BREAKING CHANGE:` footer
+6. Report: detected type, scope, whether breaking, and a one-line WHY summary
+
+Reference: `references/conventional-commits.md` → Type Classification, Scope Rules
+
+## Mode: generate
+
+Generate a complete conventional commit message from diff or description.
+
+Steps:
+1. Run `analyze` mode first to determine type, scope, and breaking status
+2. Write the subject line:
+   - Format: `<type>(<scope>): <imperative verb> <what and why>`
+   - Max 72 characters
+   - Imperative mood: "add", "fix", "remove", "update", "extract" — not "added", "fixes"
+   - Focus on the WHY, not just the what: "fix(auth): validate token expiry before redirect" not "fix(auth): update token check"
+3. Write the body (when the subject line is insufficient):
+   - Wrap at 72 characters
+   - Explain the problem being solved and the approach chosen
+   - One blank line between subject and body
+4. Write footers:
+   - `BREAKING CHANGE: <description>` for breaking changes (also add `!` to subject)
+   - `Fixes #<issue>` or `Closes #<issue>` for linked issues
+   - `Co-authored-by:` if applicable
+5. Output the full message in a code block ready to copy
+
+Message structure:
+```
+<type>(<scope>): <subject>
+
+<body — optional, explains motivation and approach>
+
+<footers — optional>
+```
+
+Reference: `references/conventional-commits.md` → Message Structure, Body and Footer Rules
+
+## Mode: stage
+
+Intelligently stage files for a logical, atomic commit.
+
+Steps:
+1. Run `git status` to list all modified, added, and deleted files
+2. Group files by logical change:
+   - Source files that implement a single feature or fix together
+   - Test files that cover those source changes
+   - Documentation that describes those changes
+   - Config or build changes that support those changes
+3. Separate unrelated changes into distinct groups — each group should be a separate commit
+4. If multiple logical groups exist: present the groupings and ask which to stage first
+5. Stage the chosen group: `git add <files>`
+6. Confirm staged set with `git diff --staged --stat`
+7. Run `generate` mode to produce the commit message for the staged group
+
+Reference: `references/conventional-commits.md` → Atomic Commits
+
+## Mode: validate
+
+Validate an existing commit message against the Conventional Commits specification.
+
+Steps:
+1. Accept the message as input (or read from `git log -1 --format=%B`)
+2. Check subject line:
+   - Has valid type from the allowed list
+   - Scope (if present) uses lowercase, no spaces
+   - `!` before `:` only when `BREAKING CHANGE` footer is also present
+   - Subject after `:` starts with lowercase, no period at end, ≤ 72 chars
+3. Check body (if present):
+   - Separated from subject by exactly one blank line
+   - Lines wrap at 72 characters
+4. Check footers (if present):
+   - `BREAKING CHANGE:` value is non-empty
+   - Issue references use correct format (`Fixes #N`, `Closes #N`)
+5. Report: PASS or list of violations with the exact rule broken and the corrected line
+
+Reference: `references/conventional-commits.md` → Validation Rules

--- a/examples/conventional-commits/README.md
+++ b/examples/conventional-commits/README.md
@@ -1,0 +1,30 @@
+Status: Stable
+
+# Conventional Commits Examples
+
+Configuration and workflow examples for enforcing Conventional Commits.
+
+## Examples
+
+| Example | Type | Description |
+|---------|------|-------------|
+| [commitlint/](commitlint/) | Config | commitlint + husky setup with scope allow-list |
+
+## Usage
+
+```bash
+# Install commitlint and husky
+cd commitlint
+npm install
+
+# Test a commit message
+echo "feat(auth): add OIDC login support" | npx commitlint
+
+# Test a bad message
+echo "updated stuff" | npx commitlint
+```
+
+## See Also
+
+- [references/conventional-commits.md](../../references/conventional-commits.md) — spec, type classification, breaking changes, tooling, validation
+- `/platform-skills:commit` — analyze diff, generate message, stage files, validate message

--- a/examples/conventional-commits/commitlint/.husky/commit-msg
+++ b/examples/conventional-commits/commitlint/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit "$1"

--- a/examples/conventional-commits/commitlint/commitlint.config.js
+++ b/examples/conventional-commits/commitlint/commitlint.config.js
@@ -1,0 +1,34 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    // Restrict scopes to known modules — add your own service/module names
+    "scope-enum": [
+      2,
+      "always",
+      [
+        "api",
+        "auth",
+        "billing",
+        "ci",
+        "config",
+        "db",
+        "deps",
+        "docs",
+        "helm",
+        "infra",
+        "orders",
+        "terraform",
+        "ui",
+      ],
+    ],
+    "subject-max-length": [2, "always", 72],
+    "body-max-line-length": [2, "always", 72],
+    "subject-case": [2, "always", "lower-case"],
+    "subject-full-stop": [2, "never", "."],
+    "type-enum": [
+      2,
+      "always",
+      ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test"],
+    ],
+  },
+};

--- a/examples/conventional-commits/commitlint/package.json
+++ b/examples/conventional-commits/commitlint/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "commitlint-config",
+  "version": "1.0.0",
+  "description": "commitlint + husky setup for Conventional Commits enforcement",
+  "type": "module",
+  "scripts": {
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^19.0.0",
+    "@commitlint/config-conventional": "^19.0.0",
+    "husky": "^9.0.0"
+  }
+}

--- a/references/conventional-commits.md
+++ b/references/conventional-commits.md
@@ -1,0 +1,313 @@
+# Conventional Commits Reference
+
+Covers the Conventional Commits 1.0.0 specification, type classification, scope rules, breaking changes, message structure, atomic commit strategy, tooling, and validation.
+
+---
+
+## Message Structure
+
+```
+<type>[(<scope>)][!]: <subject>
+
+[body]
+
+[footers]
+```
+
+### Subject Line Rules
+
+- **type** — required, lowercase, from the allowed list
+- **scope** — optional, lowercase, no spaces, in parentheses: `fix(auth):`, `feat(api):`, `chore(deps):`
+- **`!`** — marks a breaking change; requires a `BREAKING CHANGE:` footer
+- **subject** — imperative mood, lowercase start, no trailing period, ≤ 72 characters total for the line
+- Focus on **why**, not just what: `fix(auth): reject expired tokens before redirect` not `fix(auth): change token check`
+
+### Body Rules
+
+- Separated from subject by exactly one blank line
+- Wrap lines at 72 characters
+- Explain the **motivation** (what problem this solves) and the **approach** (why this solution over alternatives)
+- Do not repeat the subject — add context that doesn't fit in 72 characters
+
+### Footer Rules
+
+- One blank line between body (or subject, if no body) and footers
+- `BREAKING CHANGE: <description>` — mandatory when `!` is used; describes what breaks and how to migrate
+- `Fixes #<N>` or `Closes #<N>` — closes GitHub/GitLab issues on merge
+- `Co-authored-by: Name <email>` — credits additional authors
+- Multiple footers allowed, one per line
+
+---
+
+## Type Classification
+
+| Type | When to use | Example |
+|------|-------------|---------|
+| `feat` | New user-facing capability or behavior | `feat(orders): add bulk cancel endpoint` |
+| `fix` | Corrects broken or incorrect behavior | `fix(auth): validate token expiry before redirect` |
+| `refactor` | Restructures code without changing behavior | `refactor(payment): extract retry logic to helper` |
+| `perf` | Measurably improves performance | `perf(db): replace N+1 query with single join` |
+| `test` | Adds or corrects tests only | `test(orders): add edge cases for empty cart` |
+| `docs` | Documentation only | `docs(api): document rate limit headers` |
+| `chore` | Build tooling, dependency bumps, config with no production effect | `chore(deps): bump axios to 1.7.0` |
+| `ci` | CI/CD pipeline or workflow changes | `ci(release): pin actions to SHA` |
+| `revert` | Reverts a prior commit | `revert: feat(orders): add bulk cancel endpoint` |
+| `style` | Formatting only (whitespace, semicolons) — no logic change | `style(api): apply prettier to routes` |
+| `build` | Changes to build system or external dependencies | `build(webpack): enable tree-shaking for lodash` |
+
+### Choosing Between Types
+
+- `feat` vs `refactor` — does the user-visible API or behavior change? Yes → `feat`. No → `refactor`
+- `fix` vs `refactor` — was something broken before? Yes → `fix`. No → `refactor`
+- `chore` vs `ci` — does it affect the CI pipeline definition? Yes → `ci`. No → `chore`
+- `perf` vs `refactor` — is there a measurable latency/throughput improvement? Yes → `perf`. No → `refactor`
+
+---
+
+## Scope Rules
+
+- Use the most specific common ancestor of all changed files
+- Good scopes: service name (`auth`, `orders`), module (`db`, `cache`), layer (`api`, `ui`), tool (`deps`, `helm`, `terraform`)
+- Omit scope when changes span too many areas to name one meaningfully
+- Lowercase only, no spaces, no slashes: `fix(auth-middleware):` not `fix(Auth/Middleware):`
+- Keep scopes consistent across the team — add a `commitlint` scope allow-list to enforce
+
+---
+
+## Breaking Changes
+
+A breaking change is any change that requires consumers to update their code, configuration, or deployment:
+
+- Removing or renaming a public API, endpoint, or config key
+- Changing the type or shape of a response/input
+- Altering default behavior that existing users depend on
+- Increasing the minimum required version of a dependency
+
+```
+feat(api)!: require Authorization header on all endpoints
+
+Previously unauthenticated routes returned 200. This change returns 401
+for all requests without a valid Bearer token to enforce zero-trust.
+
+BREAKING CHANGE: Callers must include `Authorization: Bearer <token>` on
+all requests. Update SDKs to v2.x which handle this automatically.
+Closes #412
+```
+
+---
+
+## Atomic Commits
+
+Each commit should represent a single logical change that can be understood, reviewed, and reverted independently.
+
+**Atomic — one concern per commit:**
+```
+feat(orders): add idempotency key validation
+test(orders): cover duplicate idempotency key rejection
+```
+
+**Non-atomic — avoid:**
+```
+feat: add idempotency, fix auth bug, update README, bump deps
+```
+
+### How to split staged changes
+
+```bash
+# Stage specific files
+git add src/orders/validator.ts src/orders/validator.test.ts
+
+# Stage specific hunks interactively
+git add -p src/orders/service.ts
+
+# Check what will be committed
+git diff --staged --stat
+```
+
+---
+
+## Full Message Examples
+
+### Simple fix
+
+```
+fix(cache): return 404 when key is missing instead of empty string
+
+The cache client was returning an empty string for missing keys, causing
+callers to silently treat cache misses as valid empty values. Returns null
+now so callers can distinguish a miss from a cached empty value.
+
+Fixes #87
+```
+
+### New feature with scope
+
+```
+feat(billing): add proration when upgrading mid-cycle
+
+Calculates remaining days in the billing period and credits the unused
+portion against the new plan price. Previously users were charged the
+full new price regardless of when they upgraded.
+
+Closes #201
+```
+
+### Breaking change
+
+```
+feat(config)!: rename DATABASE_URL to DB_CONNECTION_STRING
+
+Aligns with the internal naming convention used across all other services.
+The old variable name is no longer read.
+
+BREAKING CHANGE: Rename DATABASE_URL to DB_CONNECTION_STRING in all
+environment files and secrets managers before deploying.
+```
+
+### Chore (no body needed)
+
+```
+chore(deps): bump terraform-aws-modules/eks to 20.8.1
+```
+
+### CI change
+
+```
+ci(release): pin github/codeql-action to SHA
+
+Floating tag @v3 caused an unexpected version jump during a release.
+SHA pinning prevents supply-chain risk from mutable tags.
+```
+
+### Revert
+
+```
+revert: feat(orders): add bulk cancel endpoint
+
+Reverts commit a3f8c2d. The bulk cancel endpoint caused a race condition
+under high concurrency (see #318). Reverting while a proper fix is prepared.
+```
+
+---
+
+## Tooling
+
+### commitlint
+
+Enforces Conventional Commits in CI and via git hooks.
+
+```bash
+npm install --save-dev @commitlint/cli @commitlint/config-conventional
+```
+
+```js
+// commitlint.config.js
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "scope-enum": [2, "always", ["auth", "api", "orders", "billing", "deps", "ci", "docs"]],
+    "subject-max-length": [2, "always", 72],
+    "body-max-line-length": [2, "always", 72],
+  },
+};
+```
+
+### husky (git hook)
+
+```bash
+npm install --save-dev husky
+npx husky init
+echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
+```
+
+### GitHub Actions — validate PR title
+
+```yaml
+name: Lint PR title
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            perf
+            test
+            docs
+            chore
+            ci
+            revert
+            style
+            build
+```
+
+### semantic-release
+
+Automates versioning and changelog generation from commit history:
+
+```bash
+npm install --save-dev semantic-release \
+  @semantic-release/commit-analyzer \
+  @semantic-release/release-notes-generator \
+  @semantic-release/changelog \
+  @semantic-release/github
+```
+
+```json
+// .releaserc.json
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", {"changelogFile": "CHANGELOG.md"}],
+    "@semantic-release/github"
+  ]
+}
+```
+
+Version bump rules:
+- `feat` → minor (`1.x.0`)
+- `fix`, `perf`, `refactor` → patch (`1.0.x`)
+- `BREAKING CHANGE` → major (`x.0.0`)
+- `chore`, `docs`, `test`, `ci` → no release
+
+---
+
+## Validation Rules
+
+A commit message is valid when all of the following pass:
+
+| Rule | Check |
+|------|-------|
+| Type present | Subject starts with a known type |
+| Type lowercase | No uppercase in type |
+| Scope lowercase | Scope (if present) contains only `[a-z0-9-]` |
+| Subject case | First character after `: ` is lowercase |
+| Subject length | Full subject line ≤ 72 characters |
+| No trailing period | Subject does not end with `.` |
+| Body separator | Exactly one blank line between subject and body |
+| Body wrap | No body line exceeds 72 characters |
+| Breaking footer | `!` in subject → `BREAKING CHANGE:` footer is present and non-empty |
+| Footer format | Footers follow `token: value` or `token #value` format |
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| commitlint rejects message | Type not in allow-list | Check `commitlint.config.js` `scope-enum` or `type-enum` |
+| semantic-release creates no release | All commits are `chore`/`docs`/`test` | Use `feat` or `fix` for releasable changes |
+| PR title lint fails | Title doesn't start with a valid type | Rename PR title to `type(scope): subject` format |
+| `!` present but no `BREAKING CHANGE` footer | Footer missing | Add `BREAKING CHANGE: <description>` as footer |
+| Scope rejected by commitlint | Scope not in allowed list | Add scope to `scope-enum` in `commitlint.config.js` |

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -28,6 +28,7 @@ Match the task to the right layer:
 15. `Documentation`: Generate and validate inline docstrings (Google/NumPy/JSDoc), OpenAPI 3.1 specs, documentation sites (MkDocs, TypeDoc), and getting started guides.
 16. `Datadog`: Deploy and configure the Datadog Agent on Kubernetes, instrument services with APM and log correlation, write monitors, dashboards, SLOs, and synthetic tests — all as Terraform-managed resources.
 17. `Dynatrace`: Deploy OneAgent via the Kubernetes Operator with automatic injection, configure anomaly detection, ingest custom metrics, define SLOs, and manage dashboards and alerting profiles with the Dynatrace Terraform provider.
+18. `Conventional Commits`: Analyze git diffs, generate commit messages that explain WHY a change was made, intelligently stage files for atomic commits, and validate messages against the Conventional Commits specification.
 
 If a task spans multiple areas, decide which layer owns the source of truth and keep the other layers consumers of that state.
 
@@ -80,6 +81,7 @@ When asked to generate code, start from the thinnest useful slice that proves th
 - For code documentation — Python docstrings, JSDoc, OpenAPI 3.1 specs, documentation sites, and developer guides — read [references/documentation.md](references/documentation.md).
 - For Datadog Agent setup, APM, log management, monitors, dashboards, SLOs, and synthetic tests — read [references/datadog.md](references/datadog.md).
 - For Dynatrace OneAgent Operator, auto-instrumentation, custom metrics, SLOs, anomaly detection, and Terraform provider — read [references/dynatrace.md](references/dynatrace.md).
+- For Conventional Commits — type classification, scope rules, breaking changes, message structure, atomic commits, commitlint, husky, semantic-release, and validation rules — read [references/conventional-commits.md](references/conventional-commits.md).
 
 Load only the files needed for the current request.
 
@@ -101,3 +103,4 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:document` — generate docstrings, OpenAPI specs, documentation sites, and getting started guides
 - `/platform-skills:datadog` — Datadog Agent setup, APM instrumentation, monitors, dashboards, SLOs, and debugging
 - `/platform-skills:dynatrace` — OneAgent deployment, instrumentation, anomaly detection, SLOs, and debugging
+- `/platform-skills:commit` — analyze diff, generate conventional commit message, stage files atomically, validate message

--- a/tests/validate-helmcheck.sh
+++ b/tests/validate-helmcheck.sh
@@ -322,7 +322,7 @@ else
   fail "$HOW missing"
 fi
 
-for cmd in "helmcheck" "review" "terraform" "debug" "gitops" "compliance" "product" "mcp" "observability" "document" "datadog" "dynatrace"; do
+for cmd in "helmcheck" "review" "terraform" "debug" "gitops" "compliance" "product" "mcp" "observability" "document" "datadog" "dynatrace" "commit"; do
   if grep -q "platform-skills:$cmd" "$HOW"; then
     pass "$HOW references /platform-skills:$cmd"
   else

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -52,6 +52,7 @@ REQUIRED_REFERENCES=(
   references/documentation.md
   references/datadog.md
   references/dynatrace.md
+  references/conventional-commits.md
 )
 
 for ref in "${REQUIRED_REFERENCES[@]}"; do
@@ -81,6 +82,7 @@ EXAMPLE_DOMAINS=(
   examples/documentation
   examples/datadog
   examples/dynatrace
+  examples/conventional-commits
 )
 
 for domain in "${EXAMPLE_DOMAINS[@]}"; do


### PR DESCRIPTION
## Summary

- Adds Domain 18: **Conventional Commits** — analyze git diffs, generate WHY-focused commit messages, stage files atomically, and validate against the Conventional Commits 1.0.0 spec
- New `/platform-skills:commit` slash command with four modes: `analyze`, `generate`, `stage`, `validate`
- Full reference guide covering type classification, scope rules, breaking changes, commitlint/husky/semantic-release tooling, and validation rules
- Working example: `examples/conventional-commits/commitlint/` with scope allow-list config, husky hook, and package.json
- Version bumped to `1.9.0` across `plugin.json` and `marketplace.json`
- Wired into `SKILL.md`, `HOW_IT_WORKS.md`, test validators, CHANGELOG, and README roadmap

## Test plan

- [ ] CI validate workflow passes (structure, YAML, Terraform, security checks)
- [ ] `tests/validate-skill.sh` passes: `references/conventional-commits.md` and `examples/conventional-commits` in required lists
- [ ] `tests/validate-helmcheck.sh` passes: `commit` present in HOW_IT_WORKS completeness check
- [ ] `plugin.json` version is `1.9.0`
- [ ] `marketplace.json` version is `1.9.0`