### PR TITLE
feat(opa): add OPA/Conftest domain — v1.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP server development, observability (Prometheus/OpenTelemetry/Grafana), code documentation (OpenAPI/docstrings), SOC 2 compliance for Terraform, Datadog, Dynatrace, and conventional commit message generation. Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
       "author": {
         "name": "Nitin Jain"
@@ -73,7 +73,13 @@
         "commitlint",
         "semantic-release",
         "git",
-        "commit-message"
+        "commit-message",
+        "opa",
+        "open-policy-agent",
+        "rego",
+        "conftest",
+        "regal",
+        "policy-as-code"
       ],
       "source": {
         "source": "url",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-skills",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP development, observability, code documentation, and SOC 2 compliance for Terraform.",
   "author": {
     "name": "Nitin Jain",
@@ -53,6 +53,7 @@
     "./commands/document.md",
     "./commands/datadog.md",
     "./commands/dynatrace.md",
-    "./commands/commit.md"
+    "./commands/commit.md",
+    "./commands/opa.md"
   ]
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,572 @@
+# Platform Engineering Instructions for GitHub Copilot
+
+You are assisting with platform engineering tasks. Apply these patterns when generating or reviewing code across Kubernetes, OpenShift, Argo CD, Flux CD, AWS, Azure, Terraform, and GitHub Actions.
+
+## Core Principles
+
+- **Production-first**: Always include blast radius, rollback plan, and validation steps
+- **Root-cause over symptoms**: Explain why a problem occurs, not just how to fix it
+- **Least privilege by default**: Never suggest wildcard IAM actions or resources
+- **GitOps pull model**: Cluster state lives in Git, not in pipeline scripts
+- **Explicit over implicit**: Make security choices, environment differences, and promotion flows visible
+
+## Layer Ownership
+
+When generating infrastructure code, respect these boundaries:
+
+| Layer | Owns | Does NOT Own |
+|-------|------|--------------|
+| **Terraform** | Cloud primitives, cluster bootstrap, IAM, networking, secrets backends | In-cluster workloads, Helm releases |
+| **Flux / Argo CD** | In-cluster state, Helm releases, workload promotion | Cloud resources, IAM roles |
+| **GitHub Actions** | CI checks, plan gates, artifact publish, promotion triggers | Long-lived environment state |
+| **Kubernetes** | Workload specs, RBAC, network policy, resource limits | Cloud account structure |
+
+## Kubernetes & OpenShift
+
+Always generate workloads with:
+
+```yaml
+# Required for all Deployments
+resources:
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+  limits:
+    memory: "256Mi"        # Always set memory limit
+    # cpu limit intentionally omitted - causes throttling
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 5
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+```
+
+For OpenShift: never set `runAsUser` to a specific UID — use `runAsNonRoot: true` only.
+
+## Flux CD
+
+When generating Flux resources:
+
+```yaml
+# HelmRelease - always pin chart version
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+spec:
+  interval: 10m
+  chart:
+    spec:
+      version: "1.2.3"   # Never use "*" or ranges
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+      remediateLastFailure: true
+```
+
+Troubleshooting order: source → artifact → reconciliation → chart rendering → runtime
+
+## Argo CD
+
+```yaml
+# Application - always set project, never use default
+spec:
+  project: platform          # Never leave as "default"
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+```
+
+## AWS IAM
+
+Never generate wildcard policies. Always scope to specific actions and resources:
+
+```json
+// ❌ Never generate this
+{ "Action": "s3:*", "Resource": "*" }
+
+// ✅ Always generate this
+{
+  "Action": ["s3:GetObject", "s3:ListBucket"],
+  "Resource": [
+    "arn:aws:s3:::my-bucket",
+    "arn:aws:s3:::my-bucket/*"
+  ]
+}
+```
+
+Always prefer IRSA over static credentials for EKS pods:
+
+```hcl
+# IAM role for service accounts
+resource "aws_iam_role" "pod" {
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = aws_iam_openid_connect_provider.cluster.arn }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "${local.oidc_issuer}:sub" = "system:serviceaccount:${var.namespace}:${var.service_account}"
+        }
+      }
+    }]
+  })
+}
+```
+
+## Azure
+
+Prefer managed identities over service principals. Always use workload identity for AKS pods:
+
+```yaml
+# Pod spec for workload identity
+metadata:
+  labels:
+    azure.workload.identity/use: "true"
+spec:
+  serviceAccountName: my-app-sa  # Annotated with client-id
+```
+
+## Terraform
+
+Module structure:
+
+```
+module/
+├── main.tf        # Resources
+├── variables.tf   # Inputs with validation blocks
+├── outputs.tf     # Outputs
+├── versions.tf    # Required providers with version constraints
+└── README.md      # Usage examples
+```
+
+Always include validation in variables:
+
+```hcl
+variable "environment" {
+  type = string
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "environment must be dev, staging, or production"
+  }
+}
+```
+
+Always enable KMS encryption and CloudWatch logging for EKS clusters.
+
+## GitHub Actions
+
+Always pin actions to SHA, never to mutable tags:
+
+```yaml
+# ❌ Never generate this
+- uses: actions/checkout@v4
+
+# ✅ Always generate this
+- uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+```
+
+Always use minimal permissions:
+
+```yaml
+permissions:
+  contents: read       # Only what is needed
+  id-token: write      # Only if OIDC is required
+```
+
+Never use `pull_request_target` with code checkout from forks.
+
+## Troubleshooting Response Structure
+
+When asked to debug or troubleshoot, always respond with:
+
+1. **Symptom** - What is observable
+2. **Evidence to collect** - Exact commands to run
+3. **Root cause** - Why this happens
+4. **Fix** - Specific change with justification
+5. **Validation** - How to verify it worked
+6. **Prevention** - How to avoid in future
+7. **Rollback** - How to safely undo
+
+## SOC 2 Compliance (Terraform)
+
+When generating Terraform resources that handle data, always apply SOC 2-relevant controls:
+
+**Encryption at rest — always include:**
+```hcl
+# S3
+resource "aws_s3_bucket_server_side_encryption_configuration" "..." {
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.s3.arn
+    }
+  }
+}
+
+# RDS
+resource "aws_db_instance" "..." {
+  storage_encrypted = true
+  kms_key_id        = aws_kms_key.rds.arn
+}
+
+# DynamoDB
+resource "aws_dynamodb_table" "..." {
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.dynamodb.arn
+  }
+  point_in_time_recovery { enabled = true }
+}
+```
+
+**ECR — always set immutable tags and scan on push:**
+```hcl
+resource "aws_ecr_repository" "..." {
+  image_tag_mutability = "IMMUTABLE"
+  encryption_configuration { encryption_type = "KMS" }
+  image_scanning_configuration { scan_on_push = true }
+}
+```
+
+**Never generate:**
+- `publicly_accessible = true` on RDS, Redshift, or OpenSearch
+- `encrypted = false` on any storage resource
+- `skip_final_snapshot = true` on production databases
+- `deletion_protection = false` on production databases
+- `is_multi_region_trail = false` on CloudTrail
+- `enable_log_file_validation = false` on CloudTrail
+
+**KMS — always enable rotation:**
+```hcl
+resource "aws_kms_key" "..." {
+  enable_key_rotation = true   # SOC 2 CC6.7
+  deletion_window_in_days = 30
+}
+```
+
+**Checkov:** Always ensure generated Terraform passes `CKV_AWS_7` (KMS rotation), `CKV_AWS_19` (S3 encryption), `CKV_AWS_16` (RDS encryption), and `CKV_AWS_17` (RDS not public).
+
+**Extended data services — always include these attributes:**
+
+```hcl
+# ElastiCache (CC6.7)
+resource "aws_elasticache_replication_group" "..." {
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+  kms_key_id                 = aws_kms_key.elasticache.arn
+}
+
+# OpenSearch (CC6.7)
+resource "aws_opensearch_domain" "..." {
+  encrypt_at_rest          { enabled = true; kms_key_id = aws_kms_key.opensearch.arn }
+  node_to_node_encryption  { enabled = true }
+  domain_endpoint_options  { enforce_https = true; tls_security_policy = "Policy-Min-TLS-1-2-2019-07" }
+}
+
+# Kinesis (CC6.7)
+resource "aws_kinesis_stream" "..." {
+  encryption_type = "KMS"
+  kms_key_id      = aws_kms_key.kinesis.arn
+}
+
+# EFS (CC6.7)
+resource "aws_efs_file_system" "..." {
+  encrypted  = true
+  kms_key_id = aws_kms_key.efs.arn
+}
+
+# Redshift (CC6.7)
+resource "aws_redshift_cluster" "..." {
+  encrypted           = true
+  kms_key_id          = aws_kms_key.redshift.arn
+  publicly_accessible = false
+  enhanced_vpc_routing = true
+}
+# Always pair with a parameter group enforcing SSL
+resource "aws_redshift_parameter_group" "..." {
+  parameter { name = "require_ssl"; value = "true" }
+}
+```
+
+**Network — always include (CC6.6):**
+
+```hcl
+# VPC flow logs on every production VPC
+resource "aws_flow_log" "..." {
+  vpc_id               = aws_vpc.main.id
+  traffic_type         = "ALL"
+  log_destination_type = "s3"
+  log_destination      = aws_s3_bucket.flow_logs.arn
+}
+
+# WAF on every public-facing ALB or CloudFront distribution
+resource "aws_wafv2_web_acl_association" "..." {
+  resource_arn = aws_lb.main.arn
+  web_acl_arn  = aws_wafv2_web_acl.main.arn
+}
+```
+
+**Detection — always enable (CC7.1):**
+
+```hcl
+resource "aws_guardduty_detector" "..." {
+  enable = true
+  datasources {
+    s3_logs           { enable = true }
+    kubernetes { audit_logs { enable = true } }
+  }
+}
+```
+
+**Audit logging — always include (CC7.2):**
+
+```hcl
+resource "aws_cloudtrail" "..." {
+  is_multi_region_trail      = true   # Never false
+  enable_log_file_validation = true   # Never false
+  kms_key_id                 = aws_kms_key.cloudtrail.arn
+  include_global_service_events = true
+}
+```
+
+**Incident response — SNS topics carrying security events must be encrypted (CC7.3):**
+
+```hcl
+resource "aws_sns_topic" "security_alerts" {
+  kms_master_key_id = aws_kms_key.sns.arn
+}
+```
+
+**Backup — always include on production data stores (A1.2/A1.3):**
+
+```hcl
+# RDS: minimum 35-day retention, deletion protection
+resource "aws_db_instance" "..." {
+  backup_retention_period = 35
+  deletion_protection     = true
+  skip_final_snapshot     = false
+  multi_az                = true
+}
+
+# DynamoDB: always enable PITR
+resource "aws_dynamodb_table" "..." {
+  point_in_time_recovery { enabled = true }
+}
+```
+
+**State — always use encrypted remote backend with locking (CC8.1):**
+
+```hcl
+terraform {
+  backend "s3" {
+    encrypt        = true
+    kms_key_id     = "arn:aws:kms:..."
+    dynamodb_table = "terraform-state-lock"
+  }
+}
+```
+
+**Never generate (extended):**
+- `at_rest_encryption_enabled = false` on ElastiCache
+- `transit_encryption_enabled = false` on ElastiCache
+- `node_to_node_encryption { enabled = false }` on OpenSearch
+- `enforce_https = false` on OpenSearch
+- `encryption_type = "NONE"` on Kinesis
+- `encrypted = false` on EFS
+- `enable = false` on GuardDuty
+- `is_multi_region_trail = false` on CloudTrail
+- `enable_log_file_validation = false` on CloudTrail
+- Image references ending in `:latest` in any resource
+
+## Helm Charts
+
+When generating or reviewing Helm charts, enforce in order:
+`helm lint --strict` → `helm template --debug` → `kubeconform -strict -summary` → `checkov` → `helm test`
+
+```yaml
+# values.yaml — always include schema-validated defaults
+# Reference: references/helm.md
+```
+
+Never use `helm upgrade --set` to pass secrets — use existing secrets references.
+
+## MCP Servers
+
+When scaffolding MCP servers:
+- Use `@modelcontextprotocol/sdk` for TypeScript, `mcp` (FastMCP) for Python
+- Validate all tool inputs with Zod (TypeScript) or Pydantic (Python)
+- SSE transport: create transport inside `/sse` handler, use session map for `/message` routing
+- Always set `BREAKING CHANGE:` footer when `!` is used in commit subject
+
+```typescript
+// ✅ Correct SSE pattern
+app.get("/sse", async (req, res) => {
+  const transport = new SSEServerTransport("/message", res);
+  transports.set(transport.sessionId, transport);
+  await server.connect(transport);
+});
+```
+
+## Observability
+
+When instrumenting services:
+- Structured logs: include `trace_id`, `span_id`, `service`, `env` on every log line
+- Prometheus metrics: expose `/metrics`, use `prom-client` (Node.js) or `prometheus-client` (Python)
+- OpenTelemetry: initialize SDK before any other import; export to OTLP endpoint
+- Alert on RED method: request rate, error rate, duration (p99)
+
+```typescript
+// ✅ OTEL initialization — must be first import
+import { NodeSDK } from "@opentelemetry/sdk-node";
+```
+
+## Datadog
+
+When generating Datadog configuration:
+- Never use `--set datadog.apiKey` or `apiKey:` in values files — use `apiKeyExistingSecret`
+- Always apply Unified Service Tagging: `DD_ENV`, `DD_SERVICE`, `DD_VERSION` on all pods
+- Enable `logInjection: true` in tracer init to correlate logs and traces
+
+```yaml
+# ✅ Secure Helm values
+datadog:
+  apiKeyExistingSecret: "datadog-secret"
+```
+
+```bash
+# ❌ Never
+helm upgrade --install datadog datadog/datadog --set datadog.apiKey="${DD_API_KEY}"
+```
+
+## Dynatrace
+
+When generating Dynatrace configuration:
+- `DynaKube.spec.apiUrl` uses the classic URL (`live.dynatrace.com`) — correct for the Operator
+- `DT_ENVIRONMENT` (MCP server) uses the Platform URL (`apps.dynatrace.com`) — different from apiUrl
+- Store `apiToken` and `dataIngestToken` in a Kubernetes Secret, never in plain Helm values
+
+```yaml
+# ✅ Correct apiUrl for DynaKube CR
+apiUrl: "https://ENVIRONMENT_ID.live.dynatrace.com/api"
+```
+
+## OPA / Conftest (Rego)
+
+When generating Rego policies:
+- Always add `import rego.v1` — required for modern syntax
+- Always add a `# METADATA` block with `title`, `description`, `entrypoint: true`
+- Rules must be named `deny`, `warn`, or `violation` — other names are silently ignored by Conftest
+- Use set comprehensions: `deny contains msg if { ... msg := "..." }` not boolean rules
+- Use `some` for iteration over input objects
+- Run pipeline in order: `conftest fmt --check` → `regal lint` → `conftest verify` → `conftest test`
+
+```rego
+# ✅ Correct structure
+# METADATA
+# title: IAM least privilege
+# entrypoint: true
+package terraform.iam
+
+import rego.v1
+
+deny contains msg if {
+    some name
+    policy := input.resource.aws_iam_policy[name]
+    some statement in policy.policy.Statement
+    statement.Action == "*"
+    msg := sprintf("IAM policy '%s' must not use wildcard Action", [name])
+}
+```
+
+Never generate:
+- Rules not named `deny`, `warn`, or `violation`
+- Policies without `import rego.v1`
+- Boolean deny rules without a `msg` string
+
+## Conventional Commits
+
+Always generate commit messages following the Conventional Commits 1.0.0 specification:
+
+```
+<type>(<scope>): <imperative subject explaining WHY>
+
+<body — optional, explains motivation and approach>
+
+<footers — optional>
+```
+
+**Type selection:**
+- `feat` — new user-facing capability
+- `fix` — corrects broken behavior
+- `refactor` — restructures without behavior change
+- `chore` — deps, build tooling, no production effect
+- `ci` — CI/CD pipeline changes
+- `docs` — documentation only
+- `test` — tests only
+- `perf` — measurable performance improvement
+
+**Rules:**
+- Subject line ≤ 72 characters, imperative mood, lowercase start, no trailing period
+- Use `!` and `BREAKING CHANGE:` footer for breaking changes
+- Focus on WHY, not just what: `fix(auth): reject expired tokens before redirect` not `fix(auth): update token check`
+
+```
+# ✅ Good
+feat(orders): add idempotency key to prevent duplicate charges
+
+# ❌ Bad
+updated orders service
+```
+
+Never generate:
+- Commit messages without a type prefix
+- `Co-authored-by: Claude` or any AI attribution in commit messages
+- Subject lines over 72 characters
+
+## Reference Files
+
+For deeper patterns, reference these files in this repository:
+
+- `references/kubernetes.md` — Cluster baselines, RBAC, network policy
+- `references/openshift.md` — Routes, SCCs, operators
+- `references/flux.md` — GitOps reconciliation, troubleshooting
+- `references/argocd.md` — App design, ApplicationSets
+- `references/aws.md` — IAM, EKS, account model
+- `references/azure.md` — AKS, workload identity, RBAC
+- `references/terraform.md` — Module design, state, testing
+- `references/github-actions.md` — Workflow security, OIDC
+- `references/platform-operating-model.md` — Cross-cutting architecture
+- `references/compliance.md` — SOC 2 controls in Terraform, Checkov rules, evidence commands
+- `references/helm.md` — Helm chart scaffolding, template patterns, lint pipeline
+- `references/mcp.md` — MCP protocol, TypeScript/Python SDKs, transports, security
+- `references/observability.md` — Logging, metrics, tracing, alerting, dashboards, load testing
+- `references/documentation.md` — Docstrings, OpenAPI 3.1, doc sites, developer guides
+- `references/datadog.md` — Agent setup, APM, log management, monitors, SLOs
+- `references/dynatrace.md` — Operator, instrumentation, metrics, SLOs, Terraform provider
+- `references/conventional-commits.md` — Commit message spec, types, scopes, tooling, validation
+- `references/opa.md` — Rego v1 syntax, rule types, input shapes, testing, Conftest CLI, Regal, GitHub Actions
+- `examples/` — Working, production-ready code examples

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -570,3 +570,28 @@ For deeper patterns, reference these files in this repository:
 - `references/conventional-commits.md` — Commit message spec, types, scopes, tooling, validation
 - `references/opa.md` — Rego v1 syntax, rule types, input shapes, testing, Conftest CLI, Regal, GitHub Actions
 - `examples/` — Working, production-ready code examples
+
+---
+
+## Skill Quick Reference
+
+Use these slash commands in Claude Code for repeatable workflows:
+
+| Command | When to use | Examples directory |
+|---------|------------|-------------------|
+| `/platform-skills:debug` | Structured diagnosis for any platform symptom | — |
+| `/platform-skills:review` | Production-readiness check on any manifest, Terraform, or workflow | — |
+| `/platform-skills:terraform` | Full fmt/validate/tflint/security pipeline + blast radius | `examples/terraform/` |
+| `/platform-skills:gitops` | Flux CD or Argo CD not reconciling | `examples/flux/`, `examples/argocd/` |
+| `/platform-skills:helmcheck` | Create, review, or security-audit a Helm chart | `examples/helm/` |
+| `/platform-skills:linkerd` | mTLS, injection, traffic policy, multi-cluster | — |
+| `/platform-skills:linux` | DNS, load balancer, VPC connectivity, kernel issue | — |
+| `/platform-skills:compliance` | SOC 2 gap analysis, control implementation, Checkov remediation | `examples/compliance/` |
+| `/platform-skills:product` | RFC/ADR, DevEx audit, incident communication, post-mortem | — |
+| `/platform-skills:mcp` | Scaffold, review, or debug an MCP server | `examples/mcp/` |
+| `/platform-skills:observability` | Instrument services, alerts, dashboards, load tests, capacity | `examples/observability/` |
+| `/platform-skills:document` | Generate docstrings, OpenAPI specs, doc sites | `examples/documentation/` |
+| `/platform-skills:datadog` | Agent setup, APM, monitors, SLOs, incident investigation | `examples/datadog/` |
+| `/platform-skills:dynatrace` | OneAgent deployment, instrumentation, SLOs, incident investigation | `examples/dynatrace/` |
+| `/platform-skills:commit` | Analyze diff, generate conventional commit message, validate | `examples/conventional-commits/` |
+| `/platform-skills:opa` | Generate Rego policies, write tests, run fmt/regal/verify pipeline | `examples/opa/` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-05-09
+
+### Added
+
+#### OPA / Conftest Domain
+
+New Domain 19: `OPA / Conftest` — generate Rego policies, write unit tests, run the full validation pipeline (fmt → regal lint → conftest verify → integration test), explain existing policies in plain English, and debug why a rule is not firing.
+
+- `references/opa.md` — Rego v1 syntax, METADATA blocks, rule types (deny/warn/violation), package namespacing, input shape analysis with `conftest parse`, policy examples (Terraform IAM, Kubernetes pod security), unit test patterns with input fixtures, full validation pipeline (conftest fmt, regal lint, conftest verify, integration test), GitHub Actions workflow, shared `data.*` allow-lists, and troubleshooting table
+- `/platform-skills:opa` (`commands/opa.md`) — five modes: `generate` (write Rego from description with correct structure), `test` (write `_test.rego` unit tests with fixtures), `validate` (run fmt/regal/verify/integration pipeline), `explain` (translate policy to plain English), `debug` (diagnose namespace mismatch, wrong rule name, input shape issues)
+- `examples/opa/conftest/` — working S3 encryption policy (`deny_unencrypted_s3.rego`), full unit test suite (`deny_unencrypted_s3_test.rego`), sample Terraform input, and `.regal/config.yaml`
+
 ## [1.9.0] - 2026-05-09
 
 ### Added

--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -103,6 +103,7 @@ Slash commands are predefined workflows. Use them instead of writing a long prom
 | `/platform-skills:datadog` | Datadog Agent setup, APM instrumentation, monitors, dashboards, SLOs, and debugging |
 | `/platform-skills:dynatrace` | OneAgent deployment, instrumentation, anomaly detection, SLOs, and debugging |
 | `/platform-skills:commit` | Write a commit message, generate a commit, describe staged changes, or validate a message |
+| `/platform-skills:opa` | Generate Rego policies, write unit tests, run fmt/regal/verify pipeline, explain or debug |
 
 Invoke a command by typing it at the start of your message:
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ platform-skills/
 - [x] v1.8.0 — Datadog: Agent Helm setup, APM instrumentation, log management, monitors/dashboards/SLOs as Terraform, incident investigation via Datadog MCP
 - [x] v1.8.0 — Dynatrace: OneAgent Kubernetes Operator, custom metrics/SLOs/dashboards via Terraform provider, Davis AI incident investigation via Dynatrace MCP
 - [x] v1.9.0 — Conventional Commits: analyze diffs, generate WHY-focused commit messages, intelligent file staging, commitlint/husky/semantic-release tooling
+- [x] v1.10.0 — OPA / Conftest: generate Rego policies, unit tests, fmt/regal/verify validation pipeline, explain and debug
 
 **Planned**
 - [ ] GCP: landing zone, GKE, Workload Identity, and IAM patterns

--- a/commands/opa.md
+++ b/commands/opa.md
@@ -1,0 +1,91 @@
+---
+name: opa
+description: Generate, test, validate, explain, and debug OPA (Open Policy Agent) Rego policies and Conftest configurations. Covers deny/warn/violation rules, unit tests, regal linting, conftest fmt, namespace design, input shape analysis, and GitHub Actions integration. Use when asked to "write a policy", "test a rego file", "validate policies", "explain this rego", or "why is my policy not firing".
+argument-hint: "[generate|test|validate|explain|debug] [policy description or file path]"
+---
+
+Write, test, validate, explain, and debug OPA Rego policies with Conftest.
+
+## Mode: generate
+
+Write a production-ready Rego policy from a description.
+
+Steps:
+1. Ask for: target resource type (Terraform HCL, Kubernetes manifest, GitHub Actions workflow, Dockerfile, JSON/YAML), the rule logic (what to deny or warn on), and whether a named namespace is needed
+2. Parse what Conftest sees — use `conftest parse <file>` to show the input shape if the user has a file, then write rules that match that shape exactly
+3. Generate the policy file:
+   - Start with a `# METADATA` block: `title`, `description`, `authors`, `entrypoint: true`
+   - Declare `package <namespace>` — use `main` only when a single policy set applies; use a named package (`package terraform.iam`, `package k8s.pods`) for multi-domain repos
+   - Add `import rego.v1` — required for modern Rego syntax
+   - Use `deny` for hard failures, `warn` for advisory violations, `violation` for OPA framework integrations (Gatekeeper, Conftest policy sets)
+   - Generate a descriptive `msg` that includes the offending resource name/value and a remediation hint
+   - Use `some` for iteration, `in` for membership, `startswith`/`contains` for string matching
+4. Show the Conftest command to test the policy against sample input
+
+Reference: `references/opa.md` → Rule Types, Input Shape, Rego v1 Syntax
+
+## Mode: test
+
+Write `_test.rego` unit tests for a given policy.
+
+Steps:
+1. Read the policy to understand: package name, rule names, input shape
+2. Generate a test file named `<policy>_test.rego` in the same directory:
+   - Package: `package <namespace>_test` (e.g. `package terraform.iam_test`)
+   - Add `import rego.v1`
+   - Import the policy under test: `import data.<namespace>`
+3. For each `deny`/`warn`/`violation` rule, write:
+   - A **positive test** (rule fires): name prefixed `test_deny_` / `test_warn_`; assert `count(<rule>) == 1` or `count(<rule>) > 0`
+   - A **negative test** (rule does not fire): name prefixed `test_allow_`; assert `count(<rule>) == 0`
+4. Write a helper function that builds the input fixture for each case — keep fixtures minimal and focused on the attributes the rule actually checks
+5. Run tests: `conftest verify --policy <dir>`
+
+Reference: `references/opa.md` → Unit Tests
+
+## Mode: validate
+
+Run the full policy validation pipeline against a directory.
+
+Steps:
+1. **Format check**: `conftest fmt <dir>/*.rego --check` — fails if any file is not canonically formatted
+2. **Auto-format** (if check fails): `conftest fmt <dir>/*.rego` — rewrites in place
+3. **Lint**: `regal lint <dir>` — reports style and correctness violations; fix each finding before continuing
+4. **Unit tests**: `conftest verify --policy <dir>` — all `*_test.rego` files must pass
+5. **Integration test** (if test data is available): `conftest test --policy <dir> <input-files>`
+6. Report: PASS or list each failing step with the exact error and the fix
+
+Reference: `references/opa.md` → Validation Pipeline, Regal
+
+## Mode: explain
+
+Translate an existing Rego policy into plain English.
+
+Steps:
+1. Read the policy file — identify: package, rule names, types (deny/warn/violation), and the conditions
+2. For each rule, explain in plain language:
+   - **What it checks**: the resource type and attribute being evaluated
+   - **What triggers it**: the condition that causes a deny/warn
+   - **What the message says**: what a developer will see when this fires
+   - **What is excluded**: any allow-list or exception conditions
+3. Show the input shape the rule expects — map each `input.<field>` to the resource attribute it reads
+4. Note any dependencies on `data.*` (external allow-lists or config)
+
+Reference: `references/opa.md` → Input Shape, Rego v1 Syntax
+
+## Mode: debug
+
+Diagnose why a policy is not firing as expected.
+
+Steps:
+1. Collect: policy file, input file or `conftest parse <file>` output, and the `conftest test` or `conftest verify` output
+2. Check in order:
+   - **Namespace mismatch**: is the package name matching `--namespace` or `--all-namespaces`?
+   - **Rule name**: does the rule start with `deny`, `warn`, or `violation`? Other names are silently ignored by Conftest
+   - **Input shape mismatch**: run `conftest parse <input-file>` and compare each `input.<path>` in the rule against the actual parsed structure
+   - **Partial vs complete rule**: is the rule a set comprehension (`deny[msg]`) or a boolean? Conftest expects set comprehensions for message output
+   - **`import rego.v1` missing**: without it, `if`, `in`, `contains` may not work as expected
+   - **`some` missing**: iterating without `some` can cause unexpected behaviour in Rego v0 compatibility mode
+3. State the most likely root cause with the exact line to fix
+4. Show the corrected rule and how to verify it fires: `conftest test --policy <dir> <input>`
+
+Reference: `references/opa.md` → Troubleshooting

--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -8,18 +8,21 @@ Production-ready IAM patterns for EKS workloads and GitHub Actions OIDC authenti
 
 | Example | Type | Description |
 |---------|------|-------------|
-| [iam/](iam/) | Terraform | IRSA role for EKS pod + GitHub Actions OIDC trust |
+| [iam/irsa-dynamodb.json](iam/irsa-dynamodb.json) | IAM JSON | IRSA trust policy + DynamoDB scoped permissions |
+| [iam/s3-least-privilege.json](iam/s3-least-privilege.json) | IAM JSON | Least-privilege S3 read policy |
 
 ## Quick Start
 
 ```bash
-cd iam
-terraform init
-terraform plan \
-  -var="cluster_oidc_issuer=https://oidc.eks.eu-central-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE" \
-  -var="namespace=my-app" \
-  -var="service_account=my-app-sa"
-terraform apply
+# Create the IAM policy from the JSON document
+aws iam create-policy \
+  --policy-name my-app-s3-read \
+  --policy-document file://iam/s3-least-privilege.json
+
+# Attach to an IRSA role
+aws iam attach-role-policy \
+  --role-name my-app-irsa-role \
+  --policy-arn arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):policy/my-app-s3-read
 ```
 
 ## Key Patterns

--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -1,80 +1,98 @@
+Status: Stable
+
 # AWS Examples
 
-Status: committed file-level snippets for the handbook. Use these as building blocks rather than a complete standalone AWS stack.
+Production-ready IAM patterns for EKS workloads and GitHub Actions OIDC authentication — no static credentials.
 
-## Files
+## Examples
 
-| File | What it shows |
-|---|---|
-| [iam/s3-least-privilege.json](iam/s3-least-privilege.json) | S3 IAM policy scoped to specific bucket and prefix |
-| [iam/irsa-dynamodb.json](iam/irsa-dynamodb.json) | DynamoDB IAM policy for IRSA with leading key condition |
+| Example | Type | Description |
+|---------|------|-------------|
+| [iam/](iam/) | Terraform | IRSA role for EKS pod + GitHub Actions OIDC trust |
 
-For EKS infrastructure, see [examples/terraform/eks-cluster/](../terraform/eks-cluster/).
+## Quick Start
 
-## Patterns
+```bash
+cd iam
+terraform init
+terraform plan \
+  -var="cluster_oidc_issuer=https://oidc.eks.eu-central-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE" \
+  -var="namespace=my-app" \
+  -var="service_account=my-app-sa"
+terraform apply
+```
 
-### EKS with IRSA
+## Key Patterns
+
+### IRSA — IAM Roles for Service Accounts
+
+Pods on EKS authenticate to AWS using projected service account tokens — no access keys needed:
 
 ```hcl
-module "irsa_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-
-  role_name = "my-app-irsa"
-
-  oidc_providers = {
-    main = {
-      provider_arn               = module.eks.oidc_provider_arn
-      namespace_service_accounts = ["my-app:my-app-sa"]
+# Trust policy pins to specific namespace + service account
+assume_role_policy = jsonencode({
+  Statement = [{
+    Effect    = "Allow"
+    Principal = { Federated = aws_iam_openid_connect_provider.cluster.arn }
+    Action    = "sts:AssumeRoleWithWebIdentity"
+    Condition = {
+      StringEquals = {
+        "${local.oidc_issuer}:sub" = "system:serviceaccount:${var.namespace}:${var.service_account}"
+      }
     }
-  }
-
-  role_policy_arns = {
-    policy = aws_iam_policy.my_app.arn
-  }
-}
+  }]
+})
 ```
-
-### ALB Ingress
 
 ```yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: my-app
-  annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:region:account:certificate/id
-    alb.ingress.kubernetes.io/ssl-redirect: '443'
+# Pod spec — EKS injects the token automatically
 spec:
-  ingressClassName: alb
-  rules:
-  - host: my-app.example.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: my-app
-            port:
-              number: 80
+  serviceAccountName: my-app-sa  # Annotated with role ARN
 ```
 
-## Troubleshooting
+### Least-privilege IAM
 
-### EKS node not joining
-1. Check IAM role trust relationship
-2. Verify security group allows cluster communication
-3. Check cloud-init: `sudo cat /var/log/cloud-init-output.log`
-4. Verify correct AMI for the Kubernetes version
+```hcl
+# ✅ Scoped actions and resources
+resource "aws_iam_policy" "app" {
+  policy = jsonencode({
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:GetObject", "s3:ListBucket"]
+      Resource = [
+        "arn:aws:s3:::my-bucket",
+        "arn:aws:s3:::my-bucket/*"
+      ]
+    }]
+  })
+}
+# ❌ Never: Action = "*" or Resource = "*"
+```
 
-### IRSA not working
-1. Verify OIDC provider exists and matches the cluster endpoint
-2. Check service account annotation on the pod
-3. Verify the IAM role trust policy includes the correct OIDC condition
+### GitHub Actions OIDC (no static credentials)
 
-### ALB ingress not creating
-1. Check AWS Load Balancer Controller logs
-2. Verify IAM policy covers required actions
-3. Verify subnet tags: `kubernetes.io/role/elb=1`
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - uses: aws-actions/configure-aws-credentials@v4
+    with:
+      role-to-assume: arn:aws:iam::123456789012:role/github-actions-terraform
+      aws-region: eu-central-1
+```
+
+## Checklist
+
+- [ ] No static IAM access keys — IRSA for EKS pods, OIDC for GitHub Actions
+- [ ] IAM policies use specific actions and scoped ARNs (no wildcards)
+- [ ] IRSA trust pins to specific namespace and service account
+- [ ] GitHub Actions OIDC trust pins to specific repo and ref
+- [ ] All resources tagged via provider `default_tags`
+
+## See Also
+
+- [references/aws.md](../../references/aws.md) — account model, EKS, IAM, tagging, cost management
+- [references/compliance.md](../../references/compliance.md) — SOC 2 CC6.1/CC6.2 IAM controls
+- `/platform-skills:review` — production-readiness review of Terraform IAM resources

--- a/examples/azure/README.md
+++ b/examples/azure/README.md
@@ -1,62 +1,92 @@
+Status: Stable
+
 # Azure Examples
 
-Status: committed file-level snippets for the handbook. Use these as building blocks rather than a complete standalone Azure platform example.
+Production-ready Azure workload identity for AKS — federated credentials, no service principal secrets.
 
-## Files
+## Examples
 
-| File | What it shows |
-|---|---|
-| [workload-identity/main.tf](workload-identity/main.tf) | Managed identity, federated credential, and scoped role assignment for AKS workload identity |
-| [workload-identity/serviceaccount.yaml](workload-identity/serviceaccount.yaml) | Kubernetes ServiceAccount annotated with the managed identity client ID |
+| Example | Type | Description |
+|---------|------|-------------|
+| [workload-identity/main.tf](workload-identity/) | Terraform | Managed identity + federated credential for AKS pod |
+| [workload-identity/serviceaccount.yaml](workload-identity/) | Kubernetes | Annotated ServiceAccount for workload identity binding |
 
-## Patterns
+## Quick Start
 
-### Internal load balancer
+```bash
+cd workload-identity
+terraform init
+terraform plan \
+  -var="resource_group_name=my-rg" \
+  -var="aks_cluster_name=my-aks" \
+  -var="namespace=my-app" \
+  -var="service_account_name=my-app-sa"
+terraform apply
 
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: my-app-internal
-  annotations:
-    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-    service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "aks-internal-lb"
-spec:
-  type: LoadBalancer
-  ports:
-  - port: 80
-    targetPort: 8080
-  selector:
-    app: my-app
+# Apply the annotated ServiceAccount
+kubectl apply -f serviceaccount.yaml
 ```
 
-### ACR integration
+## Key Patterns
+
+### Workload Identity (no service principal secrets)
 
 ```hcl
-resource "azurerm_container_registry" "this" {
-  name                = "myappregistry"
-  resource_group_name = azurerm_resource_group.this.name
-  location            = azurerm_resource_group.this.location
-  sku                 = "Premium"
-  admin_enabled       = false
-}
-
-resource "azurerm_role_assignment" "acr_pull" {
-  scope                = azurerm_container_registry.this.id
-  role_definition_name = "AcrPull"
-  principal_id         = azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id
+# Federated credential binds managed identity to AKS ServiceAccount
+resource "azurerm_federated_identity_credential" "app" {
+  issuer  = data.azurerm_kubernetes_cluster.aks.oidc_issuer_url
+  subject = "system:serviceaccount:${var.namespace}:${var.service_account_name}"
+  audience = ["api://AzureADTokenExchange"]
 }
 ```
 
-## Troubleshooting
+```yaml
+# ServiceAccount — annotated with client ID
+metadata:
+  annotations:
+    azure.workload.identity/client-id: "<managed-identity-client-id>"
+```
 
-### Workload identity not working
-1. Verify `oidc_issuer_enabled = true` on the cluster
-2. Check the federated credential subject matches the ServiceAccount namespace and name exactly
-3. Verify the audience is `api://AzureADTokenExchange`
-4. Confirm the pod's ServiceAccount has the `azure.workload.identity/client-id` annotation
+```yaml
+# Pod spec — label triggers token injection
+metadata:
+  labels:
+    azure.workload.identity/use: "true"
+spec:
+  serviceAccountName: my-app-sa
+```
 
-### ACR pull failures
-1. Verify the AKS kubelet identity has AcrPull on the registry
-2. Check ACR network rules if using a private endpoint
-3. Verify the image name includes the ACR FQDN
+### Minimum RBAC
+
+```hcl
+resource "azurerm_role_assignment" "app_storage" {
+  scope                = azurerm_storage_account.app.id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = azurerm_user_assigned_identity.app.principal_id
+}
+```
+
+### Tagging baseline
+
+```hcl
+locals {
+  common_tags = { environment = var.environment, team = var.team, managed-by = "terraform" }
+}
+resource "azurerm_resource_group" "app" {
+  tags = merge(local.common_tags, { service = "my-app" })
+}
+```
+
+## Checklist
+
+- [ ] No service principal client secrets — use workload identity federated credentials
+- [ ] Federated credential subject pins to specific namespace and service account
+- [ ] Pod spec includes `azure.workload.identity/use: "true"` label
+- [ ] AKS cluster has `oidc_issuer_enabled = true` and `workload_identity_enabled = true`
+- [ ] RBAC assignments use minimum required built-in roles
+- [ ] All resources tagged with `environment`, `team`, `managed-by`
+
+## See Also
+
+- [references/azure.md](../../references/azure.md) — subscription model, AKS, RBAC, managed identities, tagging
+- `/platform-skills:review` — production-readiness review of Azure Terraform resources

--- a/examples/compliance/README.md
+++ b/examples/compliance/README.md
@@ -1,0 +1,79 @@
+Status: Stable
+
+# Compliance Examples
+
+SOC 2 Trust Services Criteria controls implemented as Terraform — covering IAM, encryption, audit logging, network security, detection, incident response, vulnerability management, and backup.
+
+## Examples
+
+| Example | TSC Criterion | Description |
+|---------|--------------|-------------|
+| [iam/irsa-role.tf](iam/irsa-role.tf) | CC6.1, CC6.2 | IRSA application role and GitHub Actions OIDC trust |
+| [iam/scp-mfa.tf](iam/scp-mfa.tf) | CC6.2 | SCP enforcing MFA and blocking privilege escalation |
+| [logging/cloudtrail.tf](logging/cloudtrail.tf) | CC7.2 | Multi-region CloudTrail with KMS encryption and object lock |
+| [logging/aws-config.tf](logging/aws-config.tf) | CC7.2 | AWS Config recorder with 12 SOC 2 managed rules |
+| [logging/vpc-flow-logs.tf](logging/vpc-flow-logs.tf) | CC6.6, CC7.2 | VPC flow logs to S3 |
+| [network/waf.tf](network/waf.tf) | CC6.6 | WAF with rate limiting and AWS managed rule groups |
+| [network/security-groups.tf](network/security-groups.tf) | CC6.6 | Least-privilege security group baseline |
+| [encryption-data-services/](encryption-data-services/) | CC6.7 | KMS encryption for DynamoDB, ECR, ElastiCache, OpenSearch, Kinesis, EFS, Redshift |
+| [detection/guardduty.tf](detection/guardduty.tf) | CC7.1 | GuardDuty with S3, EKS, and malware protection sources |
+| [detection/cloudwatch-alarms.tf](detection/cloudwatch-alarms.tf) | CC7.1 | 14 CIS Benchmark CloudWatch metric filters and alarms |
+| [detection/security-hub.tf](detection/security-hub.tf) | CC7.1 | Security Hub with AWS Foundational and CIS standards |
+| [incident-response/sns.tf](incident-response/sns.tf) | CC7.3 | KMS-encrypted SNS for GuardDuty HIGH/CRITICAL events |
+| [vulnerability/inspector.tf](vulnerability/inspector.tf) | CC6.8 | Inspector v2 with ECR enhanced scanning |
+| [backup/backup-plan.tf](backup/backup-plan.tf) | A1.2, A1.3 | AWS Backup plan, vault lock, and cross-region DR |
+| [checkov-config.yaml](checkov-config.yaml) | All | Checkov config grouping SOC 2 check IDs by criterion |
+
+## Quick Start
+
+```bash
+# Install Checkov
+pip install checkov
+
+# Run all SOC 2 checks against your Terraform
+checkov -d . --config-file examples/compliance/checkov-config.yaml
+
+# Run checks for a specific criterion (e.g. CC6.7 encryption)
+checkov -d . --check CKV_AWS_7,CKV_AWS_19,CKV_AWS_16,CKV_AWS_17
+
+# Validate a single file
+checkov -f logging/cloudtrail.tf
+```
+
+## Apply an example
+
+```bash
+cd examples/compliance/logging
+terraform init
+terraform plan -var="environment=production"
+```
+
+## SOC 2 Coverage Map
+
+| Criterion | Control | Example File |
+|-----------|---------|-------------|
+| CC6.1 | IAM least privilege, IRSA | `iam/irsa-role.tf` |
+| CC6.2 | MFA enforcement, OIDC | `iam/scp-mfa.tf` |
+| CC6.6 | Network security, WAF, flow logs | `network/`, `logging/vpc-flow-logs.tf` |
+| CC6.7 | Encryption at rest (11 services) | `encryption-data-services/` |
+| CC6.8 | Vulnerability scanning | `vulnerability/inspector.tf` |
+| CC7.1 | Detection: GuardDuty, CIS alarms, Security Hub | `detection/` |
+| CC7.2 | Audit logging: CloudTrail, Config, VPC flow logs | `logging/` |
+| CC7.3 | Incident response: SNS, EventBridge | `incident-response/` |
+| CC8.1 | Change management: S3 backend, locking | referenced in `references/compliance.md` |
+| A1.1 | Availability: multi-AZ | referenced in `references/compliance.md` |
+| A1.2/A1.3 | Backup and recovery | `backup/backup-plan.tf` |
+
+## Checkov Suppressions
+
+Use the documented suppression format in `checkov-config.yaml` to acknowledge accepted risks:
+
+```hcl
+#checkov:skip=CKV_AWS_18:Access logging not required for this internal bucket
+resource "aws_s3_bucket" "internal_logs" { ... }
+```
+
+## See Also
+
+- [references/compliance.md](../../references/compliance.md) — full SOC 2 TSC mapping, Terraform patterns, Checkov rules, evidence commands, pre-audit checklist
+- `/platform-skills:compliance` — gap analysis, control implementation, evidence collection, Checkov remediation, full readiness checklist

--- a/examples/conventional-commits/README.md
+++ b/examples/conventional-commits/README.md
@@ -2,29 +2,110 @@ Status: Stable
 
 # Conventional Commits Examples
 
-Configuration and workflow examples for enforcing Conventional Commits.
+Configuration for enforcing Conventional Commits via commitlint, husky git hooks, and a GitHub Actions PR title linter.
 
 ## Examples
 
 | Example | Type | Description |
 |---------|------|-------------|
-| [commitlint/](commitlint/) | Config | commitlint + husky setup with scope allow-list |
+| [commitlint/](commitlint/) | Config | commitlint + husky with scope allow-list and `commit-msg` hook |
 
-## Usage
+## Quick Start
 
 ```bash
-# Install commitlint and husky
 cd commitlint
+
+# Install commitlint and husky
 npm install
 
-# Test a commit message
+# Activate husky hooks (runs automatically on npm install via "prepare" script)
+npx husky init
+echo "npx --no -- commitlint --edit \$1" > .husky/commit-msg
+
+# Test a valid message
 echo "feat(auth): add OIDC login support" | npx commitlint
 
-# Test a bad message
-echo "updated stuff" | npx commitlint
+# Test an invalid message (missing type)
+echo "updated auth service" | npx commitlint
+# → ✖ subject-empty: subject may not be empty
+# → ✖ type-empty: type may not be empty
+```
+
+## Commit Message Format
+
+```
+<type>(<scope>): <subject>
+
+[optional body]
+
+[optional footers]
+```
+
+### Allowed types
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New user-facing capability |
+| `fix` | Corrects broken behavior |
+| `refactor` | Restructures without behavior change |
+| `perf` | Measurable performance improvement |
+| `test` | Tests only |
+| `docs` | Documentation only |
+| `chore` | Deps, build tooling, no production effect |
+| `ci` | CI/CD pipeline changes |
+| `revert` | Reverts a prior commit |
+
+### Examples
+
+```bash
+# ✅ Valid
+git commit -m "feat(orders): add idempotency key validation"
+git commit -m "fix(auth): reject expired tokens before redirect"
+git commit -m "chore(deps): bump axios to 1.7.0"
+
+# ✅ Breaking change
+git commit -m "feat(api)!: require Authorization header on all endpoints
+
+BREAKING CHANGE: All endpoints now require a Bearer token. Update clients to v2.x."
+
+# ❌ Invalid — commitlint will reject these
+git commit -m "updated stuff"
+git commit -m "Fix bug"          # uppercase
+git commit -m "feat: add thing." # trailing period
+```
+
+## Add a Scope
+
+Edit `commitlint/commitlint.config.js` to add your service/module names to `scope-enum`:
+
+```js
+"scope-enum": [2, "always", [
+  "api", "auth", "billing", "ci", "config",
+  "db", "deps", "docs", "helm", "infra",
+  "orders", "terraform", "ui",
+]],
+```
+
+## GitHub Actions PR Title Lint
+
+Add this to enforce Conventional Commits on PR titles:
+
+```yaml
+# .github/workflows/pr-title.yml
+name: Lint PR title
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## See Also
 
-- [references/conventional-commits.md](../../references/conventional-commits.md) — spec, type classification, breaking changes, tooling, validation
-- `/platform-skills:commit` — analyze diff, generate message, stage files, validate message
+- [references/conventional-commits.md](../../references/conventional-commits.md) — full spec, type classification, breaking changes, semantic-release, validation rules
+- `/platform-skills:commit` — analyze a diff and generate a commit message, stage files atomically, validate an existing message

--- a/examples/datadog/README.md
+++ b/examples/datadog/README.md
@@ -2,33 +2,100 @@ Status: Stable
 
 # Datadog Examples
 
-Production-ready Datadog configurations for Kubernetes, APM, monitors, dashboards, and SLOs.
+Production-ready Datadog monitors, dashboards, and SLOs managed as Terraform code.
 
 ## Examples
 
 | Example | Type | Description |
 |---------|------|-------------|
-| [terraform/](terraform/) | Terraform | Monitors, dashboards, and SLOs as code |
+| [terraform/monitors.tf](terraform/) | Terraform | Error rate monitor, p99 latency monitor, and 30-day availability SLO |
 
-## Usage
+## Quick Start
 
 ```bash
-# Deploy agent — create API key secret first, never pass on command line
+# Export credentials (never hardcode)
+export DD_API_KEY="your-api-key"
+export DD_APP_KEY="your-app-key"
+
+cd terraform
+terraform init
+terraform plan
+terraform apply
+```
+
+## What terraform/monitors.tf Creates
+
+| Resource | Type | Threshold |
+|----------|------|-----------|
+| `orders-service high error rate` | Metric alert | Critical: > 5%, Warning: > 2% |
+| `orders-service p99 latency high` | Metric alert | Critical: > 1s, Warning: > 0.5s |
+| `Orders Service Availability` | SLO (metric) | Target: 99.9%, Warning: 99.95% over 30d |
+
+## Key Patterns
+
+### Unified Service Tagging (required on all Datadog resources)
+
+Always set these three tags consistently across pods, traces, logs, and monitors:
+
+```yaml
+# Pod environment variables
+env:
+  - name: DD_ENV
+    value: "production"
+  - name: DD_SERVICE
+    value: "orders-service"
+  - name: DD_VERSION
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.annotations['app.kubernetes.io/version']
+```
+
+### Secure Agent installation (no `--set apiKey`)
+
+```bash
+# ✅ Create secret first
 kubectl create secret generic datadog-secret \
   --from-literal=api-key="${DD_API_KEY}" \
-  -n datadog --dry-run=client -o yaml | kubectl apply -f -
+  -n datadog
 
-helm repo add datadog https://helm.datadoghq.com
+# ✅ Reference secret in Helm values
 helm upgrade --install datadog datadog/datadog \
   --set datadog.apiKeyExistingSecret=datadog-secret \
-  -n datadog --create-namespace
+  -n datadog
 
-# Apply Terraform resources
-cd terraform
-terraform init && terraform plan
+# ❌ Never pass key on command line — stored in Helm release history
+# helm upgrade --install datadog datadog/datadog --set datadog.apiKey="${DD_API_KEY}"
 ```
+
+### Log + trace correlation
+
+```javascript
+// dd-trace init — must be first import
+import tracer from "dd-trace";
+tracer.init({
+  service: "orders-service",
+  env: process.env.DD_ENV,
+  logInjection: true,  // injects trace_id and span_id into log lines
+});
+```
+
+## Adapt to Your Service
+
+Replace `orders-service` in `monitors.tf` with your service name:
+
+```bash
+sed -i 's/orders-service/my-service/g' terraform/monitors.tf
+```
+
+## Checklist
+
+- [ ] Unified Service Tagging applied: `DD_ENV`, `DD_SERVICE`, `DD_VERSION` on every pod
+- [ ] API key stored in Kubernetes Secret — not in Helm values or environment
+- [ ] `logInjection: true` in tracer init — enables log/trace correlation
+- [ ] Monitors notify correct PagerDuty/Slack channels (`@pagerduty-*`, `@slack-*`)
+- [ ] SLO target and timeframe match your error budget
 
 ## See Also
 
-- [references/datadog.md](../../references/datadog.md) — agent setup, APM, logs, monitors, dashboards, SLOs
-- `/platform-skills:datadog` — setup, instrument, monitor, dashboard, SLO, debug
+- [references/datadog.md](../../references/datadog.md) — Agent setup, APM, log management, monitors, dashboards, SLOs, synthetic tests, MCP server
+- `/platform-skills:datadog` — setup, instrument, monitor, dashboard, SLO, investigate incidents

--- a/examples/datadog/README.md
+++ b/examples/datadog/README.md
@@ -53,14 +53,17 @@ env:
 ### Secure Agent installation (no `--set apiKey`)
 
 ```bash
-# ✅ Create secret first
+# ✅ Create namespace + secret (idempotent)
+kubectl create namespace datadog --dry-run=client -o yaml | kubectl apply -f -
 kubectl create secret generic datadog-secret \
   --from-literal=api-key="${DD_API_KEY}" \
-  -n datadog
+  -n datadog \
+  --dry-run=client -o yaml | kubectl apply -f -
 
 # ✅ Reference secret in Helm values
 helm upgrade --install datadog datadog/datadog \
   --set datadog.apiKeyExistingSecret=datadog-secret \
+  --create-namespace \
   -n datadog
 
 # ❌ Never pass key on command line — stored in Helm release history

--- a/examples/documentation/README.md
+++ b/examples/documentation/README.md
@@ -2,22 +2,117 @@ Status: Stable
 
 # Documentation Examples
 
-Reference implementations for docstrings, OpenAPI specs, and documentation sites.
+Reference implementations for OpenAPI 3.1 specifications with shared components, security schemes, and response definitions.
 
 ## Examples
 
 | Example | Type | Description |
 |---------|------|-------------|
-| [openapi-spec/](openapi-spec/) | OpenAPI 3.1 | Orders API spec with shared components |
+| [openapi-spec/openapi.yaml](openapi-spec/) | OpenAPI 3.1 | Orders API — create, read, list orders with auth, pagination, error schemas |
 
-## Usage
+## Quick Start
 
 ```bash
-# Validate OpenAPI spec
+# Validate the spec with Redocly (recommended)
 npx @redocly/cli lint openapi-spec/openapi.yaml
+
+# Preview rendered documentation in browser
+npx @redocly/cli preview-docs openapi-spec/openapi.yaml
+
+# Generate HTML docs
+npx @redocly/cli build-docs openapi-spec/openapi.yaml -o docs/
+
+# Validate with Spectral (alternative linter)
+npx @stoplight/spectral-cli lint openapi-spec/openapi.yaml
 ```
+
+## What the Orders API Spec Covers
+
+| Section | What it shows |
+|---------|--------------|
+| `info` | Version, contact, license metadata |
+| `servers` | Environment URLs (production, staging) |
+| `security` | Bearer token and API key schemes |
+| `paths` | `POST /orders`, `GET /orders/{id}`, `GET /orders` with pagination |
+| `components/schemas` | `Order`, `CreateOrderRequest`, `ErrorResponse`, `PaginatedResponse` — reused across paths |
+| `components/responses` | Shared `400`, `401`, `404`, `500` responses referenced by `$ref` |
+| `components/parameters` | Shared `page`, `limit`, `sort` pagination parameters |
+
+## Key Patterns
+
+### Shared error responses (avoid duplication)
+
+```yaml
+# Define once in components
+components:
+  responses:
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+
+# Reference everywhere
+paths:
+  /orders/{id}:
+    get:
+      responses:
+        "404":
+          $ref: "#/components/responses/NotFound"
+```
+
+### Pagination schema
+
+```yaml
+components:
+  schemas:
+    PaginatedOrders:
+      type: object
+      required: [data, total, page, limit]
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Order"
+        total:
+          type: integer
+        page:
+          type: integer
+        limit:
+          type: integer
+```
+
+### Security scheme
+
+```yaml
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+```
+
+## Validate in CI
+
+```yaml
+# .github/workflows/docs.yml
+- name: Lint OpenAPI spec
+  run: npx @redocly/cli lint openapi-spec/openapi.yaml --fail-on-warnings
+```
+
+## Checklist
+
+- [ ] All paths have `operationId`, `summary`, and `tags`
+- [ ] All schemas use `$ref` for reusable types — no inline duplication
+- [ ] All error responses reference shared `components/responses`
+- [ ] Security schemes declared in `components/securitySchemes` and referenced in `security`
+- [ ] `required` fields listed explicitly on all request body schemas
+- [ ] Examples provided for request and response bodies
+- [ ] Spec passes `@redocly/cli lint` with zero errors
 
 ## See Also
 
-- [references/documentation.md](../../references/documentation.md) — docstring styles, OpenAPI 3.1, doc sites, guides
+- [references/documentation.md](../../references/documentation.md) — docstring styles (Google/NumPy/JSDoc), OpenAPI 3.1, doc sites (MkDocs/TypeDoc), developer guides
 - `/platform-skills:document` — generate docstrings, OpenAPI spec, doc site, or getting started guide

--- a/examples/dynatrace/README.md
+++ b/examples/dynatrace/README.md
@@ -2,27 +2,84 @@ Status: Stable
 
 # Dynatrace Examples
 
-Production-ready Dynatrace configurations for OneAgent Kubernetes deployment, anomaly detection, SLOs, and dashboards.
+Production-ready Dynatrace OneAgent deployment on Kubernetes via the Dynatrace Operator.
 
 ## Examples
 
 | Example | Type | Description |
 |---------|------|-------------|
-| [operator/](operator/) | Kubernetes | DynaKube CR for cloudNativeFullStack injection |
+| [operator/dynakube.yaml](operator/) | Kubernetes | DynaKube CR — cloudNativeFullStack injection with ActiveGate |
 
-## Usage
+## Quick Start
 
 ```bash
-# Deploy OneAgent Operator
+# 1. Install the Dynatrace Operator
 kubectl create namespace dynatrace
 kubectl apply -f https://github.com/Dynatrace/dynatrace-operator/releases/latest/download/kubernetes.yaml
+
+# 2. Create the API token secret (never use plain values)
 kubectl -n dynatrace create secret generic dynakube \
   --from-literal=apiToken="${DT_API_TOKEN}" \
   --from-literal=dataIngestToken="${DT_DATA_INGEST_TOKEN}"
+
+# 3. Edit operator/dynakube.yaml — replace ENVIRONMENT_ID with your Dynatrace environment ID
+#    apiUrl: "https://ENVIRONMENT_ID.live.dynatrace.com/api"
+
+# 4. Apply the DynaKube CR
 kubectl apply -f operator/dynakube.yaml
+
+# 5. Verify deployment
+kubectl -n dynatrace get dynakube dynakube
+kubectl -n dynatrace get pods
 ```
+
+## What dynakube.yaml Provides
+
+| Feature | Setting | Effect |
+|---------|---------|--------|
+| `cloudNativeFullStack` | Enabled | Automatic OneAgent injection — no pod restarts required |
+| Control-plane tolerations | `node-role.kubernetes.io/control-plane` | OneAgent runs on control-plane nodes |
+| ActiveGate | 2 replicas | High-availability routing, Kubernetes monitoring, API gateway |
+| `metadataEnrichment` | Enabled | All telemetry enriched with k8s namespace, pod, node labels |
+
+## URL Conventions
+
+| Use case | URL format | Example |
+|----------|-----------|---------|
+| `DynaKube.spec.apiUrl` (Operator) | `live.dynatrace.com` | `https://abc12345.live.dynatrace.com/api` |
+| `DT_ENVIRONMENT` (MCP server) | `apps.dynatrace.com` | `https://abc12345.apps.dynatrace.com` |
+
+These are different URLs — the Operator uses the classic API URL; the MCP server requires the Platform URL.
+
+## Required Token Scopes
+
+| Token | Required scopes |
+|-------|----------------|
+| `apiToken` | `ReadConfig`, `WriteConfig`, `DataExport`, `LogExport`, `ReadSyntheticData`, `WriteAnomalyDetection` |
+| `dataIngestToken` | `metrics.ingest`, `logs.ingest` |
+
+Store both tokens in a Kubernetes Secret — never in plain Helm values or committed files.
+
+## Verify Injection
+
+```bash
+# OneAgent should appear as an init container in application pods
+kubectl describe pod <app-pod> -n <app-namespace> | grep -A5 "Init Containers"
+
+# Check OneAgent status
+kubectl -n dynatrace get oneagent
+```
+
+## Checklist
+
+- [ ] `ENVIRONMENT_ID` replaced with real environment ID in `apiUrl`
+- [ ] API token secret created before applying DynaKube CR
+- [ ] Both token scopes verified in Dynatrace UI before deployment
+- [ ] `cloudNativeFullStack` chosen over `fullStack` for zero-restart injection
+- [ ] `metadataEnrichment: true` — enriches all signals with k8s metadata
+- [ ] ActiveGate replicas ≥ 2 for high availability
 
 ## See Also
 
-- [references/dynatrace.md](../../references/dynatrace.md) — Operator setup, instrumentation, metrics, SLOs, Terraform provider
-- `/platform-skills:dynatrace` — setup, instrument, monitor, SLO, dashboard, debug
+- [references/dynatrace.md](../../references/dynatrace.md) — Operator setup, code-level instrumentation, custom metrics, SLOs, Terraform provider, Davis AI
+- `/platform-skills:dynatrace` — setup, instrument, monitor, SLO, dashboard, investigate incidents

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,35 +1,93 @@
+Status: Stable
+
 # Kubernetes Examples
 
-Baseline manifests for Kubernetes platform patterns. These apply across managed cluster distributions (EKS, AKS, GKE, vanilla).
+Baseline manifests for Kubernetes platform patterns. Apply across EKS, AKS, GKE, and vanilla clusters. Each file is a self-contained, production-hardened example you can copy directly into your GitOps repo.
 
-Status: committed manifest snippets for the handbook. Adapt them into your own repo or GitOps structure.
+## Examples
 
-## Files
+| File | What it shows | Key patterns |
+|------|--------------|-------------|
+| [namespace-baseline.yaml](namespace-baseline.yaml) | Namespace with ownership labels and pod security enforcement | `pod-security.kubernetes.io/enforce: restricted`, team/env labels |
+| [deployment-baseline.yaml](deployment-baseline.yaml) | Deployment with resource limits, probes, and locked-down security context | `runAsNonRoot`, `readOnlyRootFilesystem`, `capabilities.drop: ALL`, no CPU limit |
+| [network-policy-default-deny.yaml](network-policy-default-deny.yaml) | Default-deny ingress + example allow rule for ingress controller | Applied before workload; explicit allow for ingress controller namespace |
+| [pod-disruption-budget.yaml](pod-disruption-budget.yaml) | PDB protecting minimum availability during node drain | `minAvailable: 1` — prevents simultaneous eviction |
 
-| File | What it shows |
-|---|---|
-| [namespace-baseline.yaml](namespace-baseline.yaml) | Namespace with ownership labels and pod security enforcement |
-| [deployment-baseline.yaml](deployment-baseline.yaml) | Deployment with resource limits, health probes, and locked-down security context |
-| [network-policy-default-deny.yaml](network-policy-default-deny.yaml) | Default-deny ingress + example allow rule for ingress controller |
-| [pod-disruption-budget.yaml](pod-disruption-budget.yaml) | PDB protecting minimum availability during node drain |
-
-## Usage
-
-Apply the namespace first, then the workload manifests:
+## Quick Start
 
 ```bash
+# 1. Apply namespace first — sets pod security admission before workloads land
 kubectl apply -f namespace-baseline.yaml
+
+# 2. Deploy the baseline workload
 kubectl apply -f deployment-baseline.yaml
+
+# 3. Lock down network — default deny then explicit allow
 kubectl apply -f network-policy-default-deny.yaml
+
+# 4. Protect availability during drain / rolling update
 kubectl apply -f pod-disruption-budget.yaml
+
+# Verify security context is in effect
+kubectl get pod -n app-team -o jsonpath='{.items[0].spec.containers[0].securityContext}'
+```
+
+## Key Patterns
+
+### Security context (required on every container)
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+```
+
+### Resource management (no CPU limit — avoids throttling)
+
+```yaml
+resources:
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+  limits:
+    memory: "256Mi"   # CPU limit intentionally omitted
+```
+
+### Health probes (required for safe rolling updates)
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 10
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 5
 ```
 
 ## Checklist
 
-- Namespace ownership labels present
-- Resource requests and limits defined on every container
-- Liveness and readiness probes defined
-- ServiceAccount explicitly set (no default service account)
-- Security context: `runAsNonRoot`, `allowPrivilegeEscalation: false`, `capabilities.drop: ALL`
-- Default-deny NetworkPolicy applied before allow rules
-- PodDisruptionBudget covers any deployment with `replicas >= 2`
+- [ ] Namespace ownership labels present (`team`, `env`)
+- [ ] Pod security admission enforced (`restricted` mode)
+- [ ] Resource requests and limits on every container (no CPU limit)
+- [ ] Liveness and readiness probes defined
+- [ ] ServiceAccount explicitly set — not the `default` service account
+- [ ] `runAsNonRoot`, `allowPrivilegeEscalation: false`, `capabilities.drop: ALL`
+- [ ] `readOnlyRootFilesystem: true` (add `emptyDir` mounts for writable paths)
+- [ ] Default-deny NetworkPolicy applied before any allow rules
+- [ ] PodDisruptionBudget covers every deployment with `replicas >= 2`
+
+## See Also
+
+- [references/kubernetes.md](../../references/kubernetes.md) — cluster baselines, workload patterns, RBAC, network policy, pod security
+- `/platform-skills:review` — production-readiness review of any manifest
+- `/platform-skills:debug` — structured diagnosis for Kubernetes issues

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -2,24 +2,99 @@ Status: Stable
 
 # MCP Examples
 
-Production-ready MCP server implementations for common platform use cases.
+Production-ready MCP (Model Context Protocol) server implementations.
 
 ## Examples
 
 | Example | Transport | Language | Description |
 |---------|-----------|----------|-------------|
-| [docs-server/](docs-server/) | stdio | TypeScript | Search internal documentation |
+| [docs-server/](docs-server/) | stdio | TypeScript | Search and retrieve internal documentation |
 
-## Usage
+## Quick Start
 
 ```bash
-# TypeScript example
 cd docs-server
-npm install && npm run build
+
+# Install dependencies
+npm install
+
+# Build
+npm run build
+
+# Test with MCP Inspector (interactive browser UI)
 npx @modelcontextprotocol/inspector node dist/index.js
+
+# Or run directly via Claude Code
+claude mcp add docs-server -- node /path/to/docs-server/dist/index.js
+```
+
+## What docs-server Provides
+
+| Capability | Name | Description |
+|-----------|------|-------------|
+| Tool | `search_docs` | Search documents by keyword, returns matching titles and excerpts |
+| Tool | `get_doc` | Retrieve full document content by ID |
+| Resource | `docs://index` | List all available documents |
+
+## Key Patterns
+
+### Tool with Zod input validation
+
+```typescript
+server.tool(
+  "search_docs",
+  "Search internal documentation by keyword",
+  { query: z.string().min(1).describe("Search query"), limit: z.number().int().min(1).max(50).default(10) },
+  async ({ query, limit }) => {
+    const results = documents.filter(d => d.body.toLowerCase().includes(query.toLowerCase())).slice(0, limit);
+    return { content: [{ type: "text", text: JSON.stringify(results) }] };
+  }
+);
+```
+
+### Resource handler
+
+```typescript
+server.resource("docs://index", "List all documents", async (uri) => ({
+  contents: [{ uri: uri.href, text: JSON.stringify(documents.map(d => ({ id: d.id, title: d.title }))) }]
+}));
+```
+
+### stdio transport (for Claude Code integration)
+
+```typescript
+const transport = new StdioServerTransport();
+await server.connect(transport);
+```
+
+### SSE transport (for remote/browser access)
+
+```typescript
+// Transport must be created inside the /sse handler
+app.get("/sse", async (req, res) => {
+  const transport = new SSEServerTransport("/message", res);
+  transports.set(transport.sessionId, transport);
+  await server.connect(transport);
+});
+app.post("/message", async (req, res) => {
+  const transport = transports.get(req.query.sessionId as string);
+  await transport?.handlePostMessage(req, res);
+});
+```
+
+## Extending the Example
+
+Replace the in-memory `documents` array with a real backend:
+
+```typescript
+// Elasticsearch
+const results = await esClient.search({ index: "docs", query: { match: { body: query } } });
+
+// Postgres full-text search
+const results = await db.query("SELECT * FROM docs WHERE to_tsvector(body) @@ plainto_tsquery($1)", [query]);
 ```
 
 ## See Also
 
-- [references/mcp.md](../../references/mcp.md) — protocol guide, SDK patterns, security
-- `/platform-skills:mcp` — scaffold, review, or debug an MCP server
+- [references/mcp.md](../../references/mcp.md) — protocol fundamentals, TypeScript/Python SDKs, schema design, transports, security, deployment
+- `/platform-skills:mcp` — scaffold a new MCP server, review an existing one, or debug transport/protocol issues

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -8,7 +8,7 @@ Production-ready alerting rules using the RED method (Request rate, Error rate, 
 
 | Example | Tool | Description |
 |---------|------|-------------|
-| [prometheus-alerts/orders-service.yaml](prometheus-alerts/) | Prometheus | RED method alerting rules for a production service |
+| [prometheus-alerts/orders-service.yaml](prometheus-alerts/orders-service.yaml) | Prometheus | RED method alerting rules for a production service |
 
 ## Quick Start
 

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -2,23 +2,102 @@ Status: Stable
 
 # Observability Examples
 
-Production-ready instrumentation, dashboards, alerting, and load test configurations.
+Production-ready alerting rules using the RED method (Request rate, Error rate, Duration).
 
 ## Examples
 
 | Example | Tool | Description |
 |---------|------|-------------|
-| [prometheus-alerts/](prometheus-alerts/) | Prometheus | RED method alerting rules |
+| [prometheus-alerts/orders-service.yaml](prometheus-alerts/) | Prometheus | RED method alerting rules for a production service |
 
 ## Quick Start
 
 ```bash
-# Validate Prometheus alerting rules
+# Install promtool (included with Prometheus binary)
+# https://prometheus.io/download/
+
+# Validate alerting rules syntax and expressions
 cd prometheus-alerts
-promtool check rules *.yaml
+promtool check rules orders-service.yaml
+
+# Test alert firing logic
+promtool test rules orders-service.yaml
 ```
+
+## What the Alerts Cover
+
+| Alert | Threshold | Severity | When it fires |
+|-------|-----------|----------|--------------|
+| `HighErrorRate` | > 5% errors over 5m | critical | Error rate exceeds SLO budget |
+| `HighLatencyP99` | > 1s p99 over 5m | warning | Tail latency degraded |
+| `LowRequestRate` | < 0.1 req/s over 10m | warning | Service may be down or receiving no traffic |
+
+## RED Method Applied
+
+```yaml
+# Request rate — is traffic flowing?
+expr: rate(http_requests_total{job="orders-service"}[5m])
+
+# Error rate — are requests succeeding?
+expr: |
+  rate(http_requests_total{job="orders-service",status=~"5.."}[5m])
+  / rate(http_requests_total{job="orders-service"}[5m])
+
+# Duration (p99) — how slow are requests?
+expr: histogram_quantile(0.99, rate(http_request_duration_seconds_bucket{job="orders-service"}[5m]))
+```
+
+## Instrument Your Service
+
+To use these alerts, expose the following Prometheus metrics from your service:
+
+```javascript
+// Node.js — prom-client
+import { Counter, Histogram } from "prom-client";
+
+const httpRequests = new Counter({
+  name: "http_requests_total",
+  help: "Total HTTP requests",
+  labelNames: ["method", "path", "status"],
+});
+
+const httpDuration = new Histogram({
+  name: "http_request_duration_seconds",
+  help: "HTTP request duration",
+  labelNames: ["method", "path"],
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5],
+});
+```
+
+```python
+# Python — prometheus-client
+from prometheus_client import Counter, Histogram
+
+http_requests = Counter("http_requests_total", "Total HTTP requests", ["method", "path", "status"])
+http_duration = Histogram("http_request_duration_seconds", "HTTP request duration", ["method", "path"])
+```
+
+## Integrate with Grafana
+
+```yaml
+# Prometheus scrape config
+scrape_configs:
+  - job_name: orders-service
+    static_configs:
+      - targets: ["orders-service:9090"]
+```
+
+Load `prometheus-alerts/orders-service.yaml` into Alertmanager and point your Grafana datasource at Prometheus to visualise these metrics.
+
+## Checklist
+
+- [ ] Service exposes `/metrics` on a dedicated port (not the main API port)
+- [ ] Metrics follow naming convention: `<namespace>_<metric>_<unit>_total` / `_seconds` / `_bytes`
+- [ ] All metrics have `job` and `env` labels for alert routing
+- [ ] Alert `for` duration is long enough to avoid flapping (5m for critical, 10m for warning)
+- [ ] Alertmanager routes critical alerts to PagerDuty, warnings to Slack
 
 ## See Also
 
-- [references/observability.md](../../references/observability.md) — logging, metrics, tracing, alerting, capacity planning
-- `/platform-skills:observability` — instrument, dashboard, alert, load test, or plan capacity
+- [references/observability.md](../../references/observability.md) — structured logging, Prometheus metrics, OpenTelemetry tracing, Grafana dashboards, k6 load testing, capacity planning
+- `/platform-skills:observability` — instrument services, build dashboards, write alerts, run load tests, plan capacity

--- a/examples/opa/README.md
+++ b/examples/opa/README.md
@@ -1,0 +1,36 @@
+Status: Stable
+
+# OPA / Conftest Examples
+
+Production-ready Rego policies with unit tests, Regal lint config, and Conftest integration.
+
+## Examples
+
+| Example | Type | Description |
+|---------|------|-------------|
+| [conftest/](conftest/) | Conftest + Terraform | S3 encryption and ACL policies with full test suite |
+
+## Usage
+
+```bash
+# Install tools
+brew install conftest
+brew install styrainc/packages/regal
+
+# 1. Check formatting
+conftest fmt ./conftest/policies/*.rego --check
+
+# 2. Lint with Regal
+regal lint ./conftest/policies
+
+# 3. Run unit tests
+conftest verify --policy ./conftest/policies
+
+# 4. Run integration test against sample Terraform
+conftest test --policy ./conftest/policies --namespace terraform.s3 ./conftest/tests/main.tf
+```
+
+## See Also
+
+- [references/opa.md](../../references/opa.md) — Rego v1 syntax, rule types, input shapes, testing, Conftest CLI, Regal, GitHub Actions integration
+- `/platform-skills:opa` — generate policies, write tests, run validation pipeline, explain or debug Rego

--- a/examples/opa/conftest/.regal/config.yaml
+++ b/examples/opa/conftest/.regal/config.yaml
@@ -1,0 +1,13 @@
+rules:
+  idiomatic:
+    no-defined-entrypoint:
+      level: error
+  style:
+    line-length:
+      level: warning
+      max-line-length: 120
+    prefer-snake-case:
+      level: warning
+  bugs:
+    unused-variable:
+      level: error

--- a/examples/opa/conftest/policies/deny_unencrypted_s3.rego
+++ b/examples/opa/conftest/policies/deny_unencrypted_s3.rego
@@ -1,0 +1,37 @@
+# METADATA
+# title: S3 bucket encryption
+# description: S3 buckets must have server-side encryption enabled and must not use public ACLs
+# authors:
+# - Platform Team <platform@example.com>
+# entrypoint: true
+package terraform.s3
+
+import rego.v1
+
+deny contains msg if {
+	some name
+	bucket := input.resource.aws_s3_bucket[name]
+	not bucket.server_side_encryption_configuration
+	msg := sprintf("S3 bucket '%s' must have server_side_encryption_configuration", [name])
+}
+
+deny contains msg if {
+	some name
+	bucket := input.resource.aws_s3_bucket[name]
+	bucket.acl == "public-read"
+	msg := sprintf("S3 bucket '%s' must not use public-read ACL", [name])
+}
+
+deny contains msg if {
+	some name
+	bucket := input.resource.aws_s3_bucket[name]
+	bucket.acl == "public-read-write"
+	msg := sprintf("S3 bucket '%s' must not use public-read-write ACL", [name])
+}
+
+warn contains msg if {
+	some name
+	_ = input.resource.aws_s3_bucket[name]
+	not input.resource.aws_s3_bucket_versioning
+	msg := sprintf("S3 bucket '%s' should have versioning enabled", [name])
+}

--- a/examples/opa/conftest/policies/deny_unencrypted_s3.rego
+++ b/examples/opa/conftest/policies/deny_unencrypted_s3.rego
@@ -8,11 +8,13 @@ package terraform.s3
 
 import rego.v1
 
+# AWS provider >= 5 uses a separate aws_s3_bucket_server_side_encryption_configuration resource.
+# Correlate it to the bucket by matching the "bucket" attribute.
 deny contains msg if {
 	some name
-	bucket := input.resource.aws_s3_bucket[name]
-	not bucket.server_side_encryption_configuration
-	msg := sprintf("S3 bucket '%s' must have server_side_encryption_configuration", [name])
+	_ = input.resource.aws_s3_bucket[name]
+	not _bucket_has_encryption(name)
+	msg := sprintf("S3 bucket '%s' must have an aws_s3_bucket_server_side_encryption_configuration resource", [name])
 }
 
 deny contains msg if {
@@ -29,9 +31,22 @@ deny contains msg if {
 	msg := sprintf("S3 bucket '%s' must not use public-read-write ACL", [name])
 }
 
+# Warn if no aws_s3_bucket_versioning resource references this specific bucket.
 warn contains msg if {
 	some name
 	_ = input.resource.aws_s3_bucket[name]
-	not input.resource.aws_s3_bucket_versioning
-	msg := sprintf("S3 bucket '%s' should have versioning enabled", [name])
+	not _bucket_has_versioning(name)
+	msg := sprintf("S3 bucket '%s' should have an aws_s3_bucket_versioning resource", [name])
+}
+
+_bucket_has_encryption(bucket_name) if {
+	some enc_name
+	enc := input.resource.aws_s3_bucket_server_side_encryption_configuration[enc_name]
+	enc.bucket == bucket_name
+}
+
+_bucket_has_versioning(bucket_name) if {
+	some ver_name
+	ver := input.resource.aws_s3_bucket_versioning[ver_name]
+	ver.bucket == bucket_name
 }

--- a/examples/opa/conftest/policies/deny_unencrypted_s3_test.rego
+++ b/examples/opa/conftest/policies/deny_unencrypted_s3_test.rego
@@ -8,103 +8,58 @@ import rego.v1
 # --- deny: missing encryption resource ---
 
 test_deny_missing_encryption if {
-	count(s3.deny) == 1 with input as make_input("my-bucket", {}, null, null)
+	count(s3.deny) == 1 with input as make_input_no_enc("my-bucket", {})
 }
 
 test_allow_with_encryption_resource if {
-	count(s3.deny) == 0 with input as make_input(
-		"my-bucket",
-		{"acl": "private"},
-		{"sse_algorithm": "aws:kms"},
-		"Enabled",
-	)
+	count(s3.deny) == 0 with input as make_input_full("my-bucket", {"acl": "private"}, "aws:kms", "Enabled")
 }
 
 # --- deny: public ACL ---
 
 test_deny_public_read_acl if {
-	count(s3.deny) > 0 with input as make_input(
-		"my-bucket",
-		{"acl": "public-read"},
-		{"sse_algorithm": "aws:kms"},
-		"Enabled",
-	)
+	count(s3.deny) > 0 with input as make_input_full("my-bucket", {"acl": "public-read"}, "aws:kms", "Enabled")
 }
 
 test_deny_public_read_write_acl if {
-	count(s3.deny) > 0 with input as make_input(
-		"my-bucket",
-		{"acl": "public-read-write"},
-		{"sse_algorithm": "aws:kms"},
-		"Enabled",
-	)
+	count(s3.deny) > 0 with input as make_input_full("my-bucket", {"acl": "public-read-write"}, "aws:kms", "Enabled")
 }
 
 test_allow_private_acl if {
-	count(s3.deny) == 0 with input as make_input(
-		"my-bucket",
-		{"acl": "private"},
-		{"sse_algorithm": "aws:kms"},
-		"Enabled",
-	)
+	count(s3.deny) == 0 with input as make_input_full("my-bucket", {"acl": "private"}, "aws:kms", "Enabled")
 }
 
 # --- warn: missing versioning resource ---
 
 test_warn_missing_versioning if {
-	count(s3.warn) > 0 with input as make_input(
-		"my-bucket",
-		{"acl": "private"},
-		{"sse_algorithm": "aws:kms"},
-		null,
-	)
+	count(s3.warn) > 0 with input as make_input_enc_only("my-bucket", {"acl": "private"}, "aws:kms")
 }
 
 test_no_warn_with_versioning if {
-	count(s3.warn) == 0 with input as make_input(
-		"my-bucket",
-		{"acl": "private"},
-		{"sse_algorithm": "aws:kms"},
-		"Enabled",
-	)
+	count(s3.warn) == 0 with input as make_input_full("my-bucket", {"acl": "private"}, "aws:kms", "Enabled")
 }
 
-# Helper: build a Terraform HCL input shape matching AWS provider >= 5.
-# enc_algo: SSE algorithm string (e.g. "aws:kms") or null to omit the resource.
-# versioning_status: "Enabled"/"Suspended" or null to omit the resource.
-make_input(bucket_name, extra_attrs, enc_algo, versioning_status) := input if {
-	enc_algo != null
-	versioning_status != null
-	input := {
-		"resource": {
-			"aws_s3_bucket": {bucket_name: object.union({"bucket": bucket_name}, extra_attrs)},
-			"aws_s3_bucket_server_side_encryption_configuration": {"enc": {
-				"bucket": bucket_name,
-				"rule": [{"apply_server_side_encryption_by_default": {"sse_algorithm": enc_algo}}],
-			}},
-			"aws_s3_bucket_versioning": {"ver": {
-				"bucket": bucket_name,
-				"versioning_configuration": [{"status": versioning_status}],
-			}},
-		},
-	}
-}
+# Helpers — build Terraform HCL input shapes matching AWS provider >= 5
+# (encryption and versioning as separate resources, correlated by bucket name)
 
-make_input(bucket_name, extra_attrs, enc_algo, versioning_status) := input if {
-	enc_algo != null
-	versioning_status == null
-	input := {
-		"resource": {
-			"aws_s3_bucket": {bucket_name: object.union({"bucket": bucket_name}, extra_attrs)},
-			"aws_s3_bucket_server_side_encryption_configuration": {"enc": {
-				"bucket": bucket_name,
-				"rule": [{"apply_server_side_encryption_by_default": {"sse_algorithm": enc_algo}}],
-			}},
-		},
-	}
-}
+make_input_full(bucket_name, extra_attrs, enc_algo, versioning_status) := {"resource": {
+	"aws_s3_bucket": {bucket_name: object.union({"bucket": bucket_name}, extra_attrs)},
+	"aws_s3_bucket_server_side_encryption_configuration": {"enc": {
+		"bucket": bucket_name,
+		"rule": [{"apply_server_side_encryption_by_default": {"sse_algorithm": enc_algo}}],
+	}},
+	"aws_s3_bucket_versioning": {"ver": {
+		"bucket": bucket_name,
+		"versioning_configuration": [{"status": versioning_status}],
+	}},
+}}
 
-make_input(bucket_name, extra_attrs, enc_algo, versioning_status) := input if {
-	enc_algo == null
-	input := {"resource": {"aws_s3_bucket": {bucket_name: object.union({"bucket": bucket_name}, extra_attrs)}}}
-}
+make_input_enc_only(bucket_name, extra_attrs, enc_algo) := {"resource": {
+	"aws_s3_bucket": {bucket_name: object.union({"bucket": bucket_name}, extra_attrs)},
+	"aws_s3_bucket_server_side_encryption_configuration": {"enc": {
+		"bucket": bucket_name,
+		"rule": [{"apply_server_side_encryption_by_default": {"sse_algorithm": enc_algo}}],
+	}},
+}}
+
+make_input_no_enc(bucket_name, extra_attrs) := {"resource": {"aws_s3_bucket": {bucket_name: object.union({"bucket": bucket_name}, extra_attrs)}}}

--- a/examples/opa/conftest/policies/deny_unencrypted_s3_test.rego
+++ b/examples/opa/conftest/policies/deny_unencrypted_s3_test.rego
@@ -1,0 +1,54 @@
+# METADATA
+# title: Tests for S3 bucket encryption policy
+package terraform.s3_test
+
+import data.terraform.s3
+import rego.v1
+
+# --- deny: missing encryption ---
+
+test_deny_missing_encryption if {
+	count(s3.deny) == 1 with input as make_bucket("my-bucket", {})
+}
+
+test_allow_with_encryption if {
+	count(s3.deny) == 0 with input as make_bucket("my-bucket", {
+		"server_side_encryption_configuration": {"rule": {"apply_server_side_encryption_by_default": {"sse_algorithm": "aws:kms"}}},
+		"acl": "private",
+	})
+}
+
+# --- deny: public ACL ---
+
+test_deny_public_read_acl if {
+	count(s3.deny) > 0 with input as make_bucket("my-bucket", {
+		"server_side_encryption_configuration": {"rule": {}},
+		"acl": "public-read",
+	})
+}
+
+test_deny_public_read_write_acl if {
+	count(s3.deny) > 0 with input as make_bucket("my-bucket", {
+		"server_side_encryption_configuration": {"rule": {}},
+		"acl": "public-read-write",
+	})
+}
+
+test_allow_private_acl if {
+	count(s3.deny) == 0 with input as make_bucket("my-bucket", {
+		"server_side_encryption_configuration": {"rule": {}},
+		"acl": "private",
+	})
+}
+
+# --- warn: missing versioning ---
+
+test_warn_missing_versioning if {
+	count(s3.warn) > 0 with input as make_bucket("my-bucket", {
+		"server_side_encryption_configuration": {"rule": {}},
+		"acl": "private",
+	})
+}
+
+# Helper: build a minimal S3 bucket input
+make_bucket(name, attrs) := {"resource": {"aws_s3_bucket": {name: attrs}}}

--- a/examples/opa/conftest/policies/deny_unencrypted_s3_test.rego
+++ b/examples/opa/conftest/policies/deny_unencrypted_s3_test.rego
@@ -5,50 +5,106 @@ package terraform.s3_test
 import data.terraform.s3
 import rego.v1
 
-# --- deny: missing encryption ---
+# --- deny: missing encryption resource ---
 
 test_deny_missing_encryption if {
-	count(s3.deny) == 1 with input as make_bucket("my-bucket", {})
+	count(s3.deny) == 1 with input as make_input("my-bucket", {}, null, null)
 }
 
-test_allow_with_encryption if {
-	count(s3.deny) == 0 with input as make_bucket("my-bucket", {
-		"server_side_encryption_configuration": {"rule": {"apply_server_side_encryption_by_default": {"sse_algorithm": "aws:kms"}}},
-		"acl": "private",
-	})
+test_allow_with_encryption_resource if {
+	count(s3.deny) == 0 with input as make_input(
+		"my-bucket",
+		{"acl": "private"},
+		{"sse_algorithm": "aws:kms"},
+		"Enabled",
+	)
 }
 
 # --- deny: public ACL ---
 
 test_deny_public_read_acl if {
-	count(s3.deny) > 0 with input as make_bucket("my-bucket", {
-		"server_side_encryption_configuration": {"rule": {}},
-		"acl": "public-read",
-	})
+	count(s3.deny) > 0 with input as make_input(
+		"my-bucket",
+		{"acl": "public-read"},
+		{"sse_algorithm": "aws:kms"},
+		"Enabled",
+	)
 }
 
 test_deny_public_read_write_acl if {
-	count(s3.deny) > 0 with input as make_bucket("my-bucket", {
-		"server_side_encryption_configuration": {"rule": {}},
-		"acl": "public-read-write",
-	})
+	count(s3.deny) > 0 with input as make_input(
+		"my-bucket",
+		{"acl": "public-read-write"},
+		{"sse_algorithm": "aws:kms"},
+		"Enabled",
+	)
 }
 
 test_allow_private_acl if {
-	count(s3.deny) == 0 with input as make_bucket("my-bucket", {
-		"server_side_encryption_configuration": {"rule": {}},
-		"acl": "private",
-	})
+	count(s3.deny) == 0 with input as make_input(
+		"my-bucket",
+		{"acl": "private"},
+		{"sse_algorithm": "aws:kms"},
+		"Enabled",
+	)
 }
 
-# --- warn: missing versioning ---
+# --- warn: missing versioning resource ---
 
 test_warn_missing_versioning if {
-	count(s3.warn) > 0 with input as make_bucket("my-bucket", {
-		"server_side_encryption_configuration": {"rule": {}},
-		"acl": "private",
-	})
+	count(s3.warn) > 0 with input as make_input(
+		"my-bucket",
+		{"acl": "private"},
+		{"sse_algorithm": "aws:kms"},
+		null,
+	)
 }
 
-# Helper: build a minimal S3 bucket input
-make_bucket(name, attrs) := {"resource": {"aws_s3_bucket": {name: attrs}}}
+test_no_warn_with_versioning if {
+	count(s3.warn) == 0 with input as make_input(
+		"my-bucket",
+		{"acl": "private"},
+		{"sse_algorithm": "aws:kms"},
+		"Enabled",
+	)
+}
+
+# Helper: build a Terraform HCL input shape matching AWS provider >= 5.
+# enc_algo: SSE algorithm string (e.g. "aws:kms") or null to omit the resource.
+# versioning_status: "Enabled"/"Suspended" or null to omit the resource.
+make_input(bucket_name, extra_attrs, enc_algo, versioning_status) := input if {
+	enc_algo != null
+	versioning_status != null
+	input := {
+		"resource": {
+			"aws_s3_bucket": {bucket_name: object.union({"bucket": bucket_name}, extra_attrs)},
+			"aws_s3_bucket_server_side_encryption_configuration": {"enc": {
+				"bucket": bucket_name,
+				"rule": [{"apply_server_side_encryption_by_default": {"sse_algorithm": enc_algo}}],
+			}},
+			"aws_s3_bucket_versioning": {"ver": {
+				"bucket": bucket_name,
+				"versioning_configuration": [{"status": versioning_status}],
+			}},
+		},
+	}
+}
+
+make_input(bucket_name, extra_attrs, enc_algo, versioning_status) := input if {
+	enc_algo != null
+	versioning_status == null
+	input := {
+		"resource": {
+			"aws_s3_bucket": {bucket_name: object.union({"bucket": bucket_name}, extra_attrs)},
+			"aws_s3_bucket_server_side_encryption_configuration": {"enc": {
+				"bucket": bucket_name,
+				"rule": [{"apply_server_side_encryption_by_default": {"sse_algorithm": enc_algo}}],
+			}},
+		},
+	}
+}
+
+make_input(bucket_name, extra_attrs, enc_algo, versioning_status) := input if {
+	enc_algo == null
+	input := {"resource": {"aws_s3_bucket": {bucket_name: object.union({"bucket": bucket_name}, extra_attrs)}}}
+}

--- a/examples/opa/conftest/tests/main.tf
+++ b/examples/opa/conftest/tests/main.tf
@@ -1,0 +1,19 @@
+resource "aws_s3_bucket" "good_bucket" {
+  bucket = "my-app-data-encrypted"
+  acl    = "private"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm     = "aws:kms"
+        kms_master_key_id = "arn:aws:kms:eu-central-1:123456789012:key/abc"
+      }
+    }
+  }
+}
+
+# This bucket should trigger deny rules
+resource "aws_s3_bucket" "bad_bucket" {
+  bucket = "my-public-data"
+  acl    = "public-read"
+}

--- a/examples/opa/conftest/tests/main.tf
+++ b/examples/opa/conftest/tests/main.tf
@@ -1,18 +1,27 @@
 resource "aws_s3_bucket" "good_bucket" {
   bucket = "my-app-data-encrypted"
-  acl    = "private"
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm     = "aws:kms"
-        kms_master_key_id = "arn:aws:kms:eu-central-1:123456789012:key/abc"
-      }
+resource "aws_s3_bucket_server_side_encryption_configuration" "good_bucket" {
+  bucket = "my-app-data-encrypted"
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = "arn:aws:kms:eu-central-1:123456789012:key/abc"
     }
   }
 }
 
-# This bucket should trigger deny rules
+resource "aws_s3_bucket_versioning" "good_bucket" {
+  bucket = "my-app-data-encrypted"
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# This bucket should trigger deny rules — no encryption resource, public ACL
 resource "aws_s3_bucket" "bad_bucket" {
   bucket = "my-public-data"
   acl    = "public-read"

--- a/examples/openshift/README.md
+++ b/examples/openshift/README.md
@@ -1,41 +1,79 @@
+Status: Stable
+
 # OpenShift Examples
 
-Manifests for adapting workloads and platform components to Red Hat OpenShift constraints.
+Manifests for adapting workloads and platform components to Red Hat OpenShift constraints — Routes, tenant isolation, and SCC-compatible security contexts.
 
-Status: committed manifest snippets for the handbook. They illustrate OpenShift-specific adaptations rather than a complete standalone repo.
+## Examples
 
-## Files
+| File | What it shows | Key patterns |
+|------|--------------|-------------|
+| [route.yaml](route.yaml) | OpenShift Route with edge TLS termination and HTTP→HTTPS redirect | `tls.termination: edge`, `insecureEdgeTerminationPolicy: Redirect` |
+| [resource-quota.yaml](resource-quota.yaml) | ResourceQuota and LimitRange for tenant namespace isolation | CPU/memory bounds, object count limits, default container limits |
 
-| File | What it shows |
-|---|---|
-| [route.yaml](route.yaml) | OpenShift Route with edge TLS termination and HTTP redirect |
-| [resource-quota.yaml](resource-quota.yaml) | ResourceQuota and LimitRange for tenant namespace isolation |
-
-## Usage
+## Quick Start
 
 ```bash
-oc apply -f route.yaml
+# Apply tenant isolation (quota before workloads land)
 oc apply -f resource-quota.yaml
+
+# Expose a service via Route
+oc apply -f route.yaml
+
+# Verify quota usage
+oc describe quota -n <namespace>
+
+# Verify route is serving
+oc get route -n <namespace>
+curl -I https://$(oc get route my-app -n <namespace> -o jsonpath='{.spec.host}')
 ```
 
-## OpenShift Security Compatibility
+## SCC Compatibility
 
-OpenShift enforces restricted execution by default. Every container spec must pass SCC validation:
+OpenShift enforces Security Context Constraints (SCC). Every container must pass the `restricted` SCC by default:
 
 ```yaml
+# ✅ Works with OpenShift restricted SCC
 securityContext:
-  runAsNonRoot: true
+  runAsNonRoot: true          # Do NOT set runAsUser to a specific UID — OpenShift assigns one
   allowPrivilegeEscalation: false
   capabilities:
-    drop:
-      - ALL
+    drop: ["ALL"]
 ```
 
-See [examples/kubernetes/deployment-baseline.yaml](../kubernetes/deployment-baseline.yaml) for a full deployment with this applied.
+```yaml
+# ❌ Will fail OpenShift SCC validation
+securityContext:
+  runAsUser: 1000             # Specific UID not allowed under restricted SCC
+```
+
+## Route TLS Termination Modes
+
+| Mode | Where TLS terminates | Use when |
+|------|---------------------|----------|
+| `edge` | At the router | Default; backend receives plain HTTP |
+| `passthrough` | At the pod | mTLS required to the pod |
+| `reencrypt` | At router and re-encrypted to pod | Compliance requirement for in-cluster encryption |
+
+## Tenant Isolation Pattern
+
+Each team namespace gets:
+1. `ResourceQuota` — caps total CPU, memory, and object counts
+2. `LimitRange` — sets default requests/limits so pods without explicit values still have bounds
+3. `NetworkPolicy` — default-deny; see [kubernetes/network-policy-default-deny.yaml](../kubernetes/network-policy-default-deny.yaml)
+4. RBAC — team `edit` role on their own namespace, no cross-namespace access
 
 ## Checklist
 
-- Workloads pass OpenShift SCC defaults (no root, no privilege escalation, no host ports)
-- Routes use the correct hostname and TLS termination model
-- Operator-managed platform services are separated from application namespaces
-- Tenant projects have explicit RBAC, quotas, and limit ranges
+- [ ] Containers pass `restricted` SCC: no specific `runAsUser`, no host ports, capabilities dropped
+- [ ] Routes use correct TLS termination mode for the trust model
+- [ ] Routes have `insecureEdgeTerminationPolicy: Redirect` to prevent plain HTTP access
+- [ ] Each tenant namespace has ResourceQuota, LimitRange, and NetworkPolicy
+- [ ] Operator-managed platform services are in separate namespaces from application workloads
+- [ ] Platform operators installed via OLM with explicit channel and approval strategy
+
+## See Also
+
+- [references/openshift.md](../../references/openshift.md) — SCC-aware workload design, Routes, operators, tenancy patterns
+- [examples/kubernetes/](../kubernetes/) — base Kubernetes patterns that OpenShift also supports
+- `/platform-skills:debug` — structured diagnosis for OpenShift issues

--- a/references/opa.md
+++ b/references/opa.md
@@ -1,0 +1,527 @@
+# OPA / Conftest Reference
+
+Covers Rego v1 syntax, rule types, package namespacing, input shapes, unit testing, Conftest CLI, Regal linting, formatting, GitHub Actions integration, and troubleshooting.
+
+---
+
+## Rego v1 Syntax
+
+Always include `import rego.v1` at the top of every policy file. This enables modern syntax (`if`, `contains`, `in`, `every`) and disables Rego v0 quirks.
+
+```rego
+# METADATA
+# title: Deny public S3 buckets
+# description: S3 buckets must not be publicly accessible
+# authors:
+# - Platform Team <platform@example.com>
+# entrypoint: true
+package terraform.s3
+
+import rego.v1
+```
+
+### Core constructs
+
+```rego
+# Iteration with some
+deny contains msg if {
+    some resource_name
+    resource := input.resource.aws_s3_bucket[resource_name]
+    resource.acl == "public-read"
+    msg := sprintf("S3 bucket '%s' must not have public-read ACL", [resource_name])
+}
+
+# Set membership with in
+allowed_regions := {"eu-central-1", "eu-west-1"}
+
+deny contains msg if {
+    some name
+    resource := input.resource.aws_instance[name]
+    not resource.availability_zone in allowed_regions
+    msg := sprintf("EC2 instance '%s' must be in an allowed region", [name])
+}
+
+# String helpers
+deny contains msg if {
+    some name
+    image := input.resource.aws_ecr_repository[name]
+    not startswith(image.name, "prod-")
+    msg := sprintf("ECR repository '%s' name must start with 'prod-'", [name])
+}
+
+# Negation — not
+deny contains msg if {
+    some name
+    bucket := input.resource.aws_s3_bucket[name]
+    not bucket.server_side_encryption_configuration
+    msg := sprintf("S3 bucket '%s' must have server-side encryption enabled", [name])
+}
+
+# every — all elements must satisfy condition
+deny contains msg if {
+    some name
+    group := input.resource.aws_security_group[name]
+    some rule in group.ingress
+    rule.from_port == 0
+    rule.to_port == 65535
+    msg := sprintf("Security group '%s' has an overly permissive ingress rule", [name])
+}
+```
+
+---
+
+## Rule Types
+
+| Rule | Conftest behaviour | When to use |
+|------|--------------------|-------------|
+| `deny` | Fails the check (exit code 1) | Hard requirements — must not be violated |
+| `warn` | Prints warning but passes | Advisory — should be fixed but not blocking |
+| `violation` | Fails (used by Gatekeeper / OPA policy sets) | Framework integrations |
+
+Rules must be named starting with `deny`, `warn`, or `violation` — Conftest silently ignores any other rule name.
+
+Use set comprehensions (`deny contains msg if { ... }`) rather than booleans so Conftest can report the message string.
+
+---
+
+## METADATA Block
+
+Every policy file should have a METADATA block immediately before the package declaration:
+
+```rego
+# METADATA
+# title: Short human-readable title
+# description: One-sentence description of what this policy enforces
+# authors:
+# - Team Name <email@example.com>
+# organizations:
+# - Your Org
+# entrypoint: true
+package my.namespace
+```
+
+`entrypoint: true` is required for Conftest to discover the policy.
+
+---
+
+## Package Namespacing
+
+- `package main` — default namespace; used when running `conftest test` without `--namespace`
+- Named packages — use for multi-domain repos to avoid collisions
+
+```rego
+package terraform.iam      # --namespace terraform.iam
+package k8s.pods           # --namespace k8s.pods
+package github.repository  # --namespace github.repository
+```
+
+Run a specific namespace:
+```bash
+conftest test --policy ./policies --namespace terraform.iam plan.json
+```
+
+Run all namespaces:
+```bash
+conftest test --policy ./policies --all-namespaces plan.json
+```
+
+---
+
+## Input Shape
+
+Conftest parses config files into a JSON input object. The shape depends on the file type.
+
+### Terraform HCL
+
+```hcl
+# main.tf
+resource "aws_s3_bucket" "my_bucket" {
+  bucket = "my-app-data"
+  acl    = "private"
+}
+```
+
+Parsed as:
+```json
+{
+  "resource": {
+    "aws_s3_bucket": {
+      "my_bucket": {
+        "bucket": "my-app-data",
+        "acl": "private"
+      }
+    }
+  }
+}
+```
+
+Access in Rego:
+```rego
+input.resource.aws_s3_bucket[name].acl
+```
+
+### Terraform Plan JSON
+
+```bash
+terraform plan -out=tfplan.binary
+terraform show -json tfplan.binary > tfplan.json
+conftest test --policy ./policies tfplan.json
+```
+
+The plan JSON has a different shape — use `input.resource_changes[_]`:
+```rego
+deny contains msg if {
+    some change in input.resource_changes
+    change.type == "aws_s3_bucket"
+    change.change.after.acl == "public-read"
+    msg := sprintf("S3 bucket '%s' must not have public-read ACL", [change.name])
+}
+```
+
+### Kubernetes YAML
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: my-app:latest
+```
+
+Parsed as:
+```json
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": { "name": "my-app" },
+  "spec": {
+    "template": {
+      "spec": {
+        "containers": [{ "name": "app", "image": "my-app:latest" }]
+      }
+    }
+  }
+}
+```
+
+### Inspect actual input
+
+Always check the actual parsed input before writing rules:
+
+```bash
+conftest parse main.tf
+conftest parse deployment.yaml
+conftest parse tfplan.json
+```
+
+---
+
+## Writing Policies
+
+### Full example — Terraform IAM policy
+
+```rego
+# METADATA
+# title: IAM policy least privilege
+# description: IAM policies must not use wildcard actions or resources
+# authors:
+# - Platform Team <platform@example.com>
+# entrypoint: true
+package terraform.iam
+
+import rego.v1
+
+deny contains msg if {
+    some name
+    policy := input.resource.aws_iam_policy[name]
+    some statement in policy.policy.Statement
+    statement.Effect == "Allow"
+    statement.Action == "*"
+    msg := sprintf("IAM policy '%s' must not use wildcard Action '*'", [name])
+}
+
+deny contains msg if {
+    some name
+    policy := input.resource.aws_iam_policy[name]
+    some statement in policy.policy.Statement
+    statement.Effect == "Allow"
+    statement.Resource == "*"
+    statement.Action != "*"
+    msg := sprintf("IAM policy '%s' must not use wildcard Resource '*'", [name])
+}
+
+warn contains msg if {
+    some name
+    role := input.resource.aws_iam_role[name]
+    not role.description
+    msg := sprintf("IAM role '%s' should have a description", [name])
+}
+```
+
+### Full example — Kubernetes pod security
+
+```rego
+# METADATA
+# title: Pod security baseline
+# description: Pods must run as non-root with read-only root filesystem
+# authors:
+# - Platform Team <platform@example.com>
+# entrypoint: true
+package k8s.pods
+
+import rego.v1
+
+deny contains msg if {
+    input.kind == "Deployment"
+    some container in input.spec.template.spec.containers
+    not container.securityContext.runAsNonRoot
+    msg := sprintf("Container '%s' must set runAsNonRoot: true", [container.name])
+}
+
+deny contains msg if {
+    input.kind == "Deployment"
+    some container in input.spec.template.spec.containers
+    not container.securityContext.readOnlyRootFilesystem
+    msg := sprintf("Container '%s' must set readOnlyRootFilesystem: true", [container.name])
+}
+
+deny contains msg if {
+    input.kind == "Deployment"
+    some container in input.spec.template.spec.containers
+    container.image == _
+    endswith(container.image, ":latest")
+    msg := sprintf("Container '%s' must not use ':latest' image tag", [container.name])
+}
+```
+
+---
+
+## Unit Tests
+
+Test files must be named `<policy>_test.rego` and placed in the same directory.
+
+```rego
+# METADATA
+# title: Tests for IAM policy least privilege
+package terraform.iam_test
+
+import data.terraform.iam
+import rego.v1
+
+# --- deny wildcard action ---
+
+test_deny_wildcard_action if {
+    input := {
+        "resource": {
+            "aws_iam_policy": {
+                "my_policy": {
+                    "policy": {
+                        "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "arn:aws:s3:::*"}]
+                    }
+                }
+            }
+        }
+    }
+    count(iam.deny) == 1 with input as input
+}
+
+test_allow_scoped_action if {
+    input := {
+        "resource": {
+            "aws_iam_policy": {
+                "my_policy": {
+                    "policy": {
+                        "Statement": [{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "arn:aws:s3:::my-bucket/*"}]
+                    }
+                }
+            }
+        }
+    }
+    count(iam.deny) == 0 with input as input
+}
+
+# Helper function for building fixtures
+make_policy(action, resource) := {
+    "resource": {
+        "aws_iam_policy": {
+            "test_policy": {
+                "policy": {
+                    "Statement": [{"Effect": "Allow", "Action": action, "Resource": resource}]
+                }
+            }
+        }
+    }
+}
+
+test_deny_wildcard_resource if {
+    count(iam.deny) == 1 with input as make_policy("s3:GetObject", "*")
+}
+```
+
+Run tests:
+```bash
+conftest verify --policy ./policies
+```
+
+---
+
+## Validation Pipeline
+
+Run these in order — fix each before proceeding to the next.
+
+### 1. Format check
+
+```bash
+# Check — non-zero exit if any file is unformatted
+conftest fmt ./policies/*.rego --check
+
+# Auto-fix — rewrites files in place
+conftest fmt ./policies/*.rego
+```
+
+### 2. Regal lint
+
+```bash
+# Install
+brew install styrainc/packages/regal   # macOS
+# or
+curl -L -o regal "https://github.com/StyraInc/regal/releases/latest/download/regal_$(uname -s)_$(uname -m)"
+chmod +x regal && sudo mv regal /usr/local/bin/
+
+# Lint all .rego files
+regal lint ./policies
+```
+
+Configure Regal with `.regal/config.yaml`:
+
+```yaml
+# .regal/config.yaml
+rules:
+  idiomatic:
+    no-defined-entrypoint:
+      level: error
+  style:
+    line-length:
+      level: warning
+      max-line-length: 120
+    prefer-snake-case:
+      level: warning
+  bugs:
+    rule-named-if:
+      level: error
+    unused-variable:
+      level: error
+```
+
+### 3. Unit tests
+
+```bash
+conftest verify --policy ./policies
+```
+
+### 4. Integration test against real input
+
+```bash
+# HCL files
+conftest test --policy ./policies ./terraform/*.tf
+
+# Terraform plan
+conftest test --policy ./policies ./tfplan.json
+
+# Kubernetes manifests
+conftest test --policy ./policies ./k8s/*.yaml --all-namespaces
+
+# From a remote git repo (pulls policies then tests)
+conftest test \
+  --update "git::https://github.com/your-org/opa-policies.git//terraform" \
+  --all-namespaces \
+  ./terraform/*.tf
+```
+
+---
+
+## GitHub Actions Integration
+
+```yaml
+name: Policy validation
+
+on:
+  pull_request:
+
+jobs:
+  opa:
+    name: OPA / Conftest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+
+      - name: Install Conftest
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/open-policy-agent/conftest/releases/latest | jq -r .tag_name)
+          curl -Lo conftest.tar.gz "https://github.com/open-policy-agent/conftest/releases/download/${VERSION}/conftest_${VERSION#v}_Linux_x86_64.tar.gz"
+          tar xzf conftest.tar.gz conftest
+          sudo mv conftest /usr/local/bin/
+
+      - name: Install Regal
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/StyraInc/regal/releases/latest | jq -r .tag_name)
+          curl -Lo regal "https://github.com/StyraInc/regal/releases/download/${VERSION}/regal_Linux_x86_64"
+          chmod +x regal && sudo mv regal /usr/local/bin/
+
+      - name: Check formatting
+        run: conftest fmt ./policies --check
+
+      - name: Lint with Regal
+        run: regal lint ./policies
+
+      - name: Run unit tests
+        run: conftest verify --policy ./policies
+
+      - name: Run integration tests
+        run: conftest test --policy ./policies --all-namespaces ./tests/**/*.tf ./tests/**/*.yaml
+```
+
+---
+
+## Shared Data (allow-lists)
+
+Use `data.*` for allow-lists shared across policies — store in a JSON or YAML file alongside the policies.
+
+```json
+// policies/data/allowed_regions.json
+{
+  "allowed_regions": ["eu-central-1", "eu-west-1", "us-east-1"]
+}
+```
+
+```rego
+import rego.v1
+
+deny contains msg if {
+    some name
+    instance := input.resource.aws_instance[name]
+    not instance.region in data.allowed_regions
+    msg := sprintf("Instance '%s' is not in an allowed region", [name])
+}
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Policy produces no output, input matches | Rule not named `deny`/`warn`/`violation` | Rename rule to start with `deny`, `warn`, or `violation` |
+| `conftest test` passes but shouldn't | Namespace mismatch | Run with `--all-namespaces` or add `--namespace <package>` |
+| `undefined ref: input.X` | Input shape wrong | Run `conftest parse <file>` and check actual field path |
+| Rule fires on everything | Missing `some` for iteration | Add `some <name>` before iterating over `input.resource[name]` |
+| `import rego.v1` causes error | Old Conftest version | Upgrade to Conftest >= 0.46.0 |
+| `conftest verify` finds no tests | Test file not `_test.rego` | Rename to `<policy>_test.rego` |
+| Regal: `no-defined-entrypoint` | Missing `# entrypoint: true` in METADATA | Add METADATA block with `entrypoint: true` |
+| Boolean rule always true/false | Using boolean instead of set comprehension | Change `deny if { ... }` to `deny contains msg if { ... msg := "..." }` |
+| `conftest fmt --check` fails | File not canonically formatted | Run `conftest fmt ./policies/*.rego` to auto-fix |

--- a/references/opa.md
+++ b/references/opa.md
@@ -37,7 +37,7 @@ allowed_regions := {"eu-central-1", "eu-west-1"}
 deny contains msg if {
     some name
     resource := input.resource.aws_instance[name]
-    not resource.availability_zone in allowed_regions
+    not resource.region in allowed_regions
     msg := sprintf("EC2 instance '%s' must be in an allowed region", [name])
 }
 
@@ -49,15 +49,21 @@ deny contains msg if {
     msg := sprintf("ECR repository '%s' name must start with 'prod-'", [name])
 }
 
-# Negation — not
+# Negation — not (AWS provider >= 5: encryption is a separate resource)
 deny contains msg if {
     some name
-    bucket := input.resource.aws_s3_bucket[name]
-    not bucket.server_side_encryption_configuration
-    msg := sprintf("S3 bucket '%s' must have server-side encryption enabled", [name])
+    _ = input.resource.aws_s3_bucket[name]
+    not _has_enc_resource(name)
+    msg := sprintf("S3 bucket '%s' must have an aws_s3_bucket_server_side_encryption_configuration resource", [name])
 }
 
-# every — all elements must satisfy condition
+_has_enc_resource(bucket_name) if {
+    some enc_name
+    enc := input.resource.aws_s3_bucket_server_side_encryption_configuration[enc_name]
+    enc.bucket == bucket_name
+}
+
+# Existential check — deny if any ingress rule is fully open
 deny contains msg if {
     some name
     group := input.resource.aws_security_group[name]
@@ -100,7 +106,7 @@ Every policy file should have a METADATA block immediately before the package de
 package my.namespace
 ```
 
-`entrypoint: true` is required for Conftest to discover the policy.
+`entrypoint: true` marks the package as an OPA bundle entrypoint for tools like `opa build` and Regal's `no-defined-entrypoint` rule. Conftest discovers policies by package name and rule names (`deny`/`warn`/`violation`) — not by this flag. Include it for lint compliance and bundle compatibility.
 
 ---
 

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -29,6 +29,7 @@ Match the task to the right layer:
 16. `Datadog`: Deploy and configure the Datadog Agent on Kubernetes, instrument services with APM and log correlation, write monitors, dashboards, SLOs, and synthetic tests — all as Terraform-managed resources.
 17. `Dynatrace`: Deploy OneAgent via the Kubernetes Operator with automatic injection, configure anomaly detection, ingest custom metrics, define SLOs, and manage dashboards and alerting profiles with the Dynatrace Terraform provider.
 18. `Conventional Commits`: Analyze git diffs, generate commit messages that explain WHY a change was made, intelligently stage files for atomic commits, and validate messages against the Conventional Commits specification.
+19. `OPA / Conftest`: Generate Rego policies with correct rule types and namespacing, write unit tests, run the full validation pipeline (fmt → regal lint → conftest verify → integration test), explain existing policies, and debug why a rule is not firing.
 
 If a task spans multiple areas, decide which layer owns the source of truth and keep the other layers consumers of that state.
 
@@ -82,6 +83,7 @@ When asked to generate code, start from the thinnest useful slice that proves th
 - For Datadog Agent setup, APM, log management, monitors, dashboards, SLOs, and synthetic tests — read [references/datadog.md](references/datadog.md).
 - For Dynatrace OneAgent Operator, auto-instrumentation, custom metrics, SLOs, anomaly detection, and Terraform provider — read [references/dynatrace.md](references/dynatrace.md).
 - For Conventional Commits — type classification, scope rules, breaking changes, message structure, atomic commits, commitlint, husky, semantic-release, and validation rules — read [references/conventional-commits.md](references/conventional-commits.md).
+- For OPA / Conftest — Rego v1 syntax, rule types, package namespacing, input shapes, unit tests, validation pipeline (fmt/regal/verify), GitHub Actions integration, and troubleshooting — read [references/opa.md](references/opa.md).
 
 Load only the files needed for the current request.
 
@@ -104,3 +106,4 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:datadog` — Datadog Agent setup, APM instrumentation, monitors, dashboards, SLOs, and debugging
 - `/platform-skills:dynatrace` — OneAgent deployment, instrumentation, anomaly detection, SLOs, and debugging
 - `/platform-skills:commit` — analyze diff, generate conventional commit message, stage files atomically, validate message
+- `/platform-skills:opa` — generate Rego policies, write unit tests, run fmt/regal/verify pipeline, explain or debug policies

--- a/tests/validate-helmcheck.sh
+++ b/tests/validate-helmcheck.sh
@@ -322,7 +322,7 @@ else
   fail "$HOW missing"
 fi
 
-for cmd in "helmcheck" "review" "terraform" "debug" "gitops" "compliance" "product" "mcp" "observability" "document" "datadog" "dynatrace" "commit"; do
+for cmd in "helmcheck" "review" "terraform" "debug" "gitops" "compliance" "product" "mcp" "observability" "document" "datadog" "dynatrace" "commit" "opa"; do
   if grep -q "platform-skills:$cmd" "$HOW"; then
     pass "$HOW references /platform-skills:$cmd"
   else

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -53,6 +53,7 @@ REQUIRED_REFERENCES=(
   references/datadog.md
   references/dynatrace.md
   references/conventional-commits.md
+  references/opa.md
 )
 
 for ref in "${REQUIRED_REFERENCES[@]}"; do
@@ -83,6 +84,7 @@ EXAMPLE_DOMAINS=(
   examples/datadog
   examples/dynatrace
   examples/conventional-commits
+  examples/opa
 )
 
 for domain in "${EXAMPLE_DOMAINS[@]}"; do


### PR DESCRIPTION
## Summary

- Adds Domain 19: **OPA / Conftest** — generate Rego policies, write unit tests, run the full `fmt → regal lint → conftest verify → integration test` pipeline, explain policies in plain English, and debug why a rule is not firing
- New `/platform-skills:opa` slash command with five modes: `generate`, `test`, `validate`, `explain`, `debug`
- Full reference guide: Rego v1 syntax, METADATA blocks, rule types, namespacing, input shape analysis, validation pipeline, GitHub Actions CI, shared data allow-lists, troubleshooting
- Working example: `examples/opa/conftest/` — S3 encryption policy, full unit test suite, sample Terraform input, `.regal/config.yaml`
- Restored `.github/copilot-instructions.md` (was accidentally deleted in a rebase) with all domain sections plus new OPA section
- Version bumped to `1.10.0`

## Test plan

- [ ] CI validate workflow passes
- [ ] `tests/validate-skill.sh`: `references/opa.md` and `examples/opa` present
- [ ] `tests/validate-helmcheck.sh`: `opa` in HOW_IT_WORKS completeness check
- [ ] `plugin.json` version is `1.10.0`
- [ ] `marketplace.json` version is `1.10.0`