### PR TITLE
docs: add COMMANDS.md — user guide for all 16 skill commands

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,0 +1,457 @@
+# Skill Commands — Usage Guide
+
+This guide shows how to invoke each `/platform-skills:<command>` slash command in Claude Code or the Claude desktop app.
+
+## Prerequisites
+
+Install the plugin once:
+
+```bash
+claude plugin install platform-skills
+```
+
+Then restart Claude Code. All commands below work in any conversation.
+
+---
+
+## Command Reference
+
+### `/platform-skills:review`
+
+Production-readiness review of any platform config — Kubernetes manifests, Terraform, GitHub Actions workflows, Helm values.
+
+```
+/platform-skills:review [paste file content or describe what to review]
+```
+
+**Examples:**
+
+```
+/platform-skills:review
+```
+*(paste a manifest — Claude will classify findings as Critical / Improvement / Note)*
+
+```
+/platform-skills:review check my HPA configuration for correctness
+```
+
+```
+/platform-skills:review
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orders-service
+...
+```
+
+---
+
+### `/platform-skills:debug`
+
+Structured troubleshooting for any platform symptom. Classifies the problem layer, proposes evidence to collect, forms a root-cause hypothesis, and suggests a fix with rollback steps.
+
+```
+/platform-skills:debug [symptom or error message]
+```
+
+**Examples:**
+
+```
+/platform-skills:debug Flux kustomization stuck in NotReady, error: "context deadline exceeded"
+```
+
+```
+/platform-skills:debug pod CrashLoopBackOff: OOMKilled, limits 256Mi
+```
+
+```
+/platform-skills:debug 503 errors spiked after deploying v2, Linkerd retries not helping
+```
+
+---
+
+### `/platform-skills:terraform`
+
+Full Terraform validation pipeline — fmt, validate, tflint, security scan — plus blast radius and IAM risk review.
+
+```
+/platform-skills:terraform [paste terraform code, plan output, or describe the change]
+```
+
+**Examples:**
+
+```
+/platform-skills:terraform review this IAM policy for least-privilege violations
+```
+
+```
+/platform-skills:terraform
+resource "aws_iam_role_policy" "app" {
+  policy = jsonencode({ Statement = [{ Effect = "Allow", Action = "*", Resource = "*" }] })
+}
+```
+
+```
+/platform-skills:terraform what is the blast radius of deleting this module?
+```
+
+---
+
+### `/platform-skills:gitops`
+
+Flux CD and Argo CD reconciliation troubleshooting — source, artifact, reconciliation, chart rendering, and runtime workload issues.
+
+```
+/platform-skills:gitops [describe the GitOps symptom, paste flux/argocd output, or share a manifest]
+```
+
+**Examples:**
+
+```
+/platform-skills:gitops flux get kustomizations shows "dependency not found"
+```
+
+```
+/platform-skills:gitops ArgoCD app stuck in OutOfSync despite manual sync
+```
+
+```
+/platform-skills:gitops HelmRelease is failing with "values don't match schema"
+```
+
+---
+
+### `/platform-skills:linkerd`
+
+Linkerd mTLS, injection, policy, and multi-cluster diagnostics.
+
+```
+/platform-skills:linkerd [describe the Linkerd symptom or paste linkerd check / viz output]
+```
+
+**Examples:**
+
+```
+/platform-skills:linkerd pod injection not working after adding annotation
+```
+
+```
+/platform-skills:linkerd mTLS handshake failures between orders-service and payments-service
+```
+
+```
+/platform-skills:linkerd how do I set up AuthorizationPolicy for internal traffic only?
+```
+
+---
+
+### `/platform-skills:linux`
+
+Linux administration, DNS, load balancing, VPC/VNet networking, and connectivity troubleshooting.
+
+```
+/platform-skills:linux [topic: dns | lb | vpc | process | disk | network | security-groups | troubleshoot]
+```
+
+**Examples:**
+
+```
+/platform-skills:linux dns pod cannot resolve service.namespace.svc.cluster.local
+```
+
+```
+/platform-skills:linux network packets dropped between node and pod, no obvious route
+```
+
+```
+/platform-skills:linux security-groups inbound rule allowing 0.0.0.0/0 on port 22
+```
+
+---
+
+### `/platform-skills:commit`
+
+Generate conventional commit messages from a staged diff or description. Supports message generation, file staging, and spec validation.
+
+```
+/platform-skills:commit [analyze|generate|stage|validate] [optional: type/scope override or description]
+```
+
+**Modes:**
+
+| Mode | What it does |
+|------|-------------|
+| `analyze` | Classifies type and scope from staged diff |
+| `generate` | Writes a full commit message with WHY |
+| `stage` | Groups unrelated files into atomic commits |
+| `validate` | Checks an existing message against the spec |
+
+**Examples:**
+
+```
+/platform-skills:commit generate
+```
+*(analyzes staged changes and writes the commit message)*
+
+```
+/platform-skills:commit validate "fix: update config"
+```
+
+```
+/platform-skills:commit analyze
+```
+*(classifies type/scope — you decide whether to commit)*
+
+---
+
+### `/platform-skills:helmcheck`
+
+Create Helm chart scaffolding, review chart structure, or run a security analysis.
+
+```
+/platform-skills:helmcheck [create <workload-type> | review | security] [chart path or description]
+```
+
+**Examples:**
+
+```
+/platform-skills:helmcheck create deployment for a Node.js API service
+```
+
+```
+/platform-skills:helmcheck review ./charts/orders-service
+```
+
+```
+/platform-skills:helmcheck security check for privileged containers and host mounts
+```
+
+---
+
+### `/platform-skills:observability`
+
+Instrument services, build Grafana dashboards, write Prometheus alerts, design load tests, and plan capacity.
+
+```
+/platform-skills:observability [instrument|dashboard|alert|loadtest|capacity] [service description]
+```
+
+**Examples:**
+
+```
+/platform-skills:observability instrument a Python FastAPI service with RED metrics
+```
+
+```
+/platform-skills:observability alert write SLO-based alerts for 99.9% availability
+```
+
+```
+/platform-skills:observability dashboard design a Grafana dashboard for the orders-service
+```
+
+```
+/platform-skills:observability loadtest write a k6 script for 1000 concurrent users
+```
+
+---
+
+### `/platform-skills:opa`
+
+Generate Rego policies, write unit tests, run the validation pipeline (fmt → regal → conftest verify), explain policies in plain English, or debug rule evaluation.
+
+```
+/platform-skills:opa [generate|test|validate|explain|debug] [policy description or file path]
+```
+
+**Modes:**
+
+| Mode | What it does |
+|------|-------------|
+| `generate` | Writes a Rego policy from a description |
+| `test` | Writes `_test.rego` unit tests with fixtures |
+| `validate` | Runs fmt → regal lint → conftest verify |
+| `explain` | Translates Rego to plain English |
+| `debug` | Diagnoses why a rule fires or doesn't |
+
+**Examples:**
+
+```
+/platform-skills:opa generate a policy that denies Kubernetes pods without resource limits
+```
+
+```
+/platform-skills:opa test write unit tests for my IAM wildcard policy
+```
+
+```
+/platform-skills:opa validate ./policies
+```
+
+```
+/platform-skills:opa explain this rule:
+deny contains msg if {
+    some name
+    bucket := input.resource.aws_s3_bucket[name]
+    bucket.acl == "public-read"
+    msg := sprintf("S3 bucket '%s' must not be public", [name])
+}
+```
+
+---
+
+### `/platform-skills:compliance`
+
+SOC 2 gap analysis, control mapping, evidence generation, and Checkov remediation for Terraform code.
+
+```
+/platform-skills:compliance [topic: gap | control | evidence | remediate | checklist]
+```
+
+**Examples:**
+
+```
+/platform-skills:compliance gap analyze my Terraform for SOC 2 CC6.1 access control gaps
+```
+
+```
+/platform-skills:compliance control map this IAM policy to SOC 2 controls
+```
+
+```
+/platform-skills:compliance remediate this Checkov failure: CKV_AWS_18
+```
+
+---
+
+### `/platform-skills:datadog`
+
+Datadog Agent setup, APM instrumentation, monitor and dashboard creation, SLOs, and incident investigation.
+
+```
+/platform-skills:datadog [setup|instrument|monitor|dashboard|slo|investigate|debug] [service or description]
+```
+
+**Examples:**
+
+```
+/platform-skills:datadog setup install Datadog Agent on EKS with APM enabled
+```
+
+```
+/platform-skills:datadog monitor create a high error rate monitor for the orders-service
+```
+
+```
+/platform-skills:datadog investigate a p99 latency spike in the payments-service over the last 2 hours
+```
+
+---
+
+### `/platform-skills:dynatrace`
+
+Dynatrace Operator deployment, OneAgent injection, code-level instrumentation, SLOs, and Davis AI incident investigation.
+
+```
+/platform-skills:dynatrace [setup|instrument|monitor|slo|dashboard|investigate|debug] [service or description]
+```
+
+**Examples:**
+
+```
+/platform-skills:dynatrace setup deploy the Dynatrace Operator on Kubernetes
+```
+
+```
+/platform-skills:dynatrace slo create an availability SLO for 99.9% over 30 days
+```
+
+```
+/platform-skills:dynatrace investigate anomaly detection firing on the checkout service
+```
+
+---
+
+### `/platform-skills:document`
+
+Generate docstrings, OpenAPI specs, documentation sites, or getting started guides.
+
+```
+/platform-skills:document [docstrings|openapi|site|guide] [language/framework] [path or description]
+```
+
+**Examples:**
+
+```
+/platform-skills:document docstrings python add Google-style docstrings to this module
+```
+
+```
+/platform-skills:document openapi generate an OpenAPI 3.1 spec for a REST orders API
+```
+
+```
+/platform-skills:document guide write a getting started guide for the orders-service
+```
+
+---
+
+### `/platform-skills:mcp`
+
+Create, review, or debug Model Context Protocol server implementations in TypeScript or Python.
+
+```
+/platform-skills:mcp [create|review|debug] [typescript|python] [description]
+```
+
+**Examples:**
+
+```
+/platform-skills:mcp create typescript an MCP server that exposes Kubernetes pod logs as a tool
+```
+
+```
+/platform-skills:mcp review my MCP server for security and error handling
+```
+
+```
+/platform-skills:mcp debug tool call returns empty result
+```
+
+---
+
+### `/platform-skills:product`
+
+Platform product thinking — DevEx audits, friction mapping, RFC/ADR drafting, incident updates, post-mortems, and capacity/cost review.
+
+```
+/platform-skills:product [topic: devex | friction | rfc | adr | incident | postmortem | capacity | cost | review]
+```
+
+**Examples:**
+
+```
+/platform-skills:product friction audit the developer onboarding experience
+```
+
+```
+/platform-skills:product rfc draft an RFC for migrating from Argo CD to Flux CD
+```
+
+```
+/platform-skills:product postmortem write a post-mortem for a database failover incident
+```
+
+```
+/platform-skills:product cost review EC2 rightsizing opportunities for the data platform
+```
+
+---
+
+## Tips
+
+- **Paste context directly** — paste a manifest, error output, or code block right after the command for the best results.
+- **Chain commands** — run `/platform-skills:debug` to diagnose, then `/platform-skills:review` to validate the fix.
+- **Reference examples** — each command has working examples in [examples/](examples/) and a deep-dive in [references/](references/).
+- **Auto-activation** — the skill activates automatically when you work with Kubernetes, Terraform, GitOps, or GitHub Actions files — you don't always need the slash command.

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,296 +1,789 @@
-# Skill Commands — Usage Guide
+# Skill Commands — Detailed Usage Guide
 
-This guide shows how to invoke each `/platform-skills:<command>` slash command in Claude Code or the Claude desktop app.
+Every `/platform-skills:<command>` slash command available in Claude Code, with all modes, what to pass, and what to expect back.
 
 ## Prerequisites
 
-Install the plugin once:
-
 ```bash
 claude plugin install platform-skills
+# Then restart Claude Code
 ```
 
-Then restart Claude Code. All commands below work in any conversation.
+Commands work in any conversation — type the slash command or describe your problem and the skill activates automatically.
 
 ---
 
-## Command Reference
+## Table of Contents
 
-### `/platform-skills:review`
+| Command | What it's for |
+|---------|--------------|
+| [/platform-skills:review](#platform-skillsreview) | Production-readiness review of any config |
+| [/platform-skills:debug](#platform-skillsdebug) | Structured troubleshooting for any symptom |
+| [/platform-skills:terraform](#platform-skillsterraform) | Terraform validation pipeline + blast radius |
+| [/platform-skills:gitops](#platform-skillsgitops) | Flux CD / Argo CD reconciliation issues |
+| [/platform-skills:linkerd](#platform-skillslinkerd) | Linkerd mTLS, injection, policy, multi-cluster |
+| [/platform-skills:linux](#platform-skillslinux) | Linux, DNS, load balancing, VPC/VNet, networking |
+| [/platform-skills:helmcheck](#platform-skillshelmcheck) | Helm chart scaffold, review, security audit |
+| [/platform-skills:commit](#platform-skillscommit) | Conventional commit message generation |
+| [/platform-skills:observability](#platform-skillsobservability) | Instrument, alert, dashboard, load test, capacity |
+| [/platform-skills:opa](#platform-skillsopa) | OPA/Conftest Rego policy generate, test, validate |
+| [/platform-skills:compliance](#platform-skillscompliance) | SOC 2 gap analysis and Terraform remediation |
+| [/platform-skills:datadog](#platform-skillsdatadog) | Datadog setup, APM, monitors, SLOs, incidents |
+| [/platform-skills:dynatrace](#platform-skillsdynatrace) | Dynatrace Operator, OneAgent, SLOs, incidents |
+| [/platform-skills:document](#platform-skillsdocument) | Docstrings, OpenAPI specs, docs sites, guides |
+| [/platform-skills:mcp](#platform-skillsmcp) | MCP server scaffold, review, debug |
+| [/platform-skills:product](#platform-skillsproduct) | DevEx, RFC/ADR, post-mortems, capacity, cost |
 
-Production-readiness review of any platform config — Kubernetes manifests, Terraform, GitHub Actions workflows, Helm values.
+---
+
+## `/platform-skills:review`
+
+**What it does:** Senior-engineer production-readiness review of any platform config. Evaluates correctness → security → operational safety → deprecations. Returns findings as Critical / Improvement / Note.
+
+**Works on:** Kubernetes manifests, Terraform modules, GitHub Actions workflows, Helm values, RBAC configs, network policies, Dockerfiles, any YAML.
 
 ```
 /platform-skills:review [paste file content or describe what to review]
 ```
 
+**What gets checked:**
+
+| Priority | Checks |
+|----------|--------|
+| 1. Correctness | API versions, required fields, label/namespace consistency, will it do what it intends? |
+| 2. Security | Least-privilege RBAC/IAM, no plaintext secrets, non-root containers, SHA-pinned actions, scoped IAM |
+| 3. Operational safety | Rollback path, blast radius, resource limits, liveness/readiness probes, GitOps prune behaviour |
+| 4. Deprecations | Deprecated APIs, action versions, fields that will break on next minor version |
+
 **Examples:**
 
+Review a Deployment manifest — paste it inline:
 ```
 /platform-skills:review
-```
-*(paste a manifest — Claude will classify findings as Critical / Improvement / Note)*
-
-```
-/platform-skills:review check my HPA configuration for correctness
-```
-
-```
-/platform-skills:review
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders-service
-...
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: app
+          image: my-registry/orders:latest
+          env:
+            - name: DB_PASSWORD
+              value: "hunter2"
 ```
+
+Review a GitHub Actions workflow file by path:
+```
+/platform-skills:review .github/workflows/deploy.yml
+```
+
+Review a Terraform IAM module inline:
+```
+/platform-skills:review
+resource "aws_iam_role_policy" "app" {
+  policy = jsonencode({
+    Statement = [{ Effect = "Allow", Action = "*", Resource = "*" }]
+  })
+}
+```
+
+Review Helm values against a specific chart:
+```
+/platform-skills:review my values.yaml for the ingress-nginx chart — are resource limits set? Is the service account locked down?
+```
+
+**What comes back:** A structured report grouped by severity. Critical items block merge; Improvements are non-blocking; Notes are informational.
 
 ---
 
-### `/platform-skills:debug`
+## `/platform-skills:debug`
 
-Structured troubleshooting for any platform symptom. Classifies the problem layer, proposes evidence to collect, forms a root-cause hypothesis, and suggests a fix with rollback steps.
+**What it does:** Structured troubleshooting using a 6-step framework: classify layer → collect evidence → root-cause hypothesis → fix → validate → rollback. Forces you to gather evidence before applying a fix.
+
+**Works on:** Any platform symptom across Terraform, Kubernetes, OpenShift, Flux CD, Argo CD, Linkerd, GitHub Actions, AWS/Azure, Secrets management.
 
 ```
 /platform-skills:debug [symptom or error message]
 ```
 
+**The 6-step output you get:**
+
+1. **Layer classification** — which system owns this problem (Flux reconciliation? K8s scheduling? AWS IAM?)
+2. **Evidence to collect** — exact commands with flags, namespaces, resource names from your description
+3. **Root-cause hypothesis** — most likely cause with reasoning; ranked if multiple are plausible
+4. **Proposed fix** — exact config change, command, or patch with before/after
+5. **Validation** — commands to confirm the fix worked
+6. **Rollback** — how to safely undo if validation fails
+
 **Examples:**
 
+Pod stuck in CrashLoopBackOff:
 ```
-/platform-skills:debug Flux kustomization stuck in NotReady, error: "context deadline exceeded"
-```
-
-```
-/platform-skills:debug pod CrashLoopBackOff: OOMKilled, limits 256Mi
+/platform-skills:debug orders-service pod CrashLoopBackOff: exit code 137
 ```
 
+Flux reconciliation not picking up merged changes:
 ```
-/platform-skills:debug 503 errors spiked after deploying v2, Linkerd retries not helping
+/platform-skills:debug Flux Kustomization stuck in NotReady — "context deadline exceeded" — changes merged 20 minutes ago but cluster not updated
+```
+
+GitHub Actions OIDC failing:
+```
+/platform-skills:debug GitHub Actions OIDC error: "Error assuming role with web identity: not authorized to perform sts:AssumeRoleWithWebIdentity"
+```
+
+Mysterious 503s after a deploy:
+```
+/platform-skills:debug 503 errors spiked immediately after deploying v2.3.0 of payments-service, rolling back didn't fully stop them
+```
+
+AWS resource creation failing:
+```
+/platform-skills:debug Terraform apply fails: "Error creating IAM role: LimitExceeded: Cannot exceed quota for InstanceSessionsPerInstanceProfile: 1"
 ```
 
 ---
 
-### `/platform-skills:terraform`
+## `/platform-skills:terraform`
 
-Full Terraform validation pipeline — fmt, validate, tflint, security scan — plus blast radius and IAM risk review.
+**What it does:** Full Terraform review covering the validation pipeline, blast radius analysis, IAM/security audit, state impact, and module design — in that order.
 
 ```
 /platform-skills:terraform [paste terraform code, plan output, or describe the change]
 ```
 
+**The 6-section output:**
+
+| Section | What it covers |
+|---------|---------------|
+| 1. Validation pipeline | fmt → validate → tflint → tfsec/checkov — pass/fail per gate with exact errors |
+| 2. Blast radius | What gets created/modified/destroyed, what gets **replaced** (destructive), downstream dependencies, mid-apply failure impact |
+| 3. IAM and security | Wildcard actions/resources, default_tags enforcement, sensitive variables, state backend encryption |
+| 4. State impact | Migration requirements, unmanaged resources that could conflict, state isolation by environment |
+| 5. Module design | Variable validation blocks, typed outputs, provider placement in caller not module |
+| 6. Recommended actions | Exact HCL snippets for each fix |
+
 **Examples:**
 
-```
-/platform-skills:terraform review this IAM policy for least-privilege violations
-```
-
+Review an IAM policy for wildcards:
 ```
 /platform-skills:terraform
-resource "aws_iam_role_policy" "app" {
-  policy = jsonencode({ Statement = [{ Effect = "Allow", Action = "*", Resource = "*" }] })
+resource "aws_iam_policy" "app" {
+  name = "app-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:*"]
+      Resource = "*"
+    }]
+  })
 }
 ```
 
+Blast radius check before applying:
 ```
-/platform-skills:terraform what is the blast radius of deleting this module?
+/platform-skills:terraform I'm about to run terraform apply on a change that modifies aws_db_subnet_group — what could break and how do I validate it?
+```
+
+Review a Terraform plan output:
+```
+/platform-skills:terraform [paste output of terraform plan]
+```
+
+Check a module for reuse quality:
+```
+/platform-skills:terraform review my EKS module — does it follow module design best practices? Are variables validated?
+```
+
+Check state isolation strategy:
+```
+/platform-skills:terraform we have one state file for all environments in s3://company-tfstate — is this a problem?
 ```
 
 ---
 
-### `/platform-skills:gitops`
+## `/platform-skills:gitops`
 
-Flux CD and Argo CD reconciliation troubleshooting — source, artifact, reconciliation, chart rendering, and runtime workload issues.
+**What it does:** Flux CD and Argo CD reconciliation troubleshooting. Classifies by layer (source → artifact → reconciliation → runtime), provides exact evidence commands, and gives a fix with rollback.
 
 ```
 /platform-skills:gitops [describe the GitOps symptom, paste flux/argocd output, or share a manifest]
 ```
 
+**Flux CD layers diagnosed:**
+
+| Layer | What it covers |
+|-------|---------------|
+| Source | GitRepository, OCIRepository, HelmRepository unreachable; auth failures |
+| Artifact | Kustomization build errors, HelmChart render failures, path not found |
+| Reconciliation | Kustomization apply conflicts, HelmRelease install/upgrade stuck, dependency ordering |
+| Runtime | Pod health check failures, hook timeouts, prune-deleted resources |
+
+**Argo CD layers diagnosed:**
+
+| Layer | What it covers |
+|-------|---------------|
+| Source | Repo credentials, branch/path misconfiguration |
+| Diff | ignoreDifferences collisions, server-side apply drift |
+| Sync | Sync waves, resource hooks, namespace creation ordering |
+| Health | Custom health checks, resource status not propagating |
+
 **Examples:**
 
+Flux Kustomization NotReady:
 ```
-/platform-skills:gitops flux get kustomizations shows "dependency not found"
-```
-
-```
-/platform-skills:gitops ArgoCD app stuck in OutOfSync despite manual sync
+/platform-skills:gitops flux get kustomizations -A shows apps kustomization NotReady: "dependency not found: infrastructure"
 ```
 
+HelmRelease stuck on upgrade:
 ```
-/platform-skills:gitops HelmRelease is failing with "values don't match schema"
+/platform-skills:gitops HelmRelease orders-service stuck in "upgrade retries exhausted" — error: "values don't match schema"
+```
+
+Argo CD perpetually OutOfSync:
+```
+/platform-skills:gitops ArgoCD application shows OutOfSync despite successful manual sync — sync keeps firing every 3 minutes
+```
+
+Image automation not updating:
+```
+/platform-skills:gitops Flux ImageUpdateAutomation is not pushing updated image tags to Git — ImagePolicy shows correct latest tag
+```
+
+Rollback a bad HelmRelease:
+```
+/platform-skills:gitops how do I safely suspend a HelmRelease, roll back to the previous chart version, and then re-enable reconciliation?
 ```
 
 ---
 
-### `/platform-skills:linkerd`
+## `/platform-skills:linkerd`
 
-Linkerd mTLS, injection, policy, and multi-cluster diagnostics.
+**What it does:** Linkerd-specific diagnostics across 8 problem classes, with exact `linkerd` CLI evidence commands, root-cause hypothesis, fix, and validation using `linkerd viz edges` / `linkerd check`.
 
 ```
 /platform-skills:linkerd [describe the Linkerd symptom or paste linkerd check / viz output]
 ```
 
+**Problem classes:**
+
+| Class | What it diagnoses |
+|-------|-----------------|
+| Injection | Proxies not being injected; annotation vs namespace annotation conflicts |
+| mTLS | Edges showing plaintext; certificate expiry; trust anchor mismatch |
+| Authorization policy | Traffic denied by Server/AuthorizationPolicy; identity string mismatches |
+| Observability | Missing metrics; PodMonitor selector not matching; linkerd viz not showing data |
+| Traffic management | HTTPRoute not splitting traffic; retries not firing; timeout not respected |
+| Multi-cluster | Mirrored services unreachable; gateway health; firewall blocking port 4143 |
+| Performance | High proxy latency; proxy CPU/memory pressure |
+| Control plane | identity/destination/proxy-injector component failures |
+
+**Evidence commands provided:**
+```bash
+linkerd check
+linkerd check --proxy
+linkerd viz edges deployment -n <namespace>
+linkerd viz stat deploy -n <namespace>
+linkerd viz tap deploy/<name> -n <namespace>
+kubectl get pods -n <ns> -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.linkerd\.io/proxy-version}{"\n"}{end}'
+kubectl get secret linkerd-identity-issuer -n linkerd -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -noout -dates
+```
+
 **Examples:**
 
+mTLS not working between services:
 ```
-/platform-skills:linkerd pod injection not working after adding annotation
-```
-
-```
-/platform-skills:linkerd mTLS handshake failures between orders-service and payments-service
+/platform-skills:linkerd linkerd viz edges shows plaintext between orders-service and payments-service
 ```
 
+Proxy injection not happening:
 ```
-/platform-skills:linkerd how do I set up AuthorizationPolicy for internal traffic only?
+/platform-skills:linkerd pods in the checkout namespace are not getting the linkerd-proxy sidecar after I added the namespace annotation
+```
+
+Traffic not splitting on HTTPRoute:
+```
+/platform-skills:linkerd HTTPRoute for canary deploy is configured 90/10 but all traffic is going to stable — no traffic to canary pods
+```
+
+Multi-cluster service unreachable:
+```
+/platform-skills:linkerd mirrored service payments-service-remote is unreachable from the primary cluster — gateway shows healthy but curl times out
+```
+
+Certificate expiry:
+```
+/platform-skills:linkerd linkerd check shows "Certificate not yet valid" on the identity issuer — cert renews in 2 days but already failing
 ```
 
 ---
 
-### `/platform-skills:linux`
+## `/platform-skills:linux`
 
-Linux administration, DNS, load balancing, VPC/VNet networking, and connectivity troubleshooting.
+**What it does:** Linux administration and networking diagnostics across 7 topic areas. Each topic has its own structured framework. Always ends with a validation command and rollback.
 
 ```
 /platform-skills:linux [topic: dns | lb | vpc | process | disk | network | security-groups | troubleshoot]
 ```
 
-**Examples:**
+**Topic frameworks:**
+
+### `dns`
+Walks the resolution path client → resolver → authoritative; identifies the break; provides exact `dig`/`nslookup` commands; covers CoreDNS health inside Kubernetes clusters, `ndots` behaviour, and search domain issues.
 
 ```
-/platform-skills:linux dns pod cannot resolve service.namespace.svc.cluster.local
+/platform-skills:linux dns pod cannot resolve payments-service.checkout.svc.cluster.local
+```
+```
+/platform-skills:linux dns external DNS propagation delay after updating Route 53 record — TTL is 300s but clients still seeing old IP after 10 minutes
 ```
 
-```
-/platform-skills:linux network packets dropped between node and pod, no obvious route
-```
+### `lb`
+Diagnoses L4 vs L7 choice, health check failures, routing issues, target group type, source IP preservation on NLB.
 
 ```
-/platform-skills:linux security-groups inbound rule allowing 0.0.0.0/0 on port 22
+/platform-skills:linux lb ALB returning 502 — target group shows healthy but upstream still getting 502s intermittently
+```
+```
+/platform-skills:linux lb should I use ALB or NLB for a gRPC service? What are the implications?
+```
+
+### `vpc`
+Subnet tier review, route table correctness, IGW/NAT GW attachment, security group rules. Peering vs Transit Gateway scale/cost trade-off. PrivateLink producer/consumer placement.
+
+```
+/platform-skills:linux vpc EKS pods in private subnet cannot reach ECR — what route and security group changes are needed?
+```
+```
+/platform-skills:linux vpc 12 VPCs need to talk to each other — peering or Transit Gateway?
+```
+
+### `process`
+Crashed services, resource exhaustion, misconfigurations. Provides `systemctl`, `journalctl`, `ps`, `lsof`, `strace` commands. Covers memory (`free -h`, `/proc/meminfo`) and CPU (`vmstat`, `mpstat`).
+
+```
+/platform-skills:linux process nginx keeps restarting — how do I find the root cause and make the fix survive a reboot?
+```
+```
+/platform-skills:linux process Java process OOMKilled by the OS but -Xmx is set to 2g and node has 8g RAM
+```
+
+### `disk`
+Checks both space (`df -hT`) and inodes (`df -i`). Finds large files with `du -sh`, identifies deleted-but-open files with `lsof | grep deleted`.
+
+```
+/platform-skills:linux disk /var/log is at 95% — how do I find what's consuming space without taking down the service?
+```
+```
+/platform-skills:linux disk disk shows full but df shows 80% — how to find the "missing" space?
+```
+
+### `network`
+Full connectivity ladder: L3 (`ping`) → L4 (`nc -zv`) → L7 (`curl -v`). Interface state, route table, socket stats. Kernel tuning for high-traffic services (`somaxconn`, `tcp_max_syn_backlog`, `ip_local_port_range`).
+
+```
+/platform-skills:linux network two pods can ping each other but TCP connection is refused on port 8080 — same namespace, same node
+```
+```
+/platform-skills:linux network high connection reset rate under load — suspect kernel TCP backlog limits
+```
+
+### `security-groups`
+Maps traffic flow source → SG on LB → SG on target → NACL. Identifies missing or incorrect rules. Notes NLB source IP preservation behaviour.
+
+```
+/platform-skills:linux security-groups ALB to ECS task health check failing — security group rule looks correct but target health shows unhealthy
+```
+```
+/platform-skills:linux security-groups NLB target is unhealthy but the same target passes curl from within the VPC
+```
+
+### `troubleshoot`
+General-purpose structured checklist when you don't know the topic. Classifies symptom first, then applies the appropriate framework.
+
+```
+/platform-skills:linux troubleshoot service was reachable 30 minutes ago, now timing out — no recent deploys
 ```
 
 ---
 
-### `/platform-skills:commit`
+## `/platform-skills:helmcheck`
 
-Generate conventional commit messages from a staged diff or description. Supports message generation, file staging, and spec validation.
-
-```
-/platform-skills:commit [analyze|generate|stage|validate] [optional: type/scope override or description]
-```
-
-**Modes:**
-
-| Mode | What it does |
-|------|-------------|
-| `analyze` | Classifies type and scope from staged diff |
-| `generate` | Writes a full commit message with WHY |
-| `stage` | Groups unrelated files into atomic commits |
-| `validate` | Checks an existing message against the spec |
-
-**Examples:**
-
-```
-/platform-skills:commit generate
-```
-*(analyzes staged changes and writes the commit message)*
-
-```
-/platform-skills:commit validate "fix: update config"
-```
-
-```
-/platform-skills:commit analyze
-```
-*(classifies type/scope — you decide whether to commit)*
-
----
-
-### `/platform-skills:helmcheck`
-
-Create Helm chart scaffolding, review chart structure, or run a security analysis.
+**What it does:** Three modes — scaffold a production-ready chart from scratch, review an existing chart for structural issues, or run a security audit.
 
 ```
 /platform-skills:helmcheck [create <workload-type> | review | security] [chart path or description]
 ```
 
+---
+
+### Mode: `create`
+
+Generates a complete, production-ready Helm chart based on workload type.
+
+| Workload type | Resources generated |
+|---------------|-------------------|
+| Web service | Deployment + Service + Ingress |
+| Worker | Deployment only (no Service) |
+| CronJob | CronJob + ServiceAccount |
+| Stateful | StatefulSet + PVC + Headless Service |
+
+**What gets generated:**
+- `Chart.yaml` with name, description, type, version, appVersion
+- `_helpers.tpl` with all 6 standard helpers: `name`, `fullname`, `chart`, `labels`, `selectorLabels`, `serviceAccountName` — `selectorLabels` correctly excludes `app.kubernetes.io/version` (immutable after creation)
+- `values.yaml` — every key commented, defaults that work with zero overrides, hardened `securityContext` (non-root, readOnlyRootFilesystem, drop ALL), resource requests+limits present
+- `deployment.yaml`, `service.yaml`, `serviceaccount.yaml` (with `automountServiceAccountToken: false`)
+- Optional: `ingress.yaml`, `hpa.yaml` (autoscaling/v2), `pdb.yaml` (policy/v1), `networkpolicy.yaml`
+- Validation pipeline: `helm lint --strict`, `helm template --debug`, `kubeconform -strict`
+
 **Examples:**
 
 ```
-/platform-skills:helmcheck create deployment for a Node.js API service
+/platform-skills:helmcheck create web service for a Node.js REST API — needs ingress, HPA, and network policy
 ```
-
 ```
-/platform-skills:helmcheck review ./charts/orders-service
+/platform-skills:helmcheck create worker for a Python background job that reads from SQS — no inbound traffic
 ```
-
 ```
-/platform-skills:helmcheck security check for privileged containers and host mounts
+/platform-skills:helmcheck create stateful for PostgreSQL with PVC and headless service
 ```
 
 ---
 
-### `/platform-skills:observability`
+### Mode: `review`
 
-Instrument services, build Grafana dashboards, write Prometheus alerts, design load tests, and plan capacity.
+Checks a chart against a severity table. Reports Critical/High/Medium/Low findings with exact fixes.
+
+**Checks include:** missing `_helpers.tpl`, no resource limits, no probes, hardcoded image tags, wrong label immutability, missing NOTES.txt, `automountServiceAccountToken: true`, undocumented values.
+
+```
+/platform-skills:helmcheck review ./charts/orders-service
+```
+```
+/platform-skills:helmcheck review — the chart has no liveness probes and I suspect the values.yaml has secrets hardcoded
+```
+
+---
+
+### Mode: `security`
+
+Full security audit across pod security, RBAC, network, and secrets.
+
+**Checks include:**
+- Pod: no `securityContext`, running as root, `readOnlyRootFilesystem: false`, capabilities not dropped, `privileged: true`, `allowPrivilegeEscalation: true`
+- RBAC: missing dedicated ServiceAccount, `automountServiceAccountToken: true`, ClusterRole used where Role would do, wildcard verbs
+- Network: missing NetworkPolicy, `hostNetwork/hostPID/hostIPC: true`
+- Secrets: plaintext in values.yaml defaults, missing PDB
+
+```
+/platform-skills:helmcheck security ./charts/payments-service
+```
+```
+/platform-skills:helmcheck security — our chart runs as root and mounts the host docker socket, help me fix it
+```
+
+---
+
+## `/platform-skills:commit`
+
+**What it does:** Generates, validates, and stages [Conventional Commits](https://www.conventionalcommits.org/) messages. Four modes: analyze → generate → stage → validate.
+
+```
+/platform-skills:commit [analyze|generate|stage|validate] [optional: type/scope override or description]
+```
+
+**Commit message format:**
+```
+<type>(<scope>): <imperative subject — 72 chars max>
+
+<body — explains WHY, wraps at 72 chars>
+
+<footers — BREAKING CHANGE:, Fixes #N>
+```
+
+---
+
+### Mode: `analyze`
+
+Inspects staged diff (or unstaged if nothing staged). Groups files by logical concern, detects type and scope, flags breaking changes.
+
+**Type detected from:**
+
+| Type | When |
+|------|------|
+| `feat` | New capability or behavior added |
+| `fix` | Corrects broken behavior |
+| `refactor` | Restructures without changing behavior |
+| `perf` | Measurably improves performance |
+| `test` | Tests only |
+| `docs` | Documentation only |
+| `chore` | Deps, build tooling, no production effect |
+| `ci` | CI/CD pipeline changes |
+| `revert` | Reverts a prior commit |
+
+**Returns:** detected type, inferred scope, breaking change flag, one-line WHY summary.
+
+```
+/platform-skills:commit analyze
+```
+```
+/platform-skills:commit analyze — I changed the auth middleware to reject tokens missing the 'sub' claim
+```
+
+---
+
+### Mode: `generate`
+
+Runs `analyze` internally, then writes the full commit message — subject (imperative mood, WHY-focused, ≤72 chars), body, and footers.
+
+```
+/platform-skills:commit generate
+```
+```
+/platform-skills:commit generate feat auth — I added OIDC login support with PKCE flow
+```
+```
+/platform-skills:commit generate — breaking change, removed the /v1/orders endpoint
+```
+
+**Example output:**
+```
+feat(auth): add OIDC login with PKCE flow
+
+Previous password-based login could not support SSO providers. PKCE
+prevents auth code interception on public clients without requiring
+a client secret.
+
+BREAKING CHANGE: /api/auth/login now returns an authorization_url
+instead of a session token. Clients must redirect to this URL.
+
+Closes #142
+```
+
+---
+
+### Mode: `stage`
+
+Lists all modified files, groups them by logical change, identifies unrelated changes that should be separate commits, and stages the chosen group.
+
+```
+/platform-skills:stage
+```
+
+**Useful when:** you've changed multiple unrelated things and want clean atomic commits.
+
+**Example:**
+```
+/platform-skills:commit stage
+```
+Output groups might be:
+- Group A: `src/auth/oidc.ts`, `src/auth/oidc.test.ts` → `feat(auth): add OIDC`
+- Group B: `package.json`, `package-lock.json` → `chore(deps): bump axios to 1.7.0`
+- Group C: `README.md` → `docs: document OIDC setup`
+
+---
+
+### Mode: `validate`
+
+Checks an existing commit message against the full spec. Reports PASS or exact violations with the corrected line.
+
+**Rules checked:** valid type, lowercase scope, `!` only with `BREAKING CHANGE` footer, subject starts lowercase, no trailing period, ≤72 chars, blank line before body, body wraps at 72 chars, well-formed footers.
+
+```
+/platform-skills:commit validate "Fix: updated auth service"
+```
+```
+/platform-skills:commit validate "$(git log -1 --format=%B)"
+```
+
+---
+
+## `/platform-skills:observability`
+
+**What it does:** Add the three pillars to a service (logs/metrics/traces), build Grafana dashboards, write Prometheus alerting rules, design k6 load tests, or estimate capacity and HPA configuration.
 
 ```
 /platform-skills:observability [instrument|dashboard|alert|loadtest|capacity] [service description]
 ```
 
-**Examples:**
+---
+
+### Mode: `instrument`
+
+Adds structured logging, RED metrics, and OpenTelemetry tracing to a service. Asks for: language/framework, existing logging library, metrics backend (Prometheus/Datadog/CloudWatch), tracing backend (Jaeger/Tempo/OTLP).
+
+**What gets generated:**
+- Structured JSON logging with correlation IDs (Pino for Node.js, structlog for Python)
+- RED metrics: `http_requests_total` counter + `http_request_duration_seconds` histogram, labelled by route and status
+- OpenTelemetry tracing with span attributes on critical paths
+- `/metrics` Prometheus scrape endpoint
+- `/healthz` and `/readyz` health check endpoints
+- List of what NOT to log (passwords, tokens, PII)
 
 ```
-/platform-skills:observability instrument a Python FastAPI service with RED metrics
+/platform-skills:observability instrument a Node.js Express API — Prometheus metrics, Tempo tracing, Pino logging
 ```
-
 ```
-/platform-skills:observability alert write SLO-based alerts for 99.9% availability
-```
-
-```
-/platform-skills:observability dashboard design a Grafana dashboard for the orders-service
-```
-
-```
-/platform-skills:observability loadtest write a k6 script for 1000 concurrent users
+/platform-skills:observability instrument a Python FastAPI service — I'm already using structlog, add RED metrics and OpenTelemetry spans for the payment and order endpoints
 ```
 
 ---
 
-### `/platform-skills:opa`
+### Mode: `dashboard`
 
-Generate Rego policies, write unit tests, run the validation pipeline (fmt → regal → conftest verify), explain policies in plain English, or debug rule evaluation.
+Generates a Grafana dashboard using RED (request-based services) or USE (resource-based infrastructure) method.
+
+**Panels generated:** request rate (req/s), error rate (%), p50/p95/p99 latency (ms), active connections, queue depth. Threshold lines at SLO boundaries, template variables for `env` and `service`.
+
+```
+/platform-skills:observability dashboard for the orders-service — RED method, SLO is 99.9% availability and p99 < 500ms
+```
+```
+/platform-skills:observability dashboard USE method for the Postgres database — CPU, memory, disk I/O, connection pool
+```
+
+---
+
+### Mode: `alert`
+
+Writes Prometheus alerting rules using `rate()` over 5-minute windows, with `for:` duration, `severity` label, and `runbook` annotation.
+
+**Alert design enforced:**
+- Page on symptoms (error rate, latency) — not causes (CPU %)
+- Every alert must have a `runbook` annotation URL
+- SLO burn-rate alerts derived from error budget, not raw thresholds
+
+```
+/platform-skills:observability alert write SLO burn-rate alerts for orders-service — 99.9% availability target, 30-day window
+```
+```
+/platform-skills:observability alert high p99 latency alert for the payments-service — critical at 1s, warning at 500ms, fire after 5 minutes
+```
+
+---
+
+### Mode: `loadtest`
+
+Writes a k6 load test with ramp-up → steady-state → ramp-down stages, thresholds matching the SLO, and `check()` assertions on status code and response time.
+
+Asks for: target endpoint, expected peak RPS, SLO thresholds (p95 latency, error rate).
+
+```
+/platform-skills:observability loadtest for POST /orders — peak 500 RPS, p95 must be under 200ms, error rate under 0.1%
+```
+```
+/platform-skills:observability loadtest simulate 2000 concurrent users on the checkout flow — ramp up over 5 minutes
+```
+
+---
+
+### Mode: `capacity`
+
+Estimates replica count, resource requests/limits, and HPA configuration based on expected load.
+
+**Formula used:** `replicas = ceil((peak_rps × avg_latency_s) / target_concurrency_per_pod)` + 50% headroom. HPA CPU target ≤ 60%.
+
+```
+/platform-skills:observability capacity orders-service handles 200 RPS at p99 150ms, expecting 3× growth — what are the resource requests and HPA settings?
+```
+```
+/platform-skills:observability capacity current 4 pods at 70% CPU at 1000 RPS — what's the right HPA min/max and target utilisation?
+```
+
+---
+
+## `/platform-skills:opa`
+
+**What it does:** Generate Rego policies, write unit tests, run the full validation pipeline (fmt → regal → conftest verify), explain policies in plain English, or debug why a rule isn't firing.
 
 ```
 /platform-skills:opa [generate|test|validate|explain|debug] [policy description or file path]
 ```
 
-**Modes:**
+---
 
-| Mode | What it does |
-|------|-------------|
-| `generate` | Writes a Rego policy from a description |
-| `test` | Writes `_test.rego` unit tests with fixtures |
-| `validate` | Runs fmt → regal lint → conftest verify |
-| `explain` | Translates Rego to plain English |
-| `debug` | Diagnoses why a rule fires or doesn't |
+### Mode: `generate`
 
-**Examples:**
+Writes a production-ready Rego policy from a description. Asks for: target resource type (Terraform HCL/plan JSON, Kubernetes manifest, GitHub Actions, Dockerfile), rule logic, and whether a named package is needed.
 
-```
-/platform-skills:opa generate a policy that denies Kubernetes pods without resource limits
-```
+**What gets generated:**
+- METADATA block: `title`, `description`, `authors`, `entrypoint: true`
+- `package <namespace>` — named packages for multi-domain repos (`package terraform.iam`, `package k8s.pods`)
+- `import rego.v1`
+- `deny` for hard failures, `warn` for advisory, `violation` for Gatekeeper
+- Descriptive `msg` including resource name and remediation hint
+- Conftest command to test it
 
 ```
-/platform-skills:opa test write unit tests for my IAM wildcard policy
+/platform-skills:opa generate a policy that denies Kubernetes Deployments without resource limits set on all containers
 ```
+```
+/platform-skills:opa generate a Terraform policy that denies S3 buckets with public ACLs and warns if versioning is not enabled
+```
+```
+/platform-skills:opa generate a policy for GitHub Actions workflows that warns if actions are not pinned to a SHA commit
+```
+
+---
+
+### Mode: `test`
+
+Writes `_test.rego` unit tests for a given policy with minimal focused fixtures.
+
+**Structure generated:**
+- Package: `package <namespace>_test`
+- Imports policy under test: `import data.<namespace>`
+- For each `deny`/`warn` rule: a positive test (`test_deny_*`, asserts count > 0) and a negative test (`test_allow_*`, asserts count == 0)
+- Helper functions to build input fixtures for each case
+- Command: `conftest verify --policy <dir>`
+
+```
+/platform-skills:opa test write unit tests for my S3 encryption policy
+```
+```
+/platform-skills:opa test — [paste policy file] — generate tests for all deny and warn rules
+```
+
+---
+
+### Mode: `validate`
+
+Runs the full 5-step validation pipeline in order. Fixes each stage before proceeding to the next.
+
+| Step | Tool | What it catches |
+|------|------|----------------|
+| 1. Format check | `conftest fmt --check` | Inconsistent indentation, non-canonical formatting |
+| 2. Auto-format | `conftest fmt` | Rewrites files in place if check failed |
+| 3. Lint | `regal lint` | Style violations, `no-defined-entrypoint`, unused variables |
+| 4. Unit tests | `conftest verify --policy` | Logic correctness against fixtures |
+| 5. Integration test | `conftest test --policy <dir> <input-files>` | Real input parsing against actual files |
 
 ```
 /platform-skills:opa validate ./policies
 ```
+```
+/platform-skills:opa validate — regal is reporting "no-defined-entrypoint" on all my files, how do I fix it?
+```
+
+---
+
+### Mode: `explain`
+
+Translates Rego into plain English, rule by rule. Maps each `input.<field>` to the actual resource attribute being read. Notes `data.*` dependencies.
+
+**For each rule explains:**
+- What resource type and attribute it checks
+- What condition triggers a deny/warn
+- What the developer sees when it fires
+- Any allow-list or exception conditions
 
 ```
-/platform-skills:opa explain this rule:
+/platform-skills:opa explain
 deny contains msg if {
     some name
     bucket := input.resource.aws_s3_bucket[name]
@@ -298,160 +791,660 @@ deny contains msg if {
     msg := sprintf("S3 bucket '%s' must not be public", [name])
 }
 ```
+```
+/platform-skills:opa explain ./policies/deny_unencrypted_s3.rego
+```
 
 ---
 
-### `/platform-skills:compliance`
+### Mode: `debug`
 
-SOC 2 gap analysis, control mapping, evidence generation, and Checkov remediation for Terraform code.
+Diagnoses why a policy is not firing (or firing when it shouldn't). Checks in order: namespace mismatch → rule name → input shape → partial vs set comprehension → `import rego.v1` missing → `some` missing.
+
+```
+/platform-skills:opa debug my deny rule produces no output when I run conftest test against main.tf
+```
+```
+/platform-skills:opa debug — I have a warn rule that fires on everything, even compliant resources
+```
+```
+/platform-skills:opa debug — conftest test passes with exit 0 but I expected a failure — [paste policy and input]
+```
+
+---
+
+## `/platform-skills:compliance`
+
+**What it does:** SOC 2 compliance for Terraform infrastructure. Gap analysis, control implementation, audit evidence collection, Checkov remediation — all mapped to Trust Services Criteria (TSC).
 
 ```
 /platform-skills:compliance [topic: gap | control | evidence | remediate | checklist]
 ```
 
-**Examples:**
+---
+
+### Mode: `gap`
+
+Maps your Terraform config or description to SOC 2 TSC criteria, identifies gaps, and prioritises: Critical (audit blocker) / High (likely finding) / Medium (improvement).
+
+**Output format:**
+```
+Criterion  | Finding                           | Severity  | Fix
+CC6.7      | S3 bucket missing KMS CMK         | Critical  | Add aws_s3_bucket_server_side_encryption_configuration
+CC7.2      | CloudTrail not multi-region       | Critical  | Set is_multi_region_trail = true
+CC6.6      | Security group allows 0.0.0.0/0   | High      | Restrict to VPN CIDR
+```
 
 ```
-/platform-skills:compliance gap analyze my Terraform for SOC 2 CC6.1 access control gaps
+/platform-skills:compliance gap analyze my EKS Terraform module for SOC 2 CC6.1 access control gaps
 ```
-
 ```
-/platform-skills:compliance control map this IAM policy to SOC 2 controls
-```
-
-```
-/platform-skills:compliance remediate this Checkov failure: CKV_AWS_18
+/platform-skills:compliance gap we're going through a SOC 2 Type II audit in 3 months — run a gap analysis on our AWS infrastructure config
 ```
 
 ---
 
-### `/platform-skills:datadog`
+### Mode: `control`
 
-Datadog Agent setup, APM instrumentation, monitor and dashboard creation, SLOs, and incident investigation.
+Implements a specific SOC 2 control in Terraform. States the criterion, provides the exact resource(s), lists the Checkov rule IDs, and shows the auditor evidence command.
+
+```
+/platform-skills:compliance control implement CC6.7 encryption at rest for our RDS instances
+```
+```
+/platform-skills:compliance control CC7.2 — how do I implement CloudTrail with integrity validation and multi-region coverage?
+```
+
+---
+
+### Mode: `evidence`
+
+Provides copy-paste AWS CLI commands to gather audit evidence for a specific criterion. Notes what each output proves and flags any elevated permissions required.
+
+```
+/platform-skills:compliance evidence CC6.7 — what AWS CLI commands do I run to show auditors that all S3 buckets have encryption enabled?
+```
+```
+/platform-skills:compliance evidence CC6.6 — how do I prove to auditors that no security groups allow 0.0.0.0/0 on port 22?
+```
+
+---
+
+### Mode: `remediate`
+
+Fixes a specific Checkov or audit finding. Provides: criterion mapping, root cause, exact old → new Terraform block, blast radius (will this replace the resource?), validation steps, rollback.
+
+```
+/platform-skills:compliance remediate CKV_AWS_18: S3 bucket does not have access logging enabled
+```
+```
+/platform-skills:compliance remediate CKV_AWS_86: CloudFront distribution does not have logging enabled
+```
+
+---
+
+### Mode: `checklist`
+
+Runs through the full SOC 2 readiness checklist. For each item: pass / fail / unknown. For fails and unknowns: what's needed + which Checkov rule enforces it. Ends with a prioritised action list.
+
+```
+/platform-skills:compliance checklist — we have Terraform for EKS, RDS, S3, IAM, and CloudTrail
+```
+
+---
+
+## `/platform-skills:datadog`
+
+**What it does:** End-to-end Datadog coverage — Agent deployment on Kubernetes, APM instrumentation, monitors, dashboards, SLOs, and live incident investigation via the Datadog MCP server.
 
 ```
 /platform-skills:datadog [setup|instrument|monitor|dashboard|slo|investigate|debug] [service or description]
 ```
 
-**Examples:**
+---
+
+### Mode: `setup`
+
+Deploys the Datadog Agent on Kubernetes via Helm. Asks for: Kubernetes distribution (EKS/AKS/GKE), Datadog site (EU `datadoghq.eu` / US `datadoghq.com`), features needed.
+
+**Generates:** Helm values with API key from Kubernetes Secret (never hardcoded), APM enabled, log collection enabled, cluster name set, Cluster Agent with 2 replicas. Adds Unified Service Tagging (`DD_ENV`, `DD_SERVICE`, `DD_VERSION`) to app Deployment.
 
 ```
-/platform-skills:datadog setup install Datadog Agent on EKS with APM enabled
+/platform-skills:datadog setup EKS cluster, EU site, need APM and log collection
 ```
-
 ```
-/platform-skills:datadog monitor create a high error rate monitor for the orders-service
-```
-
-```
-/platform-skills:datadog investigate a p99 latency spike in the payments-service over the last 2 hours
+/platform-skills:datadog setup how do I add Unified Service Tagging to my existing Deployments?
 ```
 
 ---
 
-### `/platform-skills:dynatrace`
+### Mode: `instrument`
 
-Dynatrace Operator deployment, OneAgent injection, code-level instrumentation, SLOs, and Davis AI incident investigation.
+Adds APM tracing to a service. Asks for: language and framework, whether log-trace correlation is needed.
+
+- **Node.js**: `dd-trace` init as the **first** import
+- **Python**: `ddtrace-run` entry point or `patch_all()` + `DD_TRACE_ENABLED`
+- Adds custom spans for business-critical paths
+- Shows expected APM UI outcome: service map entry, latency/error rate populated
+
+```
+/platform-skills:datadog instrument Node.js Express orders service — need log-trace correlation
+```
+```
+/platform-skills:datadog instrument Python FastAPI payments service — add custom spans for the payment processing flow
+```
+
+---
+
+### Mode: `monitor`
+
+Generates a Terraform `datadog_monitor` resource. Sets `notify_no_data: true`, warning and critical thresholds, PagerDuty/Slack notification handles, and `service:`, `env:`, `team:` tags for routing.
+
+```
+/platform-skills:datadog monitor high error rate on orders-service — critical at 5%, warning at 2%, notify @pagerduty-platform @slack-alerts
+```
+```
+/platform-skills:datadog monitor p99 latency for the checkout service — critical over 1s, warning over 500ms
+```
+
+---
+
+### Mode: `dashboard`
+
+Generates a Terraform `datadog_dashboard` with RED method widgets using APM metrics. Template variables for `env` and `service`.
+
+```
+/platform-skills:datadog dashboard orders-service RED dashboard — request rate, error rate, p50/p95/p99 latency
+```
+
+---
+
+### Mode: `slo`
+
+Generates a Terraform `datadog_service_level_objective`. Links to monitors for error budget burn alerts.
+
+```
+/platform-skills:datadog slo orders-service availability SLO — 99.9% target, 30-day window, warn at 99.95%
+```
+
+---
+
+### Mode: `investigate`
+
+**Live incident investigation using the Datadog MCP server.** Requires the MCP server connected — see `references/datadog.md` → MCP Server Setup.
+
+Runs a 4-phase investigation through the MCP:
+
+| Phase | What gets queried |
+|-------|-----------------|
+| 1. Triage | Active monitors in ALERT/WARN, event stream last 30 min, recent deployments |
+| 2. Signals | Error logs for the incident window, APM error rate + p99 time series, sample failing traces |
+| 3. Root cause | Before/after metric comparison, endpoint-level error breakdown, host CPU/memory |
+| 4. Resolution | Acknowledge/resolve monitor, post incident Slack update, create post-mortem notebook |
+
+```
+/platform-skills:datadog investigate orders-service error rate spiked at 14:30 UTC — still ongoing
+```
+
+Natural language queries Claude sends to the MCP:
+```
+What monitors are firing for service:orders-service env:production right now?
+Show error logs for orders-service between 14:30 and 15:00 UTC.
+Compare the error rate before and after 14:30 UTC.
+Which endpoints have the highest error rate?
+```
+
+---
+
+### Mode: `debug`
+
+Diagnoses Datadog data gaps without the MCP server. Classifies: Agent unhealthy, APM missing, logs not ingested, Monitor in No Data, custom metric not visible.
+
+```
+/platform-skills:datadog debug APM traces are missing for the payments-service — agent shows healthy
+```
+```
+/platform-skills:datadog debug monitor is stuck in "No Data" — the service is definitely running
+```
+
+---
+
+## `/platform-skills:dynatrace`
+
+**What it does:** Dynatrace Operator deployment, OneAgent injection, code-level instrumentation, custom metrics, SLOs, dashboards, anomaly detection, Davis AI, and live incident investigation via the Dynatrace MCP server.
 
 ```
 /platform-skills:dynatrace [setup|instrument|monitor|slo|dashboard|investigate|debug] [service or description]
 ```
 
-**Examples:**
+---
+
+### Mode: `setup`
+
+Deploys the Dynatrace Operator and OneAgent on Kubernetes. Asks for: environment ID, Kubernetes distribution, monitoring mode.
+
+- Uses `cloudNativeFullStack` for automatic injection — no pod restarts required
+- Creates Kubernetes Secret with `apiToken` and `dataIngestToken` — never plain values
+- Enables `metadataEnrichment: true` for k8s metadata on all telemetry
+
+**Required token scopes:**
+- `apiToken`: ReadConfig, WriteConfig, DataExport, LogExport, ReadSyntheticData, WriteAnomalyDetection
+- `dataIngestToken`: metrics.ingest, logs.ingest
 
 ```
-/platform-skills:dynatrace setup deploy the Dynatrace Operator on Kubernetes
-```
-
-```
-/platform-skills:dynatrace slo create an availability SLO for 99.9% over 30 days
-```
-
-```
-/platform-skills:dynatrace investigate anomaly detection firing on the checkout service
+/platform-skills:dynatrace setup EKS cluster, environment ID abc12345, cloudNativeFullStack injection
 ```
 
 ---
 
-### `/platform-skills:document`
+### Mode: `instrument`
 
-Generate docstrings, OpenAPI specs, documentation sites, or getting started guides.
+Adds custom spans for business logic (OneAgent auto-instruments HTTP/DB/cache/messaging). Asks for: language, operations to trace.
+
+- **Node.js**: `@dynatrace/oneagent-sdk`
+- **Python**: `oneagent-sdk`
+- **Java**: OneAgent Java SDK
+- Cross-service propagation via `x-dynatrace` header
+
+```
+/platform-skills:dynatrace instrument Node.js — add custom spans for the payment processing and order creation flows
+```
+
+---
+
+### Mode: `monitor`
+
+Generates Terraform `dynatrace_service_anomalies_v2` for failure rate and response time, plus `dynatrace_alerting` profile linked to PagerDuty/Slack/Opsgenie.
+
+```
+/platform-skills:dynatrace monitor orders-service — auto-detect anomalies, alert to PagerDuty platform-oncall
+```
+
+---
+
+### Mode: `slo`
+
+Generates Terraform `dynatrace_slo_v2`. Uses built-in availability metrics: `builtin:service.errors.server.successCount` / `builtin:service.requestCount.server`.
+
+```
+/platform-skills:dynatrace slo orders-service availability — 99.9% target, 30-day timeframe, warn at 99.5%
+```
+
+---
+
+### Mode: `dashboard`
+
+Generates Terraform `dynatrace_json_dashboard` with `DATA_EXPLORER` tiles for key service metrics.
+
+```
+/platform-skills:dynatrace dashboard orders-service — request count, response time, error rate, availability
+```
+
+---
+
+### Mode: `investigate`
+
+**Live incident investigation using the Dynatrace MCP server.** Requires the MCP server connected — see `references/dynatrace.md` → MCP Server Setup.
+
+> **Cost note**: `execute_dql` queries scan Grail data and may incur costs. Start with short timeframes (1h–24h). Set `DT_GRAIL_QUERY_BUDGET_GB` to cap session spend.
+
+Runs a 4-phase investigation:
+
+| Phase | What gets queried |
+|-------|-----------------|
+| 1. Triage | Open Davis AI Problems, root cause entity and affected services, k8s events |
+| 2. Signals | Error logs via DQL, exceptions with stack traces, distributed traces with errors |
+| 3. Root cause (Davis AI) | Davis Copilot plain-English explanation, Davis Analyzer automated root cause |
+| 4. Resolution | Create Dynatrace Notebook, send Slack/email, close Problem with resolution note |
+
+Example DQL queries the MCP runs:
+```dql
+fetch logs
+| filter service.name == "orders-service" and loglevel == "ERROR"
+| sort timestamp desc
+| limit 50
+| fields timestamp, content, trace_id, span_id
+```
+
+```
+/platform-skills:dynatrace investigate orders-service has an open Davis AI Problem since 14:00 UTC
+```
+
+---
+
+### Mode: `debug`
+
+Diagnoses data gaps without the MCP server. Classifies: injection failure, traces broken, custom metrics missing, SLO showing 0%, Davis AI not firing Problems.
+
+```
+/platform-skills:dynatrace debug OneAgent not injecting into pods in the checkout namespace
+```
+```
+/platform-skills:dynatrace debug custom metrics not showing in Metrics Explorer — ingest endpoint returns 202
+```
+
+---
+
+## `/platform-skills:document`
+
+**What it does:** Generate or improve technical documentation — docstrings, OpenAPI 3.1 specs, documentation sites, and getting started guides.
 
 ```
 /platform-skills:document [docstrings|openapi|site|guide] [language/framework] [path or description]
 ```
 
-**Examples:**
+---
+
+### Mode: `docstrings`
+
+Adds or improves inline documentation. Asks for: language and preferred style.
+
+| Language | Style options |
+|----------|-------------|
+| Python | Google, NumPy, Sphinx |
+| TypeScript/JavaScript | JSDoc |
+
+For each undocumented public function/class: purpose, all parameters with types, return value, exceptions raised, at least one example. Validates examples run (`python -m doctest`, `tsc --noEmit`). Generates coverage report (`interrogate`, `typedoc-coverage`).
+
+**Does NOT document:** obvious getters/setters, private methods without complex invariants.
 
 ```
-/platform-skills:document docstrings python add Google-style docstrings to this module
+/platform-skills:document docstrings python Google-style — add docstrings to all public functions in src/auth/
 ```
-
 ```
-/platform-skills:document openapi generate an OpenAPI 3.1 spec for a REST orders API
-```
-
-```
-/platform-skills:document guide write a getting started guide for the orders-service
+/platform-skills:document docstrings typescript JSDoc — document the OrderService class and all public methods
 ```
 
 ---
 
-### `/platform-skills:mcp`
+### Mode: `openapi`
 
-Create, review, or debug Model Context Protocol server implementations in TypeScript or Python.
+Generates or improves an OpenAPI 3.1 spec. Asks for: framework and existing routes or codebase.
+
+**What gets generated:**
+- All endpoints mapped: method, path, request body, response schemas per status code
+- Shared schemas extracted to `components/schemas`
+- Shared responses (400, 401, 404, 500) extracted to `components/responses`
+- `operationId` on every operation
+- Security scheme declared and applied globally or per-operation
+- Validated with `npx @redocly/cli lint`
+
+Framework-specific patterns:
+- **FastAPI**: Pydantic `Field(description=...)` + route docstrings → auto-generates `/docs`
+- **NestJS**: `@ApiProperty`, `@ApiOperation`, `@ApiResponse` decorators
+
+```
+/platform-skills:document openapi generate a spec for our Orders REST API — POST /orders, GET /orders/{id}, GET /orders with pagination
+```
+```
+/platform-skills:document openapi FastAPI — generate OpenAPI spec from the existing route functions in app/routes/
+```
+
+---
+
+### Mode: `site`
+
+Sets up a documentation site for a project.
+
+| Project type | Recommended generator |
+|-------------|----------------------|
+| Python library | MkDocs + mkdocstrings + Material theme |
+| TypeScript SDK | TypeDoc + typedoc-material-theme |
+| API portal | Redocly or Stoplight |
+| General docs | Docusaurus |
+
+Generates site config, nav structure (Getting Started, API Reference, Guides, Changelog), docstring auto-generation from source, search plugin, serve and build commands.
+
+```
+/platform-skills:document site Python library — set up MkDocs with auto-generated API reference from docstrings
+```
+```
+/platform-skills:document site REST API portal — we want rendered API docs with try-it-out for partners
+```
+
+---
+
+### Mode: `guide`
+
+Writes a getting started guide or tutorial. Structure enforced:
+
+1. **Prerequisites** — exact versions, accounts, permissions
+2. **Installation** — copy-paste commands
+3. **Quick start** — simplest working example (under 10 lines)
+4. **Next steps** — links to deeper topics
+
+Rules: all code examples tested and runnable, realistic values (not `<YOUR_VALUE>` placeholders), one concept per section, expected output for each command.
+
+```
+/platform-skills:document guide write a getting started guide for the orders-service SDK — Node.js, installing from npm, making the first API call
+```
+```
+/platform-skills:document guide Kubernetes deployment guide for new engineers — assumes basic kubectl, no Helm knowledge
+```
+
+---
+
+## `/platform-skills:mcp`
+
+**What it does:** Scaffold, review, or debug Model Context Protocol (MCP) server implementations in TypeScript or Python.
 
 ```
 /platform-skills:mcp [create|review|debug] [typescript|python] [description]
 ```
 
-**Examples:**
+---
+
+### Mode: `create`
+
+Scaffolds a production-ready MCP server. Asks for: language, transport (stdio / HTTP+SSE), list of tools and resources needed.
+
+**What gets generated:**
+- Project scaffold with correct SDK setup (TypeScript SDK or Python `mcp` package)
+- Tool handlers with Zod (TypeScript) or Pydantic (Python) schema validation — no `z.any()` or empty schemas
+- Resource providers and prompt templates
+- Transport configuration
+- Error handling: `isError: true` content on failures, no unhandled exceptions
+- Authentication and rate limiting for HTTP transports
+- MCP Inspector test commands and expected responses
+- Deployment checklist (env vars, secrets, logging)
 
 ```
-/platform-skills:mcp create typescript an MCP server that exposes Kubernetes pod logs as a tool
+/platform-skills:mcp create typescript — MCP server that exposes Kubernetes pod logs and events as tools, uses stdio transport
 ```
-
 ```
-/platform-skills:mcp review my MCP server for security and error handling
-```
-
-```
-/platform-skills:mcp debug tool call returns empty result
+/platform-skills:mcp create python — MCP server that wraps our internal deployment API — 3 tools: list_services, get_status, trigger_deploy
 ```
 
 ---
 
-### `/platform-skills:product`
+### Mode: `review`
 
-Platform product thinking — DevEx audits, friction mapping, RFC/ADR drafting, incident updates, post-mortems, and capacity/cost review.
+Reviews an existing MCP server or client. Evaluates in priority order:
+
+1. **Protocol compliance** — JSON-RPC 2.0, capability negotiation, well-formed content arrays
+2. **Schema validation** — Zod/Pydantic on all inputs, no `z.any()`
+3. **Security** — no credentials in tool responses, auth on HTTP transports, rate limiting
+4. **Error handling** — `isError: true` with message, no unhandled exceptions
+5. **Transport** — correct transport for use case, no blocking sync code in async transports
+
+```
+/platform-skills:mcp review my MCP server — focus on whether error handling is correct and if the schemas are tight enough
+```
+
+---
+
+### Mode: `debug`
+
+Diagnoses protocol and integration failures. Classifies: Transport → Protocol → Schema → Handler → Integration.
+
+**Evidence to collect:**
+```bash
+# Verify protocol compliance
+npx @modelcontextprotocol/inspector node dist/index.js
+
+# Smoke-test via stdio
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | node dist/index.js
+```
+
+```
+/platform-skills:mcp debug tool is not appearing in the tools list in Claude — server starts without errors
+```
+```
+/platform-skills:mcp debug tool call returns empty result but no error — the handler is executing
+```
+```
+/platform-skills:mcp debug schema validation rejecting a valid input — Zod error: "Expected string, received number"
+```
+
+---
+
+## `/platform-skills:product`
+
+**What it does:** Platform product thinking — DevEx audits, friction analysis, RFC/ADR drafting, incident communication, blameless post-mortems, capacity planning, cost optimisation, and platform health review.
 
 ```
 /platform-skills:product [topic: devex | friction | rfc | adr | incident | postmortem | capacity | cost | review]
 ```
 
-**Examples:**
+Every response ends with: **Next step** (one concrete action to take immediately) + **Signal to watch** (one metric or observable that confirms the change is working).
+
+---
+
+### `devex`
+
+Audits developer experience using the SPACE framework (Satisfaction, Performance, Activity, Communication, Efficiency). Identifies the top friction point from description, proposes one systemic fix (not a local patch), and suggests one metric to track improvement.
 
 ```
-/platform-skills:product friction audit the developer onboarding experience
+/platform-skills:product devex developers are spending 45 minutes to get a new service to production on day 1
 ```
-
 ```
-/platform-skills:product rfc draft an RFC for migrating from Argo CD to Flux CD
-```
-
-```
-/platform-skills:product postmortem write a post-mortem for a database failover incident
-```
-
-```
-/platform-skills:product cost review EC2 rightsizing opportunities for the data platform
+/platform-skills:product devex CI pipeline takes 25 minutes — engineers skip it and push directly to staging
 ```
 
 ---
 
-## Tips
+### `friction`
 
-- **Paste context directly** — paste a manifest, error output, or code block right after the command for the best results.
-- **Chain commands** — run `/platform-skills:debug` to diagnose, then `/platform-skills:review` to validate the fix.
-- **Reference examples** — each command has working examples in [examples/](examples/) and a deep-dive in [references/](references/).
-- **Auto-activation** — the skill activates automatically when you work with Kubernetes, Terraform, GitOps, or GitHub Actions files — you don't always need the slash command.
+Maps the problem to the friction audit table (onboarding / CI / secrets / environment / ownership). States root cause, proposes the platform-level response, defines measurable "done".
+
+```
+/platform-skills:product friction every team has their own Terraform repo with different patterns — no shared modules
+```
+```
+/platform-skills:product friction rotating secrets takes 3 engineers and an incident window
+```
+
+---
+
+### `rfc`
+
+Produces a complete RFC:
+- Problem (what is broken, why now)
+- Proposal (concrete change)
+- Alternatives considered
+- Impact (which teams, what migration)
+- Open questions
+
+```
+/platform-skills:product rfc draft an RFC for migrating from Argo CD to Flux CD — 15 teams affected, GitOps repo restructure required
+```
+```
+/platform-skills:product rfc adopt Gateway API as the standard ingress interface across all clusters
+```
+
+---
+
+### `adr`
+
+Produces a complete Architecture Decision Record:
+- Context (what forced this decision)
+- Decision (what was decided)
+- Consequences (what becomes easier / harder / what to monitor)
+
+```
+/platform-skills:product adr decision to use Crossplane instead of Terraform for cluster-level infrastructure
+```
+```
+/platform-skills:product adr we decided to use a mono-repo GitOps structure over per-team repos
+```
+
+---
+
+### `incident`
+
+Produces a structured incident status update:
+- Time, severity, affected component
+- Impact statement (user-visible, quantified if possible)
+- What we know / what we are doing
+- Next update time
+
+```
+/platform-skills:product incident orders-service is returning 500s, started at 14:30 UTC, about 20% of requests affected
+```
+
+---
+
+### `postmortem`
+
+Produces a blameless post-mortem structure:
+- Timeline with timestamps
+- Impact: duration, affected users, business impact
+- Root cause: systemic, not human blame
+- Contributing factors
+- Action items with owner and due date
+
+```
+/platform-skills:product postmortem database failover at 02:15 UTC caused 18 minutes of downtime for checkout — root cause was missing health check on standby
+```
+
+---
+
+### `capacity`
+
+Ties growth to a business metric, states current baseline and projected growth, recommends headroom target and trigger threshold, proposes next review date.
+
+```
+/platform-skills:product capacity orders-service — currently 500 RPS at 60% CPU on 8 pods, expecting 3× growth in Q3
+```
+
+---
+
+### `cost`
+
+Identifies top cost driver, applies the monthly cost loop (rightsizing → unused resources → showback), proposes a specific reduction action with owner and deadline.
+
+```
+/platform-skills:product cost EC2 spend is $40k/month — largest cluster has m5.2xlarge nodes at 15% average CPU
+```
+```
+/platform-skills:product cost we have 200 EBS volumes and no visibility into which are orphaned
+```
+
+---
+
+### `review`
+
+Runs the full platform health checklist covering Developer Experience, Operations, Security and Compliance, and Cost. Flags gaps and proposes the minimum action to close each.
+
+```
+/platform-skills:product review we're a 3-team platform org, 12 clusters, planning a SOC 2 audit in 6 months
+```
+
+---
+
+## Tips for best results
+
+**Paste context** — paste the manifest, error output, plan output, or code block directly after the command. The more concrete the input, the more actionable the output.
+
+**You don't need the slash command** — describe your problem in plain English and the skill activates automatically when you're working with relevant files.
+
+**Chain commands** — `/platform-skills:debug` to diagnose, then `/platform-skills:review` to validate the fix before merging.
+
+**Multi-mode workflows:**
+- New service: `instrument` → `alert` → `dashboard` → `loadtest`
+- New policy: `generate` → `test` → `validate`
+- New Helm chart: `create` → `review` → `security`
+- Incident: `investigate` → `postmortem` → `rfc` (if systemic)
+- Compliance: `gap` → `remediate` → `evidence` → `checklist`
+
+**Deep-dive references** — each command points to a `references/<domain>.md` file. Read those for full spec coverage, edge cases, and worked examples.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Both layers work independently. The plugin is optional.
 | Read a domain guide | [references/](references/) |
 | Copy a working example | [examples/](examples/) |
 | Install as a Claude plugin | [Installation](#installation) |
+| Learn how to use each slash command | [COMMANDS.md](COMMANDS.md) |
 | Set up VSCode with or without Claude | [VSCODE_INTEGRATION.md](VSCODE_INTEGRATION.md) |
 | Contribute a pattern | [CONTRIBUTING.md](CONTRIBUTING.md) |
 


### PR DESCRIPTION
## Summary

- Adds `COMMANDS.md` — a user-facing reference showing how to invoke each `/platform-skills:<command>` slash command with real examples
- Covers all 16 commands: review, debug, terraform, gitops, linkerd, linux, commit, helmcheck, observability, opa, compliance, datadog, dynatrace, document, mcp, product
- Each command shows the argument format, mode table (where applicable), and 3-4 concrete usage examples with realistic inputs
- Adds a link to `COMMANDS.md` in the main README navigation table

## Test plan

- [ ] All 16 commands listed match current `commands/` directory contents
- [ ] Slash command syntax matches `plugin.json` command names
- [ ] No broken links