### PR TITLE
feat: add PR Review domain (v1.12.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.11.0",
-      "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP server development, observability (Prometheus/OpenTelemetry/Grafana), code documentation (OpenAPI/docstrings), SOC 2 compliance for Terraform, Datadog, Dynatrace, conventional commit message generation, OPA/Conftest Rego policies, and Kyverno admission policies (ValidatingPolicy/MutatingPolicy/GeneratingPolicy/ImageValidatingPolicy, CEL expressions, Audit→Deny promotion, PolicyException, PSP/Gatekeeper migration). Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
+      "version": "1.12.0",
+      "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP server development, observability (Prometheus/OpenTelemetry/Grafana), code documentation (OpenAPI/docstrings), SOC 2 compliance for Terraform, Datadog, Dynatrace, conventional commit message generation, OPA/Conftest Rego policies, Kyverno admission policies (ValidatingPolicy/MutatingPolicy/GeneratingPolicy/ImageValidatingPolicy, CEL expressions, Audit→Deny promotion), and comprehensive PR review (cost impact, environment drift, ownership governance, compliance, deprecated API upgrade, rollback feasibility). Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
       "author": {
         "name": "Nitin Jain"
       },
@@ -85,7 +85,13 @@
         "admission-webhook",
         "pod-security",
         "policy-exception",
-        "policy-report"
+        "policy-report",
+        "pr-review",
+        "cost-analysis",
+        "environment-drift",
+        "rollback",
+        "upgrade-safety",
+        "governance"
       ],
       "source": {
         "source": "url",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platform-skills",
-  "version": "1.11.0",
-  "description": "Practical guidance for platform engineers: Kubernetes, Kyverno admission policies, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP development, observability, code documentation, and SOC 2 compliance for Terraform.",
+  "version": "1.12.0",
+  "description": "Practical guidance for platform engineers: Kubernetes, Kyverno admission policies, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP development, observability, code documentation, SOC 2 compliance, and comprehensive PR review (cost, drift, ownership, compliance, upgrade, rollback).",
   "author": {
     "name": "Nitin Jain",
     "email": "nitin.solna@gmail.com",
@@ -37,7 +37,12 @@
     "kyverno",
     "admission-policy",
     "policy-as-code",
-    "pod-security"
+    "pod-security",
+    "pr-review",
+    "cost-analysis",
+    "environment-drift",
+    "rollback",
+    "upgrade-safety"
   ],
   "skills": [
     "./skills/platform-skills"
@@ -59,6 +64,7 @@
     "./commands/dynatrace.md",
     "./commands/commit.md",
     "./commands/opa.md",
-    "./commands/kyverno.md"
+    "./commands/kyverno.md",
+    "./commands/pr-review.md"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-05-16
+
+### Added
+
+#### PR Review Domain
+
+New Domain 21: `PR Review` — comprehensive pre-merge risk review across six dimensions. Each mode inspects the diff and current file state, reports findings with severity, and recommends concrete fixes.
+
+- `references/pr-review.md` — cost impact (compute, storage, network spend delta with AWS pricing reference), environment drift detection (Kustomize overlay gaps, Helm values sibling mismatches, Terraform workspace drift, GitOps source drift, feature flag drift), ownership and governance (CODEOWNERS gaps, missing team labels, Terraform module README requirements, PR governance checklist), SOC 2 compliance mapping (CC6.1–CC8.1, A1.2 with Terraform patterns and `aws` CLI evidence collection commands), deprecated API / version hygiene (Kubernetes API removal timeline, Terraform provider constraint patterns, GitHub Actions SHA pinning, container digest pinning), rollback feasibility scoring (reversibility matrix: FULL/PARTIAL/MANUAL/NONE, blast radius: LOCAL/CLUSTER/PLATFORM/DATA, pre-merge requirements for high-risk changes, GitOps rollback patterns), and bot comment triage workflow with GH CLI commands for resolving threads
+- `/platform-skills:pr-review` (`commands/pr-review.md`) — six modes: `cost` (spend delta with severity per resource), `drift` (environment alignment across overlays, values files, Terraform workspaces), `ownership` (CODEOWNERS, team labels, module README, PR governance), `compliance` (SOC 2 control impact with remediation and auditor evidence commands), `upgrade` (deprecated Kubernetes APIs, loose Terraform constraints, floating action versions, `:latest` images), `rollback` (reversibility and blast radius score per change with Rollback Risk Score: 🟢/🟡/🔴), `full` (all six modes with Merge Readiness Summary)
+
 ## [1.11.0] - 2026-05-16
 
 ### Added

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1579,6 +1579,64 @@ Runs the full platform health checklist covering Developer Experience, Operation
 
 ---
 
+## `/platform-skills:pr-review`
+
+Comprehensive pre-merge risk review across six dimensions. Each mode inspects the diff and current file state, reports findings with severity, and recommends concrete fixes.
+
+**Modes**
+
+| Mode | What it reviews |
+|---|---|
+| `cost` | Compute, storage, and network spend delta |
+| `drift` | Environment alignment across dev/staging/prod overlays and values files |
+| `ownership` | CODEOWNERS gaps, missing team labels, Terraform module README, PR governance |
+| `compliance` | SOC 2 control impact — IAM, encryption, logging, network, change management |
+| `upgrade` | Deprecated Kubernetes APIs, loose Terraform provider constraints, floating action versions, `:latest` images |
+| `rollback` | Reversibility and blast radius score for every change |
+| `full` | All six modes in sequence with a Merge Readiness Summary |
+
+**Usage**
+
+```
+/platform-skills:pr-review cost [paste gh pr diff output or PR number]
+/platform-skills:pr-review drift
+/platform-skills:pr-review ownership
+/platform-skills:pr-review compliance
+/platform-skills:pr-review upgrade
+/platform-skills:pr-review rollback
+/platform-skills:pr-review full 42
+```
+
+**Example prompts**
+
+```
+/platform-skills:pr-review cost — here is the diff for PR #42: [paste output of gh pr diff 42]
+```
+```
+/platform-skills:pr-review drift — values-dev.yaml changed, check if prod is aligned
+```
+```
+/platform-skills:pr-review compliance — new IAM role added, verify CC6.1 and CC6.2
+```
+```
+/platform-skills:pr-review rollback — we're renaming a Deployment and adding an RDS storage increase
+```
+```
+/platform-skills:pr-review full 42
+```
+
+**Multi-mode workflow**
+
+```
+/platform-skills:pr-review full   # get the complete risk picture
+# fix blockers
+/platform-skills:review           # validate specific manifests before re-review
+```
+
+Reference: `references/pr-review.md`
+
+---
+
 ## Tips for best results
 
 **Paste context** — paste the manifest, error output, plan output, or code block directly after the command. The more concrete the input, the more actionable the output.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -4,7 +4,7 @@ This guide is for people who are new to Claude and want to start using this repo
 
 ## What This Repository Is
 
-`platform-skills` is a platform engineering handbook covering 20 domains: Terraform, Kubernetes, OpenShift, Flux / Argo CD, GitHub Actions, AWS / Azure, Linkerd, Linux & Networking, Platform Mindset, Cross-platform, Compliance (SOC 2), Helm, MCP, Observability, Documentation, Datadog, Dynatrace, Conventional Commits, OPA / Conftest, and Kyverno. You can browse it directly on GitHub, clone it for templates, or install it as a Claude plugin for interactive guidance. The handbook works without installing the plugin.
+`platform-skills` is a platform engineering handbook covering 21 domains: Terraform, Kubernetes, OpenShift, Flux / Argo CD, GitHub Actions, AWS / Azure, Linkerd, Linux & Networking, Platform Mindset, Cross-platform, Compliance (SOC 2), Helm, MCP, Observability, Documentation, Datadog, Dynatrace, Conventional Commits, OPA / Conftest, Kyverno, and PR Review. You can browse it directly on GitHub, clone it for templates, or install it as a Claude plugin for interactive guidance. The handbook works without installing the plugin.
 
 It helps with:
 

--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -206,6 +206,202 @@ A practical loop for any platform task:
 
 ---
 
+## How the PR Review Workflow Works
+
+`/platform-skills:pr-review` is the structured pre-merge risk review command. It accepts a PR number or a pasted diff and reviews it across six independent dimensions. Each mode produces severity-rated findings with concrete recommendations and, where relevant, exact remediation code.
+
+### Getting the diff
+
+```bash
+# Pipe the diff into your clipboard
+gh pr diff 42 | pbcopy   # macOS
+
+# Or write it to a file
+gh pr diff 42 > pr-42.diff
+```
+
+Then paste it after the command:
+
+```text
+/platform-skills:pr-review full
+
+[paste diff here]
+```
+
+### The six modes
+
+#### cost — spend delta
+
+Inspects compute, storage, and network changes for their cost impact. Compares instance types, replica counts, PVC sizes, NAT Gateways, and load balancers against AWS pricing benchmarks.
+
+```text
+/platform-skills:pr-review cost
+
+[diff showing replicas: 2 → 8 on a Deployment using m5.xlarge nodes]
+```
+
+Output:
+```
+[COST] payments-api Deployment — replicas increased from 2 to 8
+  Estimated delta: +$840/month (8× m5.xlarge On-Demand)
+  Severity: HIGH
+  Recommendation: Use HPA with minReplicas: 2 so floor cost stays low outside peak.
+```
+
+See: [examples/pr-review/cost/](examples/pr-review/cost/)
+
+#### drift — environment alignment
+
+Checks whether a change applied to one environment's config (Helm values, Kustomize overlay, Terraform workspace) was intentionally omitted from sibling environments or silently missed. Flags any security controls that differ across environments as HIGH.
+
+```text
+/platform-skills:pr-review drift
+
+values-dev.yaml: [paste]
+values-prod.yaml: [paste]
+```
+
+Output:
+```
+[DRIFT] values-dev.yaml vs values-prod.yaml
+  Field: ingress.annotations."nginx.ingress.kubernetes.io/ssl-redirect"
+  Dev: "true"   Prod: MISSING (chart default: "false")
+  Severity: HIGH — prod ingress does not force HTTPS; dev does
+  Recommendation: Add ssl-redirect: "true" to values-prod.yaml
+```
+
+See: [examples/pr-review/drift/](examples/pr-review/drift/)
+
+#### ownership — governance gaps
+
+Reviews whether new directories, namespaces, Terraform modules, and PRs have the ownership signals that make a platform operable at scale: CODEOWNERS entries, team labels, module READMEs, and variable descriptions.
+
+```text
+/platform-skills:pr-review ownership
+
+[diff adding a new platform/ directory and a Kubernetes Namespace]
+```
+
+Output:
+```
+[OWNERSHIP] platform/ — new top-level directory
+  Gap: No CODEOWNERS entry. Any engineer can self-merge PRs to this path.
+  Severity: HIGH
+  Recommendation: Add to .github/CODEOWNERS:
+    platform/   @platform-team @platform-leads
+```
+
+See: [examples/pr-review/ownership/](examples/pr-review/ownership/)
+
+#### compliance — SOC 2 control impact
+
+Maps every relevant change in the diff to a SOC 2 Trust Services Criteria control area (CC6.1–CC8.1, A1.2). Flags critical findings that would block an audit, provides exact Terraform remediations, and outputs the `aws` CLI commands auditors need to verify the control.
+
+```text
+/platform-skills:pr-review compliance
+
+[diff with wildcard IAM policy and unencrypted RDS]
+```
+
+Output:
+```
+[COMPLIANCE] CC6.1 — Logical access
+  Finding: aws_iam_role_policy.app uses Action: "*" Resource: "*"
+  Severity: CRITICAL
+  Remediation: Replace with explicit actions scoped to required services.
+  Auditor evidence: aws iam simulate-principal-policy ...
+```
+
+See: [examples/pr-review/compliance/](examples/pr-review/compliance/)
+
+#### upgrade — deprecated API and version hygiene
+
+Checks every `apiVersion` in the diff against the Kubernetes deprecation timeline, flags Terraform provider constraints that allow major version jumps, identifies GitHub Actions pinned to branches instead of SHAs, and finds `:latest` container image tags.
+
+```text
+/platform-skills:pr-review upgrade
+
+[diff with networking.k8s.io/v1beta1 Ingress and >= 3.0 provider constraint]
+```
+
+Output:
+```
+[UPGRADE] ingress.yaml:1 — networking.k8s.io/v1beta1 Ingress
+  Removed in: Kubernetes 1.22 — BREAKING
+  Replacement: apiVersion: networking.k8s.io/v1
+  Migration effort: LOW
+```
+
+See: [examples/pr-review/upgrade/](examples/pr-review/upgrade/)
+
+#### rollback — feasibility score
+
+Scores each change on two axes: **Reversibility** (FULL / PARTIAL / MANUAL / NONE) and **Blast radius** (LOCAL / CLUSTER / PLATFORM / DATA). Produces a traffic-light Rollback Risk Score and lists the exact pre-merge requirements for anything that is not fully reversible.
+
+```text
+/platform-skills:pr-review rollback
+
+[diff with RDS allocated_storage increase and Deployment rename]
+```
+
+Output:
+```
+[ROLLBACK] aws_db_instance.payments — allocated_storage 100 → 500 GB
+  Reversibility: NONE — AWS does not support storage decrease
+  Blast radius: DATA
+  Pre-merge requirement: Take manual RDS snapshot and record ARN in PR description
+
+Rollback Risk Score: 🔴 HIGH
+```
+
+See: [examples/pr-review/rollback/](examples/pr-review/rollback/)
+
+### full mode — Merge Readiness Summary
+
+Run all six modes in sequence and get a single consolidated summary:
+
+```text
+/platform-skills:pr-review full 42
+```
+
+```
+Cost delta:      +$840/month (2 findings)
+Drift:           3 environment mismatches
+Ownership gaps:  2 findings
+Compliance:      2 control areas affected (2 critical)
+Upgrade risk:    2 deprecated items (2 breaking)
+Rollback score:  🔴 HIGH
+
+Blockers (must fix before merge):
+  - Wildcard IAM action and resource (CC6.1)
+  - RDS storage_encrypted = false (CC6.7)
+  - networking.k8s.io/v1beta1 Ingress (removed in K8s 1.22)
+  - RDS storage increase — take snapshot first (Reversibility: NONE)
+
+Recommended:
+  - Add ssl-redirect annotation to values-prod.yaml
+  - Add CODEOWNERS entry for platform/
+
+Informational:
+  - replica increase adds $840/month; confirm with team before merge
+```
+
+### What the agent does under the hood
+
+```
+You: /platform-skills:pr-review compliance [paste diff]
+
+Claude:
+  1. Reads commands/pr-review.md → loads compliance mode definition
+  2. Reads references/pr-review.md → loads SOC 2 control mapping table
+  3. Reads references/compliance.md → loads Terraform patterns and evidence commands
+  4. Parses the diff — identifies IAM, RDS, S3, and network resource changes
+  5. Maps each change to a TSC control code
+  6. For each finding: produces severity, exact remediation, and auditor evidence command
+```
+
+---
+
 ## What the Agent Cannot Do
 
 Be clear about the limits:

--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -105,6 +105,7 @@ Slash commands are predefined workflows. Use them instead of writing a long prom
 | `/platform-skills:commit` | Write a commit message, generate a commit, describe staged changes, or validate a message |
 | `/platform-skills:opa` | Generate Rego policies, write unit tests, run fmt/regal/verify pipeline, explain or debug |
 | `/platform-skills:kyverno` | Generate, test, audit, debug, or migrate Kyverno admission policies |
+| `/platform-skills:pr-review` | Comprehensive PR review: cost, drift, ownership, compliance, upgrade, rollback |
 
 Invoke a command by typing it at the start of your message:
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Both layers work independently. The plugin is optional.
 | 🦖 Dynatrace | [references/dynatrace.md](references/dynatrace.md) | OneAgent Kubernetes Operator, custom metrics, SLOs, dashboards and alerting via Terraform provider |
 | 💬 Conventional Commits | [references/conventional-commits.md](references/conventional-commits.md) | Message structure, type classification, atomic staging, commitlint/husky/semantic-release tooling |
 | 📋 OPA / Conftest | [references/opa.md](references/opa.md) | Rego v1 syntax, rule types, unit tests, fmt/regal/verify validation pipeline, GitHub Actions integration |
+| 🔍 PR Review | [references/pr-review.md](references/pr-review.md) | Cost impact, environment drift, ownership gaps, SOC 2 compliance, deprecated API / version hygiene, rollback feasibility |
 
 ## Core principles
 
@@ -150,7 +151,8 @@ platform-skills/
 │   ├── linux-networking.md
 │   ├── platform-mindset.md
 │   ├── compliance.md                   # SOC 2 controls in Terraform (v1.6.0)
-│   └── helm.md                         # Helm chart patterns, lint pipeline, values design
+│   ├── helm.md                         # Helm chart patterns, lint pipeline, values design
+│   └── pr-review.md                    # PR review: cost, drift, ownership, compliance, upgrade, rollback (v1.12.0)
 │
 ├── examples/                           # Working examples and handbook snippets
 │   ├── flux/basic-monorepo/            # Complete Flux CD monorepo structure
@@ -197,6 +199,7 @@ platform-skills/
 - [x] v1.9.0 — Conventional Commits: analyze diffs, generate WHY-focused commit messages, intelligent file staging, commitlint/husky/semantic-release tooling
 - [x] v1.10.0 — OPA / Conftest: generate Rego policies, unit tests, fmt/regal/verify validation pipeline, explain and debug
 - [x] v1.11.0 — Kyverno: ValidatingPolicy/MutatingPolicy/GeneratingPolicy/ImageValidatingPolicy (policies.kyverno.io/v1), CEL expressions, Audit→Deny promotion, PolicyException, PolicyReport analysis, kyverno-cli testing, PSP and Gatekeeper migration
+- [x] v1.12.0 — PR Review: cost impact, environment drift, ownership and governance gaps, SOC 2 compliance, deprecated API / version hygiene, rollback feasibility scoring
 
 **Planned**
 - [ ] GCP: landing zone, GKE, Workload Identity, and IAM patterns

--- a/README.md
+++ b/README.md
@@ -40,28 +40,28 @@ Both layers work independently. The plugin is optional.
 
 | Domain | Reference guide | What it covers |
 |---|---|---|
-| ☸️ Kubernetes | [references/kubernetes.md](references/kubernetes.md) | Cluster baseline, workload patterns, network policy, RBAC, pod security |
-| 🛡️ Kyverno | [references/kyverno.md](references/kyverno.md) | Validate/mutate/generate/verifyImages policies, Audit→Enforce promotion, PolicyException, PolicyReport, kyverno-cli testing, PSP/Gatekeeper migration |
-| 🟥 OpenShift | [references/openshift.md](references/openshift.md) | Routes, SCC compatibility, operator usage, tenant isolation |
-| 🚢 Argo CD | [references/argocd.md](references/argocd.md) | App-of-apps design, ApplicationSet, sync control, promotion flows |
-| 🔄 Flux CD | [references/flux.md](references/flux.md) | Monorepo structure, reconciliation, multi-tenancy, image automation |
-| ☁️ AWS | [references/aws.md](references/aws.md) | IAM least-privilege, IRSA, EKS, resource tagging, cost allocation |
-| 🌐 Azure | [references/azure.md](references/azure.md) | Workload identity, AKS, RBAC, resource tagging, Azure Policy |
-| 🏗️ Terraform | [references/terraform.md](references/terraform.md) | Module design, state management, testing, CI/CD integration |
-| 🚀 GitHub Actions | [references/github-actions.md](references/github-actions.md) | Security hardening, OIDC, SHA pinning, reusable workflows |
+| <img src="https://cdn.simpleicons.org/kubernetes/326CE5" width="16" height="16" alt="Kubernetes"> Kubernetes | [references/kubernetes.md](references/kubernetes.md) | Cluster baseline, workload patterns, network policy, RBAC, pod security |
+| 🛡️ Kyverno | [references/kyverno.md](references/kyverno.md) | Validate/mutate/generate/verifyImages policies, Audit→Deny promotion, PolicyException, PolicyReport, kyverno-cli testing, PSP/Gatekeeper migration |
+| <img src="https://cdn.simpleicons.org/redhatopenshift/EE0000" width="16" height="16" alt="OpenShift"> OpenShift | [references/openshift.md](references/openshift.md) | Routes, SCC compatibility, operator usage, tenant isolation |
+| <img src="https://cdn.simpleicons.org/argo/EF7B4D" width="16" height="16" alt="Argo CD"> Argo CD | [references/argocd.md](references/argocd.md) | App-of-apps design, ApplicationSet, sync control, promotion flows |
+| <img src="https://cdn.simpleicons.org/flux/5468FF" width="16" height="16" alt="Flux CD"> Flux CD | [references/flux.md](references/flux.md) | Monorepo structure, reconciliation, multi-tenancy, image automation |
+| <img src="https://cdn.simpleicons.org/amazonaws/FF9900" width="16" height="16" alt="AWS"> AWS | [references/aws.md](references/aws.md) | IAM least-privilege, IRSA, EKS, resource tagging, cost allocation |
+| <img src="https://cdn.simpleicons.org/microsoftazure/0078D4" width="16" height="16" alt="Azure"> Azure | [references/azure.md](references/azure.md) | Workload identity, AKS, RBAC, resource tagging, Azure Policy |
+| <img src="https://cdn.simpleicons.org/terraform/844FBA" width="16" height="16" alt="Terraform"> Terraform | [references/terraform.md](references/terraform.md) | Module design, state management, testing, CI/CD integration |
+| <img src="https://cdn.simpleicons.org/githubactions/2088FF" width="16" height="16" alt="GitHub Actions"> GitHub Actions | [references/github-actions.md](references/github-actions.md) | Security hardening, OIDC, SHA pinning, reusable workflows |
 | 🗺️ Platform model | [references/platform-operating-model.md](references/platform-operating-model.md) | Ownership boundaries, promotion flows, cross-tool design |
 | 🔐 Secrets | [references/secrets.md](references/secrets.md) | External Secrets Operator, Sealed Secrets, provider setup, troubleshooting |
-| 🔗 Linkerd | [references/linkerd.md](references/linkerd.md) | mTLS, proxy injection, AuthorizationPolicy, observability, multi-cluster |
-| 🐧 Linux & Networking | [references/linux-networking.md](references/linux-networking.md) | Linux admin, DNS, load balancing, VPC/VNet design, connectivity troubleshooting |
+| <img src="https://cdn.simpleicons.org/linkerd/2BEDA7" width="16" height="16" alt="Linkerd"> Linkerd | [references/linkerd.md](references/linkerd.md) | mTLS, proxy injection, AuthorizationPolicy, observability, multi-cluster |
+| <img src="https://cdn.simpleicons.org/linux/FCC624" width="16" height="16" alt="Linux"> Linux & Networking | [references/linux-networking.md](references/linux-networking.md) | Linux admin, DNS, load balancing, VPC/VNet design, connectivity troubleshooting |
 | 🧠 Platform Mindset | [references/platform-mindset.md](references/platform-mindset.md) | DevEx, friction audits, RFC/ADR, incident comms, post-mortems, capacity planning |
 | 🔒 Compliance | [references/compliance.md](references/compliance.md) | SOC 2 Trust Services Criteria in Terraform: IAM, encryption, detection, audit logging, backup, Checkov enforcement |
-| ⛵ Helm | [references/helm.md](references/helm.md) | Chart scaffolding, values design, template patterns, security hardening, lint/validation pipeline, GitOps integration |
+| <img src="https://cdn.simpleicons.org/helm/0F1689" width="16" height="16" alt="Helm"> Helm | [references/helm.md](references/helm.md) | Chart scaffolding, values design, template patterns, security hardening, lint/validation pipeline, GitOps integration |
 | 🔌 MCP | [references/mcp.md](references/mcp.md) | Model Context Protocol server/client development, TypeScript and Python SDKs, stdio/SSE transports, security, testing |
-| 📊 Observability | [references/observability.md](references/observability.md) | Structured logging, Prometheus metrics, OpenTelemetry tracing, Grafana dashboards, alerting rules, k6 load testing, capacity planning |
+| <img src="https://cdn.simpleicons.org/prometheus/E6522C" width="16" height="16" alt="Prometheus"> Observability | [references/observability.md](references/observability.md) | Structured logging, Prometheus metrics, OpenTelemetry tracing, Grafana dashboards, alerting rules, k6 load testing, capacity planning |
 | 📝 Documentation | [references/documentation.md](references/documentation.md) | Docstrings (Google/NumPy/JSDoc), OpenAPI 3.1 specs, doc sites (MkDocs/TypeDoc), developer guides |
-| 📈 Datadog | [references/datadog.md](references/datadog.md) | Agent Helm setup, APM instrumentation, log management, monitors/dashboards/SLOs as Terraform |
-| 🔭 Dynatrace | [references/dynatrace.md](references/dynatrace.md) | OneAgent Kubernetes Operator, custom metrics, SLOs, dashboards and alerting via Terraform provider |
-| 💬 Conventional Commits | [references/conventional-commits.md](references/conventional-commits.md) | Message structure, type classification, atomic staging, commitlint/husky/semantic-release tooling |
+| <img src="https://cdn.simpleicons.org/datadog/632CA6" width="16" height="16" alt="Datadog"> Datadog | [references/datadog.md](references/datadog.md) | Agent Helm setup, APM instrumentation, log management, monitors/dashboards/SLOs as Terraform |
+| <img src="https://cdn.simpleicons.org/dynatrace/1496FF" width="16" height="16" alt="Dynatrace"> Dynatrace | [references/dynatrace.md](references/dynatrace.md) | OneAgent Kubernetes Operator, custom metrics, SLOs, dashboards and alerting via Terraform provider |
+| <img src="https://cdn.simpleicons.org/git/F05032" width="16" height="16" alt="Git"> Conventional Commits | [references/conventional-commits.md](references/conventional-commits.md) | Message structure, type classification, atomic staging, commitlint/husky/semantic-release tooling |
 | 📋 OPA / Conftest | [references/opa.md](references/opa.md) | Rego v1 syntax, rule types, unit tests, fmt/regal/verify validation pipeline, GitHub Actions integration |
 | 🔍 PR Review | [references/pr-review.md](references/pr-review.md) | Cost impact, environment drift, ownership gaps, SOC 2 compliance, deprecated API / version hygiene, rollback feasibility |
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Both layers work independently. The plugin is optional.
 | 🔌 MCP | [references/mcp.md](references/mcp.md) | Model Context Protocol server/client development, TypeScript and Python SDKs, stdio/SSE transports, security, testing |
 | 📊 Observability | [references/observability.md](references/observability.md) | Structured logging, Prometheus metrics, OpenTelemetry tracing, Grafana dashboards, alerting rules, k6 load testing, capacity planning |
 | 📝 Documentation | [references/documentation.md](references/documentation.md) | Docstrings (Google/NumPy/JSDoc), OpenAPI 3.1 specs, doc sites (MkDocs/TypeDoc), developer guides |
-| 🐕 Datadog | [references/datadog.md](references/datadog.md) | Agent Helm setup, APM instrumentation, log management, monitors/dashboards/SLOs as Terraform |
-| 🦖 Dynatrace | [references/dynatrace.md](references/dynatrace.md) | OneAgent Kubernetes Operator, custom metrics, SLOs, dashboards and alerting via Terraform provider |
+| 📈 Datadog | [references/datadog.md](references/datadog.md) | Agent Helm setup, APM instrumentation, log management, monitors/dashboards/SLOs as Terraform |
+| 🔭 Dynatrace | [references/dynatrace.md](references/dynatrace.md) | OneAgent Kubernetes Operator, custom metrics, SLOs, dashboards and alerting via Terraform provider |
 | 💬 Conventional Commits | [references/conventional-commits.md](references/conventional-commits.md) | Message structure, type classification, atomic staging, commitlint/husky/semantic-release tooling |
 | 📋 OPA / Conftest | [references/opa.md](references/opa.md) | Rego v1 syntax, rule types, unit tests, fmt/regal/verify validation pipeline, GitHub Actions integration |
 | 🔍 PR Review | [references/pr-review.md](references/pr-review.md) | Cost impact, environment drift, ownership gaps, SOC 2 compliance, deprecated API / version hygiene, rollback feasibility |

--- a/SKILL.md
+++ b/SKILL.md
@@ -22,6 +22,7 @@ Match the task to the right layer:
 9. `Platform Mindset`: Treat developers as customers. Apply product thinking, friction audits, DevEx metrics, RFC/ADR processes, incident communication, and blameless post-mortems.
 10. `Cross-platform`: Design repo boundaries, ownership, promotion flows, and security controls first.
 11. `Kyverno`: Write and maintain Kubernetes-native admission policies using the CEL-based types — `ValidatingPolicy`, `MutatingPolicy`, `GeneratingPolicy`, `ImageValidatingPolicy` (all `policies.kyverno.io/v1`). Covers `matchConstraints`, `matchConditions`, CEL validations/mutations, `generator.Apply()`, Audit→Deny promotion, PolicyException, and kyverno-cli testing.
+12. `PR Review`: Comprehensive pre-merge risk review across six dimensions — cost impact, environment drift, ownership and governance gaps, SOC 2 compliance, deprecated API / version hygiene, and rollback feasibility scoring.
 
 If a task spans multiple areas, decide which layer owns the source of truth and keep the other layers consumers of that state.
 
@@ -66,6 +67,7 @@ When asked to generate code, start from the thinnest useful slice that proves th
 - For Linkerd service mesh, mTLS, observability, traffic management, and multi-cluster, read [references/linkerd.md](references/linkerd.md).
 - For Linux administration, DNS, load balancing, VPC/VNet design, kernel tuning, and network troubleshooting, read [references/linux-networking.md](references/linux-networking.md).
 - For product mindset, developer experience, friction audits, RFC/ADR, incident communication, post-mortems, and capacity planning, read [references/platform-mindset.md](references/platform-mindset.md).
+- For comprehensive PR review — cost impact, environment drift, ownership gaps, SOC 2 compliance, deprecated APIs, version hygiene, rollback feasibility, and bot comment triage — read [references/pr-review.md](references/pr-review.md).
 
 Load only the files needed for the current request.
 
@@ -81,3 +83,4 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:kyverno` — Kyverno policy generation, testing, cluster audit, debugging, and PSP/Gatekeeper migration
 - `/platform-skills:linux` — Linux administration, DNS, load balancing, VPC/VNet, and connectivity troubleshooting
 - `/platform-skills:product` — product thinking, friction audits, DevEx, RFC/ADR, incident updates, post-mortems
+- `/platform-skills:pr-review` — comprehensive PR review: cost, drift, ownership, compliance, upgrade, rollback

--- a/commands/pr-review.md
+++ b/commands/pr-review.md
@@ -1,0 +1,400 @@
+---
+name: pr-review
+description: Comprehensive PR review across six dimensions — cost impact, environment drift, ownership gaps, SOC 2 compliance, deprecated API / version hygiene, and rollback feasibility. Each mode inspects the diff and current file state, reports findings with severity, and recommends concrete fixes. Use when preparing a PR for merge, conducting a pre-deployment readiness check, or performing a post-merge risk assessment.
+argument-hint: "[cost|drift|ownership|compliance|upgrade|rollback|full] [PR number or diff]"
+---
+
+You are a senior platform engineer performing a structured pre-merge risk review.
+
+Input: `$ARGUMENTS` — one of the modes below, optionally followed by a PR number or pasted diff.
+
+If no PR number or diff is provided, ask the user to paste the diff or provide `gh pr diff <number>` output before proceeding.
+
+---
+
+## Mode: cost
+
+Identify changes in the diff that will increase or decrease cloud spend.
+
+### What to check
+
+**Compute**
+- Instance type changes (e.g. `t3.medium` → `m5.xlarge`) — flag cost multiplier
+- Replica count increases in Deployment, HPA `minReplicas`, or Karpenter `NodePool` `limits`
+- New node groups or node pools — estimate baseline cost from instance type
+- Removal of Spot/preemptible usage in favour of On-Demand
+
+**Storage**
+- New PersistentVolumeClaim — flag size and StorageClass (`gp2` vs `gp3` vs `io1`)
+- `gp2` → flag: `gp3` is 20% cheaper at equal performance
+- EBS volume type changes that affect IOPS cost
+- New S3 buckets without lifecycle rules — unbounded storage growth risk
+- RDS storage changes — `allocated_storage` increases are irreversible without snapshot/restore
+
+**Network**
+- New NAT Gateway — ~$32/month per AZ plus $0.045/GB data processing
+- Cross-AZ load balancer targets — invisible per-GB charge
+- New NLB or ALB — ~$16–22/month base plus LCU cost
+- CloudFront distribution additions
+- VPN or Direct Connect attachment changes
+
+**Data transfer**
+- New inter-region replication (S3, RDS, DynamoDB)
+- New egress paths (new public endpoints, new internet-facing services)
+
+**Managed services**
+- New RDS instance or Aurora cluster — note instance class and Multi-AZ flag
+- New ElastiCache cluster
+- New MSK or Kinesis stream
+- New EKS managed node group with on-demand instances
+
+### Output format
+
+For each finding:
+```
+[COST] <resource name> — <change description>
+  Estimated delta: +$X/month (basis: <pricing reference>)
+  Severity: HIGH / MEDIUM / LOW
+  Recommendation: <concrete action to reduce cost or accept with justification>
+```
+
+End with a **Cost Summary** table:
+
+| Resource | Change | Est. Delta/month | Severity |
+|---|---|---|---|
+
+Flag any change with no resource requests/limits set — these lead to silent overprovisioning.
+
+Reference: `references/pr-review.md` → Cost Impact
+
+---
+
+## Mode: drift
+
+Detect configuration drift between environments (dev/staging/prod, or cluster overlays).
+
+### What to check
+
+**Kustomize / overlay drift**
+- A base or overlay changed for one environment but not its siblings — scan for `overlays/dev`, `overlays/staging`, `overlays/prod` patterns
+- `kustomization.yaml` patch added to one overlay but missing from another
+- Image tag pinned differently across overlays
+
+**Helm values drift**
+- `values-dev.yaml`, `values-staging.yaml`, `values-prod.yaml` — if one changed, check siblings
+- Replica counts, resource limits, ingress hostnames, feature flags that differ without explanation
+- A values key present in dev but absent in prod (would fall back to chart default silently)
+
+**Terraform workspace / environment drift**
+- `environments/dev/main.tf` changed but `environments/prod/main.tf` not touched
+- Module version pinned to different versions across environments
+- Variable values diverged without a comment explaining why
+
+**GitOps source drift**
+- Flux `HelmRelease` or `Kustomization` with different `spec.interval`, `spec.timeout`, or `spec.retries` between clusters
+- Argo CD `Application` targeting different target revisions per environment without explicit promotion intent
+
+**Feature flag drift**
+- ConfigMap or environment variable that enables a feature in staging but is absent from prod equivalent
+
+### Output format
+
+For each finding:
+```
+[DRIFT] <file> vs <sibling file>
+  Field: <key path>
+  Dev value: <x>   Staging value: <y>   Prod value: <z or MISSING>
+  Severity: HIGH / MEDIUM / INFO
+  Recommendation: Align values or add a comment explaining intentional divergence
+```
+
+Ask: "Is this drift intentional or an oversight?" — flag HIGH if it affects a path that runs in prod but not lower environments.
+
+Reference: `references/pr-review.md` → Environment Drift
+
+---
+
+## Mode: ownership
+
+Identify governance gaps introduced or exposed by the diff.
+
+### What to check
+
+**CODEOWNERS**
+- New top-level directory with no CODEOWNERS entry
+- New `references/`, `commands/`, or `examples/` subdirectory not covered by an existing glob
+- Deleted directory that still has a CODEOWNERS entry (stale rule)
+
+**Kubernetes resource ownership**
+- New Namespace with no `team:` or `owner:` label
+- New Deployment, StatefulSet, or CronJob with no `app.kubernetes.io/team` label
+- ServiceAccount with no owning team annotation
+
+**Terraform module ownership**
+- New module directory with no `README.md` describing purpose, inputs, outputs, and team
+- `variables.tf` with no `description` on any variable
+- Module consumed with no `source` pinned to a version tag
+
+**PR governance**
+- No linked issue or ticket reference in PR description (search for `#`, `JIRA-`, `LINEAR-`)
+- PR author would be the only required reviewer (self-merge risk) — note if CODEOWNERS has no coverage for changed paths
+- No `CHANGELOG.md` update when `version` changed in `plugin.json`, `marketplace.json`, `Chart.yaml`, or `package.json`
+
+**Policy coverage**
+- New Namespace with no matching Kyverno `ValidatingPolicy` or `NetworkPolicy`
+- New workload type not covered by existing admission policies
+
+### Output format
+
+```
+[OWNERSHIP] <file or resource>
+  Gap: <description of missing ownership signal>
+  Severity: HIGH / MEDIUM / LOW
+  Recommendation: <exact addition needed>
+```
+
+Reference: `references/pr-review.md` → Ownership and Governance
+
+---
+
+## Mode: compliance
+
+Assess SOC 2 Trust Services Criteria impact of the diff.
+
+Map each finding to a SOC 2 control area:
+
+| Code | Area |
+|---|---|
+| CC6.1 | Logical access — least privilege, RBAC, no wildcard IAM |
+| CC6.2 | Authentication — MFA, OIDC, no static credentials |
+| CC6.6 | Network security — VPC isolation, security groups, private subnets |
+| CC6.7 | Encryption — at-rest and in-transit on all data stores |
+| CC6.8 | Vulnerability management — IaC scanning, image scanning |
+| CC7.1 | Detection — GuardDuty, CloudWatch, Security Hub |
+| CC7.2 | Audit logging — CloudTrail, VPC flow logs, API access logs |
+| CC8.1 | Change management — PR workflow, plan review, state locking |
+| A1.2  | Backup — automated backups, retention ≥ 35 days |
+
+### What to check
+
+**CC6.1 — Logical access**
+- IAM policy with `Action: "*"` or `Resource: "*"` — wildcard must have explicit justification
+- RBAC ClusterRole with `verbs: ["*"]` or `resources: ["*"]`
+- New service account bound to a ClusterRole with broad permissions
+- IRSA / Workload Identity role with no condition narrowing to a specific namespace/SA
+
+**CC6.2 — Authentication**
+- Static AWS access keys (`aws_access_key_id`) anywhere in diff — critical
+- Long-lived tokens or passwords in ConfigMaps or environment variables
+- New GitHub Actions workflow using `aws-actions/configure-aws-credentials` without OIDC
+
+**CC6.6 — Network**
+- Security group with `0.0.0.0/0` ingress on non-80/443 ports
+- New publicly accessible RDS instance (`publicly_accessible = true`)
+- Kubernetes Service of type `LoadBalancer` with no annotation restricting source CIDRs
+- NetworkPolicy removed from a namespace
+
+**CC6.7 — Encryption**
+- New S3 bucket without `server_side_encryption_configuration`
+- RDS instance with `storage_encrypted = false`
+- EBS volume with `encrypted = false`
+- Secret stored in a ConfigMap instead of a Secret resource or external secrets backend
+
+**CC7.2 — Audit logging**
+- CloudTrail trail disabled or logging bucket changed
+- S3 bucket access logging removed
+- Kubernetes audit policy weakened (reduced log level)
+
+**CC8.1 — Change management**
+- Terraform state backend changed without documented migration plan
+- `prevent_destroy = true` removed from a stateful resource
+- Direct push to main/protected branch bypassing PR workflow
+
+### Output format
+
+```
+[COMPLIANCE] CC<X.X> — <control area>
+  Finding: <description>
+  File: <path>
+  Severity: CRITICAL / HIGH / MEDIUM
+  Remediation: <exact fix with code example>
+  Auditor evidence: <command to produce evidence for auditors>
+```
+
+End with a **Compliance Summary** listing all affected control codes and whether each is a blocker.
+
+Reference: `references/pr-review.md` → Compliance and SOC 2, `references/compliance.md`
+
+---
+
+## Mode: upgrade
+
+Detect deprecated APIs, EOL versions, and version hygiene issues.
+
+### What to check
+
+**Kubernetes API versions**
+
+Check each resource `apiVersion` in the diff against the target cluster version:
+
+| Deprecated API | Removed in | Replacement |
+|---|---|---|
+| `extensions/v1beta1` Ingress | 1.22 | `networking.k8s.io/v1` |
+| `networking.k8s.io/v1beta1` Ingress | 1.22 | `networking.k8s.io/v1` |
+| `policy/v1beta1` PodSecurityPolicy | 1.25 | Kyverno / OPA / PSA |
+| `policy/v1beta1` PodDisruptionBudget | 1.25 | `policy/v1` |
+| `autoscaling/v2beta1` HPA | 1.26 | `autoscaling/v2` |
+| `batch/v1beta1` CronJob | 1.25 | `batch/v1` |
+| `apiextensions.k8s.io/v1beta1` CRD | 1.22 | `apiextensions.k8s.io/v1` |
+| `kyverno.io/v1` ClusterPolicy | deprecated 1.17, removal 1.20 | `policies.kyverno.io/v1` |
+
+**Terraform provider versions**
+- Provider constraint too loose: `>= 3.0` allows major version jumps with breaking changes — recommend `~> X.Y`
+- `required_terraform` version missing or too broad
+- Module `source` without a version tag (e.g. `source = "git::..."` with no `ref=`)
+
+**GitHub Actions**
+- Action pinned to a branch (`@main`, `@master`) — must be pinned to a SHA or immutable tag
+- Action using a deprecated major version (e.g. `actions/checkout@v2` when `v4` is current)
+- `runs-on: ubuntu-18.04` or `ubuntu-20.04` — both EOL on GitHub Actions
+
+**Container images**
+- `:latest` tag — not reproducible, breaks rollback
+- Image from an unverified registry without digest pinning
+- Base image with a known EOL tag (e.g. `node:14`, `python:3.7`)
+
+**Helm**
+- `apiVersion: v1` chart when `v2` features are used (dependencies, type field)
+- Deprecated chart values that map to removed chart keys (validate against chart schema)
+
+**Tool versions in CI**
+- `terraform` version pinned to a specific patch but not aligned with `required_version` constraint
+- `kubectl` version more than one minor version skew from the cluster version
+- `helm` version not pinned (uses runner default)
+
+### Output format
+
+```
+[UPGRADE] <file>:<line>
+  Found: <deprecated item>
+  Target version: <cluster/provider/tool version>
+  Removed in: <version where this breaks>
+  Replacement: <exact updated value>
+  Migration effort: LOW / MEDIUM / HIGH
+```
+
+Flag any item that will break on the next minor version upgrade as **BREAKING**.
+
+Reference: `references/pr-review.md` → Upgrade and Version Hygiene
+
+---
+
+## Mode: rollback
+
+Score the rollback feasibility of the changes in the diff.
+
+### Rollback feasibility scoring
+
+Score each change on two axes:
+
+**Reversibility** (can you undo this by reverting the commit?)
+- `FULL` — revert commit restores previous state completely
+- `PARTIAL` — revert restores config but side effects persist (e.g. DNS TTL, cache)
+- `MANUAL` — revert is not enough; manual steps required
+- `NONE` — change is irreversible without data loss or significant effort
+
+**Blast radius** (what breaks if rollback is needed?)
+- `LOCAL` — one service or namespace
+- `CLUSTER` — all workloads in a cluster
+- `PLATFORM` — shared infrastructure (IAM, VPC, DNS, state backend)
+- `DATA` — data store schema, backup policy, or retention change
+
+### What to check
+
+**Database / stateful changes**
+- Schema migration without a corresponding down migration → Reversibility: NONE
+- `allocated_storage` increase on RDS → irreversible without snapshot/restore
+- DynamoDB table attribute or key schema change → Reversibility: NONE
+- Backup retention period reduced → audit trail gap even after revert
+
+**Kubernetes resource renames**
+- Resource renamed (Deployment, ConfigMap, Secret) with `prune: true` in Kustomization → old resource deleted on sync, new resource created — rollback requires re-creating old resource
+- Service rename with active DNS records → clients cache old name
+
+**Terraform destructive operations**
+- `-/+` replace in plan output for any stateful resource (RDS, EKS node group, ElastiCache)
+- `prevent_destroy = true` removed from a resource
+- `force_destroy = true` added to an S3 bucket or EKS cluster
+- State backend migration without locking
+
+**GitOps**
+- `prune: true` Kustomization + resource deletion → rollback recreates resource but loses any out-of-band state
+- HelmRelease with `remediation.uninstall: true` — rollback triggers full uninstall, not just version pin
+- Image tag changed to a mutable tag (`:latest`) — rollback points to different image than before
+
+**Secrets and credentials**
+- Secret rotation without grace period — old clients fail immediately on rollback
+- IRSA / Workload Identity role ARN changed — pods need restart to pick up new token
+
+**IAM and RBAC**
+- IAM role deleted or trust policy changed — dependent services break immediately
+- RBAC ClusterRole deleted — ServiceAccounts lose permissions immediately
+
+### Output format
+
+```
+[ROLLBACK] <resource / file>
+  Change: <description>
+  Reversibility: FULL / PARTIAL / MANUAL / NONE
+  Blast radius: LOCAL / CLUSTER / PLATFORM / DATA
+  Rollback procedure: <exact steps if not a simple git revert>
+  Pre-merge requirement: <what must be in place before merging — backup, snapshot, migration script>
+```
+
+End with a **Rollback Risk Score**:
+
+| Risk Level | Criteria |
+|---|---|
+| 🟢 LOW | All changes FULL reversibility, LOCAL blast radius |
+| 🟡 MEDIUM | Any PARTIAL reversibility or CLUSTER blast radius |
+| 🔴 HIGH | Any MANUAL/NONE reversibility or PLATFORM/DATA blast radius |
+
+If risk is HIGH, recommend: require a pre-merge snapshot, runbook, or explicit sign-off before merge.
+
+Reference: `references/pr-review.md` → Rollback Feasibility
+
+---
+
+## Mode: full
+
+Run all six modes in sequence against the same diff. Output sections in this order:
+
+1. **Cost** — spend delta
+2. **Drift** — environment alignment
+3. **Ownership** — governance gaps
+4. **Compliance** — SOC 2 control impact
+5. **Upgrade** — deprecated APIs and version hygiene
+6. **Rollback** — feasibility and risk score
+
+End with a **Merge Readiness Summary**:
+
+```
+Cost delta:      +$X/month (N findings)
+Drift:           N environment mismatches
+Ownership gaps:  N findings
+Compliance:      N control areas affected (K critical)
+Upgrade risk:    N deprecated items (K breaking)
+Rollback score:  🟢 LOW / 🟡 MEDIUM / 🔴 HIGH
+
+Blockers (must fix before merge):
+  - <item 1>
+  - <item 2>
+
+Recommended (should fix, not blocking):
+  - <item 1>
+
+Informational:
+  - <item 1>
+```
+
+Reference: `references/pr-review.md`

--- a/examples/pr-review/README.md
+++ b/examples/pr-review/README.md
@@ -1,0 +1,161 @@
+# PR Review Examples
+
+Realistic before/after scenarios for each `/platform-skills:pr-review` mode. Each example shows the input that triggers a finding and the expected output the command produces.
+
+## Structure
+
+```
+cost/
+  deployment-replica-increase.yaml   # Replica bump + missing resource requests
+  terraform-nat-gateway.tf           # Redundant NAT Gateways per subnet vs per AZ
+
+drift/
+  values-dev.yaml                    # Dev Helm values with ssl-redirect + feature flag
+  values-prod.yaml                   # Prod Helm values missing those keys
+  kustomization-prod.yaml            # Prod overlay missing HPA patch present in dev/staging
+
+ownership/
+  missing-codeowners.txt             # New top-level directory with no CODEOWNERS entry
+  namespace-missing-labels.yaml      # Namespace with no team label or ResourceQuota
+
+compliance/
+  iam-wildcard.tf                    # Wildcard IAM (CC6.1) + unencrypted RDS (CC6.7)
+
+upgrade/
+  deprecated-apis.yaml               # networking.k8s.io/v1beta1, batch/v1beta1 (removed 1.22/1.25)
+  terraform-loose-constraints.tf     # ">= 3.0" provider constraint, unversioned module source
+
+rollback/
+  rds-storage-increase.tf            # Irreversible RDS storage increase + prevent_destroy removal
+  resource-rename.yaml               # Deployment rename with prune:true + broken Service selector
+```
+
+## Quick Start
+
+Get the diff for a real PR and pipe it in:
+
+```bash
+gh pr diff 42 | pbcopy    # macOS
+```
+
+Then in Claude:
+
+```
+/platform-skills:pr-review cost
+[paste diff]
+```
+
+Or run all modes at once:
+
+```
+/platform-skills:pr-review full 42
+```
+
+## Example by Mode
+
+### cost
+
+```
+/platform-skills:pr-review cost
+
+[paste examples/pr-review/cost/deployment-replica-increase.yaml diff]
+```
+
+Expected findings:
+- `[COST] HIGH` — replica increase with estimated $/month delta
+- `[COST] MEDIUM` — missing resource requests on containers
+
+### drift
+
+```
+/platform-skills:pr-review drift
+
+values-dev.yaml: [paste]
+values-prod.yaml: [paste]
+```
+
+Expected findings:
+- `[DRIFT] HIGH` — ssl-redirect annotation missing in prod
+- `[DRIFT] MEDIUM` — featureFlags.newCheckoutFlow absent in prod
+- `[DRIFT] MEDIUM` — resources.requests missing in prod
+
+### ownership
+
+```
+/platform-skills:pr-review ownership
+
+[paste diff adding platform/ directory]
+```
+
+Expected findings:
+- `[OWNERSHIP] HIGH` — no CODEOWNERS entry for new path
+- `[OWNERSHIP] MEDIUM` — new Terraform module with no README
+- `[OWNERSHIP] MEDIUM` — Namespace with no team label
+
+### compliance
+
+```
+/platform-skills:pr-review compliance
+
+[paste examples/pr-review/compliance/iam-wildcard.tf diff]
+```
+
+Expected findings:
+- `[COMPLIANCE] CC6.1 CRITICAL` — wildcard IAM action and resource
+- `[COMPLIANCE] CC6.7 CRITICAL` — RDS storage_encrypted = false
+
+### upgrade
+
+```
+/platform-skills:pr-review upgrade
+
+[paste examples/pr-review/upgrade/deprecated-apis.yaml diff]
+```
+
+Expected findings:
+- `[UPGRADE] BREAKING` — networking.k8s.io/v1beta1 removed in 1.22
+- `[UPGRADE] BREAKING` — batch/v1beta1 removed in 1.25
+
+### rollback
+
+```
+/platform-skills:pr-review rollback
+
+[paste examples/pr-review/rollback/rds-storage-increase.tf diff]
+```
+
+Expected findings:
+- `[ROLLBACK] Reversibility: NONE, Blast radius: DATA` — RDS storage increase
+- `[ROLLBACK] Reversibility: MANUAL` — prevent_destroy removal
+- Rollback Risk Score: 🔴 HIGH
+
+### full
+
+```
+/platform-skills:pr-review full
+
+[paste complete diff]
+```
+
+Produces all six sections in sequence, ending with a **Merge Readiness Summary**:
+
+```
+Cost delta:      +$280/month (2 findings)
+Drift:           3 environment mismatches
+Ownership gaps:  2 findings
+Compliance:      2 control areas affected (2 critical)
+Upgrade risk:    2 deprecated items (2 breaking)
+Rollback score:  🔴 HIGH
+
+Blockers (must fix before merge):
+  - Wildcard IAM (CC6.1)
+  - Unencrypted RDS (CC6.7)
+  - RDS storage increase: take snapshot first
+  - networking.k8s.io/v1beta1 Ingress (removed in 1.22)
+```
+
+## See Also
+
+- [references/pr-review.md](../../references/pr-review.md) — full reference with pricing tables, SOC 2 control mapping, Kubernetes deprecation timeline, and rollback decision matrix
+- [commands/pr-review.md](../../commands/pr-review.md) — slash command definition with all mode specs
+- `/platform-skills:review` — production-readiness review for a single manifest or file

--- a/examples/pr-review/compliance/iam-wildcard.tf
+++ b/examples/pr-review/compliance/iam-wildcard.tf
@@ -1,0 +1,91 @@
+# SCENARIO: Compliance — wildcard IAM and unencrypted RDS (CC6.1, CC6.7)
+#
+# Expected output:
+#
+#   [COMPLIANCE] CC6.1 — Logical access
+#     Finding: aws_iam_role_policy.app_policy uses Action: "*" and Resource: "*"
+#     File: compliance/iam-wildcard.tf
+#     Severity: CRITICAL — grants full AWS access to the application role;
+#     violates least privilege and will block SOC 2 CC6.1 audit evidence.
+#     Remediation: Replace with explicit actions scoped to required services.
+#     See fix below.
+#     Auditor evidence: aws iam simulate-principal-policy --policy-source-arn <role-arn> \
+#       --action-names "s3:*" --resource-arns "*"
+#
+#   [COMPLIANCE] CC6.7 — Encryption
+#     Finding: aws_db_instance.app storage_encrypted = false
+#     File: compliance/iam-wildcard.tf
+#     Severity: CRITICAL — RDS data at rest unencrypted; fails CC6.7.
+#     Remediation: Set storage_encrypted = true and provide a kms_key_id.
+#     Note: enabling encryption on an existing unencrypted instance requires
+#     a snapshot → restore cycle (Reversibility: NONE — see rollback mode).
+#     Auditor evidence: aws rds describe-db-instances \
+#       --query 'DBInstances[*].{ID:DBInstanceIdentifier,Encrypted:StorageEncrypted}'
+
+# ❌ BEFORE — violates CC6.1 and CC6.7
+
+resource "aws_iam_role_policy" "app_policy" {
+  name = "app-policy"
+  role = aws_iam_role.app.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "*"        # ❌ CC6.1 — wildcard action
+      Resource = "*"        # ❌ CC6.1 — wildcard resource
+    }]
+  })
+}
+
+resource "aws_db_instance" "app" {
+  identifier        = "payments-db"
+  engine            = "postgres"
+  instance_class    = "db.t3.medium"
+  allocated_storage = 20
+  storage_encrypted = false    # ❌ CC6.7 — unencrypted at rest
+  username          = "admin"
+  password          = var.db_password
+}
+
+# ✅ AFTER — CC6.1 and CC6.7 compliant
+
+resource "aws_iam_role_policy" "app_policy" {
+  name = "app-s3-read"
+  role = aws_iam_role.app.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ]
+      Resource = [
+        "arn:aws:s3:::${var.assets_bucket}",
+        "arn:aws:s3:::${var.assets_bucket}/*"
+      ]
+    }]
+  })
+}
+
+resource "aws_kms_key" "rds" {
+  description             = "KMS key for payments RDS encryption"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+}
+
+resource "aws_db_instance" "app" {
+  identifier        = "payments-db"
+  engine            = "postgres"
+  instance_class    = "db.t3.medium"
+  allocated_storage = 20
+  storage_encrypted = true            # ✅ CC6.7
+  kms_key_id        = aws_kms_key.rds.arn
+  username          = "admin"
+  password          = var.db_password
+
+  backup_retention_period = 35        # ✅ A1.2 — minimum 35 days for SOC 2
+  deletion_protection     = true
+}

--- a/examples/pr-review/compliance/iam-wildcard.tf
+++ b/examples/pr-review/compliance/iam-wildcard.tf
@@ -1,32 +1,36 @@
 # SCENARIO: Compliance — wildcard IAM and unencrypted RDS (CC6.1, CC6.7)
 #
-# Expected output:
+# Expected pr-review compliance output:
 #
 #   [COMPLIANCE] CC6.1 — Logical access
-#     Finding: aws_iam_role_policy.app_policy uses Action: "*" and Resource: "*"
-#     File: compliance/iam-wildcard.tf
-#     Severity: CRITICAL — grants full AWS access to the application role;
-#     violates least privilege and will block SOC 2 CC6.1 audit evidence.
+#     Finding: aws_iam_role_policy.app_policy_before uses Action: "*" Resource: "*"
+#     Severity: CRITICAL — grants full AWS access; violates least privilege
 #     Remediation: Replace with explicit actions scoped to required services.
-#     See fix below.
-#     Auditor evidence: aws iam simulate-principal-policy --policy-source-arn <role-arn> \
+#     Auditor evidence: aws iam simulate-principal-policy --policy-source-arn <arn> \
 #       --action-names "s3:*" --resource-arns "*"
 #
 #   [COMPLIANCE] CC6.7 — Encryption
-#     Finding: aws_db_instance.app storage_encrypted = false
-#     File: compliance/iam-wildcard.tf
-#     Severity: CRITICAL — RDS data at rest unencrypted; fails CC6.7.
-#     Remediation: Set storage_encrypted = true and provide a kms_key_id.
-#     Note: enabling encryption on an existing unencrypted instance requires
-#     a snapshot → restore cycle (Reversibility: NONE — see rollback mode).
+#     Finding: aws_db_instance.app_before storage_encrypted = false
+#     Severity: CRITICAL — RDS data at rest unencrypted
+#     Remediation: Set storage_encrypted = true and provide kms_key_id.
 #     Auditor evidence: aws rds describe-db-instances \
 #       --query 'DBInstances[*].{ID:DBInstanceIdentifier,Encrypted:StorageEncrypted}'
 
-# ❌ BEFORE — violates CC6.1 and CC6.7
+variable "db_password" {
+  description = "RDS master password"
+  type        = string
+  sensitive   = true
+}
 
-resource "aws_iam_role_policy" "app_policy" {
-  name = "app-policy"
-  role = aws_iam_role.app.id
+variable "assets_bucket" {
+  description = "S3 bucket name for application assets"
+  type        = string
+}
+
+# ❌ BEFORE — violates CC6.1 and CC6.7
+resource "aws_iam_role_policy" "app_policy_before" {
+  name = "app-policy-before"
+  role = "app-role"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -38,21 +42,22 @@ resource "aws_iam_role_policy" "app_policy" {
   })
 }
 
-resource "aws_db_instance" "app" {
-  identifier        = "payments-db"
+resource "aws_db_instance" "app_before" {
+  identifier        = "payments-db-before"
   engine            = "postgres"
   instance_class    = "db.t3.medium"
   allocated_storage = 20
   storage_encrypted = false # ❌ CC6.7 — unencrypted at rest
   username          = "admin"
   password          = var.db_password
+
+  skip_final_snapshot = true
 }
 
 # ✅ AFTER — CC6.1 and CC6.7 compliant
-
 resource "aws_iam_role_policy" "app_policy" {
   name = "app-s3-read"
-  role = aws_iam_role.app.id
+  role = "app-role"
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -88,4 +93,5 @@ resource "aws_db_instance" "app" {
 
   backup_retention_period = 35 # ✅ A1.2 — minimum 35 days for SOC 2
   deletion_protection     = true
+  skip_final_snapshot     = false
 }

--- a/examples/pr-review/compliance/iam-wildcard.tf
+++ b/examples/pr-review/compliance/iam-wildcard.tf
@@ -32,8 +32,8 @@ resource "aws_iam_role_policy" "app_policy" {
     Version = "2012-10-17"
     Statement = [{
       Effect   = "Allow"
-      Action   = "*"        # ❌ CC6.1 — wildcard action
-      Resource = "*"        # ❌ CC6.1 — wildcard resource
+      Action   = "*" # ❌ CC6.1 — wildcard action
+      Resource = "*" # ❌ CC6.1 — wildcard resource
     }]
   })
 }
@@ -43,7 +43,7 @@ resource "aws_db_instance" "app" {
   engine            = "postgres"
   instance_class    = "db.t3.medium"
   allocated_storage = 20
-  storage_encrypted = false    # ❌ CC6.7 — unencrypted at rest
+  storage_encrypted = false # ❌ CC6.7 — unencrypted at rest
   username          = "admin"
   password          = var.db_password
 }
@@ -81,11 +81,11 @@ resource "aws_db_instance" "app" {
   engine            = "postgres"
   instance_class    = "db.t3.medium"
   allocated_storage = 20
-  storage_encrypted = true            # ✅ CC6.7
+  storage_encrypted = true # ✅ CC6.7
   kms_key_id        = aws_kms_key.rds.arn
   username          = "admin"
   password          = var.db_password
 
-  backup_retention_period = 35        # ✅ A1.2 — minimum 35 days for SOC 2
+  backup_retention_period = 35 # ✅ A1.2 — minimum 35 days for SOC 2
   deletion_protection     = true
 }

--- a/examples/pr-review/cost/deployment-replica-increase.yaml
+++ b/examples/pr-review/cost/deployment-replica-increase.yaml
@@ -1,0 +1,72 @@
+# SCENARIO: Cost impact — replica increase + instance class upgrade
+#
+# A PR bumps a Deployment from 2 to 8 replicas and the underlying node group
+# from t3.medium to m5.xlarge. The /platform-skills:pr-review cost mode would
+# produce the findings below.
+#
+# Expected output (abbreviated):
+#
+#   [COST] payments-api Deployment — replicas increased from 2 to 8
+#     Estimated delta: +$280/month (8× m5.xlarge On-Demand @ $140/month each vs 2×)
+#     Severity: HIGH
+#     Recommendation: Confirm scale requirement. If this is a load test, revert
+#     after. Consider HPA with minReplicas: 2 and maxReplicas: 8 so floor cost
+#     stays low outside peak hours.
+#
+#   [COST] eks-workers NodeGroup — instance type changed t3.medium → m5.xlarge
+#     Estimated delta: +$110/month per node (m5.xlarge $140 vs t3.medium $30)
+#     Severity: HIGH
+#     Recommendation: Validate whether the application actually requires 16 GB RAM.
+#     If memory is the constraint, consider r6i.large (16 GB, $95/month) instead.
+#
+#   [COST] payments-api container — no resource requests set
+#     Estimated delta: unbounded (overprovisioning risk on shared nodes)
+#     Severity: MEDIUM
+#     Recommendation: Set requests.cpu and requests.memory so the scheduler can
+#     bin-pack correctly and Karpenter/Cluster Autoscaler sizes nodes accurately.
+
+# BEFORE (main branch)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments-api
+  namespace: payments
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payments-api
+  template:
+    metadata:
+      labels:
+        app: payments-api
+    spec:
+      containers:
+        - name: payments-api
+          image: payments-api:v1.4.2
+          # ❌ No resource requests — prevents accurate bin-packing
+          ports:
+            - containerPort: 8080
+---
+# AFTER (PR branch) — what triggers the cost findings
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments-api
+  namespace: payments
+spec:
+  replicas: 8    # ← increased from 2
+  selector:
+    matchLabels:
+      app: payments-api
+  template:
+    metadata:
+      labels:
+        app: payments-api
+    spec:
+      containers:
+        - name: payments-api
+          image: payments-api:v1.4.2
+          # ❌ Still no resource requests
+          ports:
+            - containerPort: 8080

--- a/examples/pr-review/cost/terraform-nat-gateway.tf
+++ b/examples/pr-review/cost/terraform-nat-gateway.tf
@@ -1,0 +1,50 @@
+# SCENARIO: Cost impact — new NAT Gateway per subnet instead of per AZ
+#
+# A PR adds three NAT Gateways — one per subnet — instead of one per AZ.
+# This triples the NAT Gateway cost and adds unnecessary cross-AZ data charges.
+#
+# Expected output:
+#
+#   [COST] aws_nat_gateway.private_b, aws_nat_gateway.private_c — redundant NAT Gateways
+#     Estimated delta: +$64/month (2 additional NAT Gateways @ ~$32/month each)
+#     Severity: HIGH
+#     Recommendation: Use one NAT Gateway per AZ (not per subnet). private_b and
+#     private_c are in the same AZs as an existing NAT Gateway. Route both private
+#     subnets in the same AZ through the same NAT Gateway.
+#
+#   [COST] aws_eip.nat_b, aws_eip.nat_c — unused Elastic IPs if NAT Gateways removed
+#     Estimated delta: +$7.20/month per idle EIP
+#     Severity: LOW
+#     Recommendation: Remove with the NAT Gateways; idle EIPs are billed.
+
+# ❌ BEFORE — one NAT Gateway per AZ (correct pattern, $32/month)
+resource "aws_nat_gateway" "private_a" {
+  allocation_id = aws_eip.nat_a.id
+  subnet_id     = aws_subnet.public_a.id
+  tags          = { Name = "nat-private-a" }
+}
+
+# ❌ AFTER — PR adds two more, one per additional subnet (costs $96/month total)
+resource "aws_nat_gateway" "private_b" {
+  allocation_id = aws_eip.nat_b.id
+  subnet_id     = aws_subnet.public_b.id   # same AZ as an existing private subnet
+  tags          = { Name = "nat-private-b" }
+}
+
+resource "aws_nat_gateway" "private_c" {
+  allocation_id = aws_eip.nat_c.id
+  subnet_id     = aws_subnet.public_c.id   # same AZ as another existing private subnet
+  tags          = { Name = "nat-private-c" }
+}
+
+resource "aws_eip" "nat_b" { domain = "vpc" }
+resource "aws_eip" "nat_c" { domain = "vpc" }
+
+# ✅ RECOMMENDED — one NAT Gateway per AZ, route both private subnets in that AZ to it
+# resource "aws_route_table" "private_b" {
+#   vpc_id = aws_vpc.main.id
+#   route {
+#     cidr_block     = "0.0.0.0/0"
+#     nat_gateway_id = aws_nat_gateway.private_a.id  # reuse AZ-a NAT if same AZ
+#   }
+# }

--- a/examples/pr-review/cost/terraform-nat-gateway.tf
+++ b/examples/pr-review/cost/terraform-nat-gateway.tf
@@ -1,48 +1,68 @@
-# SCENARIO: Cost impact — new NAT Gateway per subnet instead of per AZ
+# SCENARIO: Cost impact — redundant NAT Gateways per subnet instead of per AZ
 #
-# A PR adds three NAT Gateways — one per subnet — instead of one per AZ.
-# This triples the NAT Gateway cost and adds unnecessary cross-AZ data charges.
+# Expected pr-review cost output:
 #
-# Expected output:
-#
-#   [COST] aws_nat_gateway.private_b, aws_nat_gateway.private_c — redundant NAT Gateways
+#   [COST] aws_nat_gateway.private_b, aws_nat_gateway.private_c — redundant
 #     Estimated delta: +$64/month (2 additional NAT Gateways @ ~$32/month each)
 #     Severity: HIGH
-#     Recommendation: Use one NAT Gateway per AZ (not per subnet). private_b and
-#     private_c are in the same AZs as an existing NAT Gateway. Route both private
-#     subnets in the same AZ through the same NAT Gateway.
+#     Recommendation: Use one NAT Gateway per AZ (not per subnet). Route both
+#     private subnets in the same AZ through the same NAT Gateway.
 #
-#   [COST] aws_eip.nat_b, aws_eip.nat_c — unused Elastic IPs if NAT Gateways removed
+#   [COST] aws_eip.nat_b, aws_eip.nat_c — idle EIPs if NAT Gateways removed
 #     Estimated delta: +$7.20/month per idle EIP
 #     Severity: LOW
-#     Recommendation: Remove with the NAT Gateways; idle EIPs are billed.
 
-# ❌ BEFORE — one NAT Gateway per AZ (correct pattern, $32/month)
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+# Placeholder subnet/EIP references (would be data sources in real usage)
+resource "aws_eip" "nat_a" { domain = "vpc" }
+resource "aws_eip" "nat_b" { domain = "vpc" }
+resource "aws_eip" "nat_c" { domain = "vpc" }
+
+resource "aws_subnet" "public_a" {
+  vpc_id            = var.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "eu-central-1a"
+}
+
+resource "aws_subnet" "public_b" {
+  vpc_id            = var.vpc_id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "eu-central-1b"
+}
+
+resource "aws_subnet" "public_c" {
+  vpc_id            = var.vpc_id
+  cidr_block        = "10.0.3.0/24"
+  availability_zone = "eu-central-1c"
+}
+
+# ✅ BEFORE — one NAT Gateway per AZ (~$32/month)
 resource "aws_nat_gateway" "private_a" {
   allocation_id = aws_eip.nat_a.id
   subnet_id     = aws_subnet.public_a.id
   tags          = { Name = "nat-private-a" }
 }
 
-# ❌ AFTER — PR adds two more, one per additional subnet (costs $96/month total)
+# ❌ AFTER (PR adds these) — one per additional subnet, same AZ (~$96/month total)
 resource "aws_nat_gateway" "private_b" {
   allocation_id = aws_eip.nat_b.id
-  subnet_id     = aws_subnet.public_b.id # same AZ as an existing private subnet
+  subnet_id     = aws_subnet.public_b.id # ❌ same AZ as an existing private subnet
   tags          = { Name = "nat-private-b" }
 }
 
 resource "aws_nat_gateway" "private_c" {
   allocation_id = aws_eip.nat_c.id
-  subnet_id     = aws_subnet.public_c.id # same AZ as another existing private subnet
+  subnet_id     = aws_subnet.public_c.id # ❌ same AZ as another existing private subnet
   tags          = { Name = "nat-private-c" }
 }
 
-resource "aws_eip" "nat_b" { domain = "vpc" }
-resource "aws_eip" "nat_c" { domain = "vpc" }
-
-# ✅ RECOMMENDED — one NAT Gateway per AZ, route both private subnets in that AZ to it
+# ✅ RECOMMENDED — route both private subnets in each AZ through the single NAT Gateway
 # resource "aws_route_table" "private_b" {
-#   vpc_id = aws_vpc.main.id
+#   vpc_id = var.vpc_id
 #   route {
 #     cidr_block     = "0.0.0.0/0"
 #     nat_gateway_id = aws_nat_gateway.private_a.id  # reuse AZ-a NAT if same AZ

--- a/examples/pr-review/cost/terraform-nat-gateway.tf
+++ b/examples/pr-review/cost/terraform-nat-gateway.tf
@@ -27,13 +27,13 @@ resource "aws_nat_gateway" "private_a" {
 # ❌ AFTER — PR adds two more, one per additional subnet (costs $96/month total)
 resource "aws_nat_gateway" "private_b" {
   allocation_id = aws_eip.nat_b.id
-  subnet_id     = aws_subnet.public_b.id   # same AZ as an existing private subnet
+  subnet_id     = aws_subnet.public_b.id # same AZ as an existing private subnet
   tags          = { Name = "nat-private-b" }
 }
 
 resource "aws_nat_gateway" "private_c" {
   allocation_id = aws_eip.nat_c.id
-  subnet_id     = aws_subnet.public_c.id   # same AZ as another existing private subnet
+  subnet_id     = aws_subnet.public_c.id # same AZ as another existing private subnet
   tags          = { Name = "nat-private-c" }
 }
 

--- a/examples/pr-review/drift/kustomization-prod.yaml
+++ b/examples/pr-review/drift/kustomization-prod.yaml
@@ -1,0 +1,32 @@
+# SCENARIO: Kustomize overlay drift — prod missing a patch that dev and staging have
+#
+# A PR adds a HorizontalPodAutoscaler patch to the dev and staging overlays but
+# forgets to add it to the prod overlay.
+#
+# Expected output:
+#
+#   [DRIFT] overlays/dev/kustomization.yaml + overlays/staging/kustomization.yaml
+#            vs overlays/prod/kustomization.yaml
+#     Field: patchesStrategicMerge (hpa-patch.yaml)
+#     Dev value: present   Staging value: present   Prod value: MISSING
+#     Severity: HIGH — HPA active in dev/staging but base Deployment runs without
+#     autoscaling in prod; prod will not scale under load
+#     Recommendation: Add hpa-patch.yaml to overlays/prod/kustomization.yaml or
+#     confirm prod scaling is handled differently (e.g. KEDA) with a comment.
+
+# overlays/prod/kustomization.yaml — MISSING the hpa patch
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+images:
+  - name: payments-api
+    newTag: v1.4.2
+
+# ❌ hpa-patch.yaml present in dev and staging overlays but not here
+# patches:
+#   - path: hpa-patch.yaml
+
+namespace: payments-prod

--- a/examples/pr-review/drift/values-dev.yaml
+++ b/examples/pr-review/drift/values-dev.yaml
@@ -1,0 +1,46 @@
+# SCENARIO: Environment drift — feature flag and TLS setting present in dev, absent in prod
+#
+# The /platform-skills:pr-review drift mode would flag:
+#
+#   [DRIFT] values-dev.yaml vs values-prod.yaml
+#     Field: ingress.annotations."nginx.ingress.kubernetes.io/ssl-redirect"
+#     Dev value: "true"   Prod value: MISSING (falls back to chart default: "false")
+#     Severity: HIGH — prod ingress does not force HTTPS; dev does
+#     Recommendation: Add ssl-redirect: "true" to values-prod.yaml or confirm
+#     this is handled at the load balancer layer with evidence.
+#
+#   [DRIFT] values-dev.yaml vs values-prod.yaml
+#     Field: featureFlags.newCheckoutFlow
+#     Dev value: "true"   Prod value: MISSING (falls back to chart default: "false")
+#     Severity: MEDIUM — feature live in dev but dark in prod; intentional or missed?
+#     Recommendation: Add explicit value to values-prod.yaml with a comment explaining
+#     the promotion timeline, or enable if the flag was cleared for prod.
+#
+#   [DRIFT] values-dev.yaml vs values-prod.yaml
+#     Field: resources.requests.memory
+#     Dev value: 128Mi   Prod value: MISSING
+#     Severity: MEDIUM — prod falls back to chart default (no requests); silent overprovisioning
+#     Recommendation: Set resource requests explicitly in values-prod.yaml.
+
+replicaCount: 1
+
+image:
+  repository: payments-api
+  tag: "v1.4.2"
+
+ingress:
+  enabled: true
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"    # ← present in dev, missing in prod
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi      # ← present in dev, missing in prod
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+featureFlags:
+  newCheckoutFlow: "true"    # ← enabled in dev, absent from prod

--- a/examples/pr-review/drift/values-prod.yaml
+++ b/examples/pr-review/drift/values-prod.yaml
@@ -1,0 +1,23 @@
+# SCENARIO: values-prod.yaml — three keys missing relative to values-dev.yaml
+# Run: /platform-skills:pr-review drift
+# and paste both files to see the drift findings above.
+
+replicaCount: 3
+
+image:
+  repository: payments-api
+  tag: "v1.4.2"
+
+ingress:
+  enabled: true
+  annotations:
+    # ❌ ssl-redirect missing — falls back to chart default (false)
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+
+# ❌ resources.requests missing — silent overprovisioning in prod
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# ❌ featureFlags absent — chart default disables new checkout flow in prod

--- a/examples/pr-review/ownership/missing-codeowners.txt
+++ b/examples/pr-review/ownership/missing-codeowners.txt
@@ -1,0 +1,40 @@
+# SCENARIO: Ownership gaps — new directory with no CODEOWNERS entry
+#
+# A PR adds a new top-level directory `platform/` with Terraform modules but
+# no CODEOWNERS rule. Any engineer can merge PRs to this directory with no
+# required reviewer.
+#
+# Expected output:
+#
+#   [OWNERSHIP] platform/ — new top-level directory
+#     Gap: No CODEOWNERS entry covers platform/**. PRs touching this path have
+#     no required reviewer — any team member can self-merge.
+#     Severity: HIGH
+#     Recommendation: Add to .github/CODEOWNERS:
+#       platform/   @platform-team @platform-leads
+#
+#   [OWNERSHIP] platform/eks-cluster/ — new Terraform module
+#     Gap: No README.md in module directory. Purpose, inputs, outputs, and
+#     owning team are undocumented.
+#     Severity: MEDIUM
+#     Recommendation: Add platform/eks-cluster/README.md with: description,
+#     usage example, variable table, output table, and owning team.
+#
+#   [OWNERSHIP] platform/eks-cluster/variables.tf — 4 variables with no description
+#     Gap: cluster_name, node_count, instance_type, region have no description field.
+#     Severity: LOW
+#     Recommendation: Add description = "..." to each variable block.
+
+# ❌ CURRENT .github/CODEOWNERS — missing platform/ entry
+*                   @platform-team
+
+references/         @platform-team
+commands/           @platform-team
+examples/           @platform-team
+.claude-plugin/     @platform-leads
+CHANGELOG.md        @platform-leads
+
+# platform/       <-- NOT PRESENT
+
+# ✅ RECOMMENDED addition
+# platform/       @platform-team @platform-leads

--- a/examples/pr-review/ownership/namespace-missing-labels.yaml
+++ b/examples/pr-review/ownership/namespace-missing-labels.yaml
@@ -1,0 +1,71 @@
+# SCENARIO: Ownership gaps — new Namespace with no team label or ResourceQuota
+#
+# Expected output:
+#
+#   [OWNERSHIP] Namespace/payments — missing team label
+#     Gap: No app.kubernetes.io/team label. Cannot attribute cost, alert routing,
+#     or policy scope to an owning team.
+#     Severity: MEDIUM
+#     Recommendation: Add label app.kubernetes.io/team: payments-team
+#
+#   [OWNERSHIP] Namespace/payments — no ResourceQuota
+#     Gap: Namespace has no ResourceQuota. Runaway pods can consume unlimited
+#     cluster resources and affect other tenants.
+#     Severity: HIGH
+#     Recommendation: Add a ResourceQuota with cpu/memory limits appropriate
+#     for the team's expected workload.
+#
+#   [OWNERSHIP] Namespace/payments — no LimitRange
+#     Gap: No LimitRange means containers with no resource requests/limits get
+#     scheduled without constraints.
+#     Severity: MEDIUM
+#     Recommendation: Add a LimitRange setting default requests and limits.
+
+# ❌ BEFORE — namespace with no ownership signals
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: payments
+  # ❌ no team label
+  # ❌ no owner annotation
+---
+# ✅ AFTER — namespace with full ownership signals
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: payments
+  labels:
+    app.kubernetes.io/team: payments-team
+    app.kubernetes.io/part-of: commerce-platform
+  annotations:
+    team-contact: payments-team@example.com
+---
+# ✅ ResourceQuota to protect cluster neighbours
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: payments-quota
+  namespace: payments
+spec:
+  hard:
+    requests.cpu: "4"
+    requests.memory: 8Gi
+    limits.cpu: "8"
+    limits.memory: 16Gi
+    pods: "20"
+---
+# ✅ LimitRange to set defaults for containers that omit resource fields
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: payments-limits
+  namespace: payments
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: 500m
+        memory: 256Mi
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi

--- a/examples/pr-review/rollback/rds-storage-increase.tf
+++ b/examples/pr-review/rollback/rds-storage-increase.tf
@@ -1,46 +1,45 @@
 # SCENARIO: Rollback — RDS storage increase (irreversible) + prevent_destroy removal
 #
-# Expected output:
+# Expected pr-review rollback output:
 #
-#   [ROLLBACK] aws_db_instance.payments — allocated_storage increase
+#   [ROLLBACK] aws_db_instance.payments_after — allocated_storage increase
 #     Change: 100 GB → 500 GB
-#     Reversibility: NONE — AWS does not support decreasing RDS allocated_storage.
-#     Reducing storage requires: snapshot → create new instance from snapshot
-#     with smaller size → data migration → DNS cutover. Estimated 2–4 hours.
+#     Reversibility: NONE — AWS does not support decreasing RDS allocated_storage
 #     Blast radius: DATA
-#     Rollback procedure:
-#       1. Take manual snapshot: aws rds create-db-snapshot --db-instance-identifier payments-db
-#       2. Verify snapshot complete before applying
-#       3. If rollback needed post-apply: restore from snapshot to new instance,
-#          update application DNS/connection string, verify data integrity
 #     Pre-merge requirement: manual RDS snapshot taken and ARN recorded in PR
 #
-#   [ROLLBACK] aws_db_instance.payments — prevent_destroy removed
-#     Change: lifecycle.prevent_destroy = true → removed
-#     Reversibility: MANUAL — without prevent_destroy, a future `terraform destroy`
-#     or accidental resource removal will permanently delete the RDS instance and
-#     all data. This change does not immediately destroy anything but removes the
-#     safety net.
-#     Blast radius: DATA
-#     Rollback procedure: Re-add prevent_destroy = true in a follow-up commit.
-#     Pre-merge requirement: Explicit justification in PR description for why
-#     prevent_destroy is being removed.
+#   [ROLLBACK] aws_db_instance.payments_after — prevent_destroy removed
+#     Reversibility: MANUAL — future terraform destroy will permanently delete data
+#     Pre-merge requirement: explicit justification in PR description
 #
 # Rollback Risk Score: 🔴 HIGH
-#   Reason: NONE reversibility + DATA blast radius on storage increase.
-#   Required before merge: RDS snapshot ARN in PR description + team lead sign-off.
 
-# ❌ BEFORE — protected, sized at 100 GB
-resource "aws_db_instance" "payments" {
-  identifier        = "payments-db"
+resource "aws_kms_key" "rds" {
+  description             = "KMS key for payments RDS"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+}
+
+variable "db_password" {
+  description = "RDS master password"
+  type        = string
+  sensitive   = true
+}
+
+# ✅ BEFORE — protected, sized at 100 GB
+resource "aws_db_instance" "payments_before" {
+  identifier        = "payments-db-before"
   engine            = "postgres"
   instance_class    = "db.t3.medium"
   allocated_storage = 100
   storage_encrypted = true
   kms_key_id        = aws_kms_key.rds.arn
+  username          = "admin"
+  password          = var.db_password
 
   backup_retention_period = 35
   deletion_protection     = true
+  skip_final_snapshot     = false
 
   lifecycle {
     prevent_destroy = true # safety net against accidental deletion
@@ -48,25 +47,19 @@ resource "aws_db_instance" "payments" {
 }
 
 # ❌ AFTER (PR) — storage increase + prevent_destroy removed
-resource "aws_db_instance" "payments" {
-  identifier        = "payments-db"
+resource "aws_db_instance" "payments_after" {
+  identifier        = "payments-db-after"
   engine            = "postgres"
   instance_class    = "db.t3.medium"
   allocated_storage = 500 # ← irreversible increase
   storage_encrypted = true
   kms_key_id        = aws_kms_key.rds.arn
+  username          = "admin"
+  password          = var.db_password
 
   backup_retention_period = 35
   deletion_protection     = true
+  skip_final_snapshot     = false
 
   # ❌ prevent_destroy removed — no longer protected from terraform destroy
 }
-
-# ✅ RECOMMENDED — keep prevent_destroy, document the storage increase intent
-# resource "aws_db_instance" "payments" {
-#   ...
-#   allocated_storage = 500
-#   lifecycle {
-#     prevent_destroy = true   # keep even after storage increase
-#   }
-# }

--- a/examples/pr-review/rollback/rds-storage-increase.tf
+++ b/examples/pr-review/rollback/rds-storage-increase.tf
@@ -43,7 +43,7 @@ resource "aws_db_instance" "payments" {
   deletion_protection     = true
 
   lifecycle {
-    prevent_destroy = true    # safety net against accidental deletion
+    prevent_destroy = true # safety net against accidental deletion
   }
 }
 
@@ -52,7 +52,7 @@ resource "aws_db_instance" "payments" {
   identifier        = "payments-db"
   engine            = "postgres"
   instance_class    = "db.t3.medium"
-  allocated_storage = 500    # ← irreversible increase
+  allocated_storage = 500 # ← irreversible increase
   storage_encrypted = true
   kms_key_id        = aws_kms_key.rds.arn
 

--- a/examples/pr-review/rollback/rds-storage-increase.tf
+++ b/examples/pr-review/rollback/rds-storage-increase.tf
@@ -1,0 +1,72 @@
+# SCENARIO: Rollback — RDS storage increase (irreversible) + prevent_destroy removal
+#
+# Expected output:
+#
+#   [ROLLBACK] aws_db_instance.payments — allocated_storage increase
+#     Change: 100 GB → 500 GB
+#     Reversibility: NONE — AWS does not support decreasing RDS allocated_storage.
+#     Reducing storage requires: snapshot → create new instance from snapshot
+#     with smaller size → data migration → DNS cutover. Estimated 2–4 hours.
+#     Blast radius: DATA
+#     Rollback procedure:
+#       1. Take manual snapshot: aws rds create-db-snapshot --db-instance-identifier payments-db
+#       2. Verify snapshot complete before applying
+#       3. If rollback needed post-apply: restore from snapshot to new instance,
+#          update application DNS/connection string, verify data integrity
+#     Pre-merge requirement: manual RDS snapshot taken and ARN recorded in PR
+#
+#   [ROLLBACK] aws_db_instance.payments — prevent_destroy removed
+#     Change: lifecycle.prevent_destroy = true → removed
+#     Reversibility: MANUAL — without prevent_destroy, a future `terraform destroy`
+#     or accidental resource removal will permanently delete the RDS instance and
+#     all data. This change does not immediately destroy anything but removes the
+#     safety net.
+#     Blast radius: DATA
+#     Rollback procedure: Re-add prevent_destroy = true in a follow-up commit.
+#     Pre-merge requirement: Explicit justification in PR description for why
+#     prevent_destroy is being removed.
+#
+# Rollback Risk Score: 🔴 HIGH
+#   Reason: NONE reversibility + DATA blast radius on storage increase.
+#   Required before merge: RDS snapshot ARN in PR description + team lead sign-off.
+
+# ❌ BEFORE — protected, sized at 100 GB
+resource "aws_db_instance" "payments" {
+  identifier        = "payments-db"
+  engine            = "postgres"
+  instance_class    = "db.t3.medium"
+  allocated_storage = 100
+  storage_encrypted = true
+  kms_key_id        = aws_kms_key.rds.arn
+
+  backup_retention_period = 35
+  deletion_protection     = true
+
+  lifecycle {
+    prevent_destroy = true    # safety net against accidental deletion
+  }
+}
+
+# ❌ AFTER (PR) — storage increase + prevent_destroy removed
+resource "aws_db_instance" "payments" {
+  identifier        = "payments-db"
+  engine            = "postgres"
+  instance_class    = "db.t3.medium"
+  allocated_storage = 500    # ← irreversible increase
+  storage_encrypted = true
+  kms_key_id        = aws_kms_key.rds.arn
+
+  backup_retention_period = 35
+  deletion_protection     = true
+
+  # ❌ prevent_destroy removed — no longer protected from terraform destroy
+}
+
+# ✅ RECOMMENDED — keep prevent_destroy, document the storage increase intent
+# resource "aws_db_instance" "payments" {
+#   ...
+#   allocated_storage = 500
+#   lifecycle {
+#     prevent_destroy = true   # keep even after storage increase
+#   }
+# }

--- a/examples/pr-review/rollback/resource-rename.yaml
+++ b/examples/pr-review/rollback/resource-rename.yaml
@@ -1,0 +1,98 @@
+# SCENARIO: Rollback — Kubernetes resource rename with prune:true GitOps
+#
+# A PR renames a Deployment from "payments-api" to "payments-service".
+# With prune: true in the Flux Kustomization, the old Deployment is deleted
+# and the new one created. Rolling back means re-creating the old resource.
+#
+# Expected output:
+#
+#   [ROLLBACK] Deployment/payments-api → Deployment/payments-service — resource rename
+#     Change: Deployment renamed; Flux will delete payments-api and create payments-service
+#     Reversibility: MANUAL — git revert restores the old name in Git, but Flux will
+#     then delete payments-service and recreate payments-api. Any active connections
+#     drained to payments-service will need to reconnect. Pods terminate during rename.
+#     Blast radius: LOCAL (single namespace)
+#     Rollback procedure:
+#       1. git revert <commit-sha>
+#       2. git push → Flux reconciles: deletes payments-service, creates payments-api
+#       3. Verify: kubectl get deploy -n payments
+#       4. Check dependent Services and Ingress still resolve correctly
+#     Pre-merge requirement:
+#       - Confirm all Services, Ingresses, and HPA objects reference the new name
+#       - Confirm no external tools (monitoring, alerts, RBAC) are hardcoded to old name
+#
+#   [ROLLBACK] Service/payments-api-svc — name unchanged
+#     The Service still points to matchLabels: app: payments-api.
+#     After rename, the selector will match nothing — all traffic drops.
+#     Reversibility: MANUAL
+#     Blast radius: LOCAL → CLUSTER (if other services call payments-api)
+#     Pre-merge requirement: Update Service selector to app: payments-service
+
+# ❌ BEFORE — original name
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments-api      # ← being renamed in this PR
+  namespace: payments
+  labels:
+    app: payments-api
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: payments-api
+  template:
+    metadata:
+      labels:
+        app: payments-api    # ← selector label also changes
+    spec:
+      containers:
+        - name: payments-api
+          image: payments-api:v1.4.2
+---
+# ❌ Service — selector NOT updated in this PR (will break after rename)
+apiVersion: v1
+kind: Service
+metadata:
+  name: payments-api-svc
+  namespace: payments
+spec:
+  selector:
+    app: payments-api      # ← still points to old label — traffic drops after rename
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+# ✅ AFTER — correct rename with Service selector updated
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments-service
+  namespace: payments
+  labels:
+    app: payments-service
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: payments-service
+  template:
+    metadata:
+      labels:
+        app: payments-service
+    spec:
+      containers:
+        - name: payments-service
+          image: payments-api:v1.4.2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: payments-api-svc
+  namespace: payments
+spec:
+  selector:
+    app: payments-service    # ✅ updated to match new label
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/examples/pr-review/upgrade/deprecated-apis.yaml
+++ b/examples/pr-review/upgrade/deprecated-apis.yaml
@@ -1,0 +1,94 @@
+# SCENARIO: Upgrade — deprecated Kubernetes API versions and floating action pins
+#
+# Expected output:
+#
+#   [UPGRADE] ingress.yaml:1 — networking.k8s.io/v1beta1 Ingress
+#     Found: apiVersion: networking.k8s.io/v1beta1
+#     Target version: Kubernetes 1.24
+#     Removed in: 1.22 — this manifest will fail to apply on any cluster >= 1.22
+#     Replacement: apiVersion: networking.k8s.io/v1 (spec.rules and spec.tls unchanged;
+#     spec.backend replaced by spec.defaultBackend)
+#     Migration effort: LOW
+#
+#   [UPGRADE] cronjob.yaml:1 — batch/v1beta1 CronJob
+#     Found: apiVersion: batch/v1beta1
+#     Target version: Kubernetes 1.25
+#     Removed in: 1.25 — use batch/v1
+#     Replacement: apiVersion: batch/v1 (spec unchanged)
+#     Migration effort: LOW
+#
+#   [UPGRADE] pdb.yaml:1 — policy/v1beta1 PodDisruptionBudget
+#     Found: apiVersion: policy/v1beta1
+#     Target version: Kubernetes 1.25
+#     Removed in: 1.25 — use policy/v1
+#     Replacement: apiVersion: policy/v1 (spec unchanged)
+#     Migration effort: LOW
+
+# ❌ Deprecated Ingress API — removed in Kubernetes 1.22
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: payments-ingress
+  namespace: payments
+spec:
+  rules:
+    - host: payments.example.com
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: payments-api
+              servicePort: 80
+---
+# ✅ Current Ingress API
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: payments-ingress
+  namespace: payments
+spec:
+  rules:
+    - host: payments.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: payments-api
+                port:
+                  number: 80
+---
+# ❌ Deprecated CronJob API — removed in Kubernetes 1.25
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: db-backup
+  namespace: payments
+spec:
+  schedule: "0 2 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: backup
+              image: backup-tool:v2.1.0
+          restartPolicy: OnFailure
+---
+# ✅ Current CronJob API
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup
+  namespace: payments
+spec:
+  schedule: "0 2 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: backup
+              image: backup-tool:v2.1.0
+          restartPolicy: OnFailure

--- a/examples/pr-review/upgrade/terraform-loose-constraints.tf
+++ b/examples/pr-review/upgrade/terraform-loose-constraints.tf
@@ -23,18 +23,18 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"    # ❌ allows major version jumps with breaking changes
+      version = ">= 3.0" # ❌ allows major version jumps with breaking changes
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.0"    # ❌ same issue
+      version = ">= 2.0" # ❌ same issue
     }
   }
-  required_version = ">= 1.0"    # ❌ too loose — any 1.x or 2.x will match
+  required_version = ">= 1.0" # ❌ too loose — any 1.x or 2.x will match
 }
 
 module "eks" {
-  source = "terraform-aws-modules/eks/aws"    # ❌ no version pin — floats to latest
+  source = "terraform-aws-modules/eks/aws" # ❌ no version pin — floats to latest
   # ...
 }
 
@@ -44,18 +44,18 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"    # ✅ locks to 5.x, won't jump to 6.0
+      version = "~> 5.0" # ✅ locks to 5.x, won't jump to 6.0
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.27"   # ✅ locks to 2.x patch releases
+      version = "~> 2.27" # ✅ locks to 2.x patch releases
     }
   }
-  required_version = "~> 1.7"    # ✅ locks to 1.x
+  required_version = "~> 1.7" # ✅ locks to 1.x
 }
 
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0"    # ✅ pinned to major version
+  version = "~> 20.0" # ✅ pinned to major version
   # ...
 }

--- a/examples/pr-review/upgrade/terraform-loose-constraints.tf
+++ b/examples/pr-review/upgrade/terraform-loose-constraints.tf
@@ -1,0 +1,61 @@
+# SCENARIO: Upgrade — loose Terraform provider constraints and floating module ref
+#
+# Expected output:
+#
+#   [UPGRADE] versions.tf — AWS provider constraint too loose
+#     Found: version = ">= 3.0"
+#     Removed in: allows major version jump (3→4→5) with breaking changes
+#     Replacement: version = "~> 5.0"
+#     Migration effort: MEDIUM — review AWS provider v5 migration guide for
+#     breaking changes (e.g. default_tags behaviour, removed resources)
+#     Flag: BREAKING — ">= 3.0" will silently adopt provider v5 breaking changes
+#     on next `terraform init -upgrade`
+#
+#   [UPGRADE] main.tf — EKS module source without version pin
+#     Found: source = "terraform-aws-modules/eks/aws" with no version
+#     Removed in: N/A — but next `terraform init` may pull a new major version
+#     Replacement: version = "~> 20.0"
+#     Migration effort: HIGH — module major versions have breaking input/output changes
+
+# ❌ BEFORE — loose constraints
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"    # ❌ allows major version jumps with breaking changes
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0"    # ❌ same issue
+    }
+  }
+  required_version = ">= 1.0"    # ❌ too loose — any 1.x or 2.x will match
+}
+
+module "eks" {
+  source = "terraform-aws-modules/eks/aws"    # ❌ no version pin — floats to latest
+  # ...
+}
+
+# ✅ AFTER — pessimistic constraints
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"    # ✅ locks to 5.x, won't jump to 6.0
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.27"   # ✅ locks to 2.x patch releases
+    }
+  }
+  required_version = "~> 1.7"    # ✅ locks to 1.x
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"    # ✅ pinned to major version
+  # ...
+}

--- a/examples/pr-review/upgrade/terraform-loose-constraints.tf
+++ b/examples/pr-review/upgrade/terraform-loose-constraints.tf
@@ -1,61 +1,51 @@
-# SCENARIO: Upgrade — loose Terraform provider constraints and floating module ref
+# SCENARIO: Upgrade — loose Terraform provider constraints and unversioned module ref
 #
-# Expected output:
+# Expected pr-review upgrade output:
 #
-#   [UPGRADE] versions.tf — AWS provider constraint too loose
+#   [UPGRADE] versions_before.tf — AWS provider constraint too loose
 #     Found: version = ">= 3.0"
-#     Removed in: allows major version jump (3→4→5) with breaking changes
+#     Flag: BREAKING — allows silent jump to provider v5 with breaking changes
 #     Replacement: version = "~> 5.0"
-#     Migration effort: MEDIUM — review AWS provider v5 migration guide for
-#     breaking changes (e.g. default_tags behaviour, removed resources)
-#     Flag: BREAKING — ">= 3.0" will silently adopt provider v5 breaking changes
-#     on next `terraform init -upgrade`
+#     Migration effort: MEDIUM
 #
-#   [UPGRADE] main.tf — EKS module source without version pin
+#   [UPGRADE] versions_before.tf — unversioned module source
 #     Found: source = "terraform-aws-modules/eks/aws" with no version
-#     Removed in: N/A — but next `terraform init` may pull a new major version
 #     Replacement: version = "~> 20.0"
-#     Migration effort: HIGH — module major versions have breaking input/output changes
+#     Migration effort: HIGH
 
-# ❌ BEFORE — loose constraints
-
+# ❌ BEFORE — loose constraints (use _before suffix to avoid duplicate block errors)
 terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 3.0" # ❌ allows major version jumps with breaking changes
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.0" # ❌ same issue
-    }
   }
   required_version = ">= 1.0" # ❌ too loose — any 1.x or 2.x will match
 }
 
-module "eks" {
-  source = "terraform-aws-modules/eks/aws" # ❌ no version pin — floats to latest
-  # ...
-}
+# ✅ AFTER — pessimistic constraints (in a real fix, replace the block above)
+# terraform {
+#   required_providers {
+#     aws = {
+#       source  = "hashicorp/aws"
+#       version = "~> 5.0"    # ✅ locks to 5.x, won't jump to 6.0
+#     }
+#     kubernetes = {
+#       source  = "hashicorp/kubernetes"
+#       version = "~> 2.27"   # ✅ locks to 2.x patch releases
+#     }
+#   }
+#   required_version = "~> 1.7"    # ✅ locks to 1.x
+# }
 
-# ✅ AFTER — pessimistic constraints
+# ❌ BEFORE — module without version pin
+# module "eks" {
+#   source = "terraform-aws-modules/eks/aws"    # ❌ floats to latest on terraform init
+# }
 
-terraform {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.0" # ✅ locks to 5.x, won't jump to 6.0
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.27" # ✅ locks to 2.x patch releases
-    }
-  }
-  required_version = "~> 1.7" # ✅ locks to 1.x
-}
-
-module "eks" {
-  source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.0" # ✅ pinned to major version
-  # ...
-}
+# ✅ AFTER — module pinned to major version
+# module "eks" {
+#   source  = "terraform-aws-modules/eks/aws"
+#   version = "~> 20.0"    # ✅ locked to 20.x
+# }

--- a/references/pr-review.md
+++ b/references/pr-review.md
@@ -1,0 +1,571 @@
+# PR Review Reference
+
+Comprehensive pre-merge risk review across six dimensions: cost impact, environment drift, ownership and governance, SOC 2 compliance, deprecated API / version hygiene, and rollback feasibility.
+
+Use this reference when running `/platform-skills:pr-review` or when manually performing a structured pre-merge review.
+
+---
+
+## How to Run a PR Review
+
+```bash
+# Get the diff for a PR
+gh pr diff 42
+
+# Or pipe directly into context
+gh pr diff 42 | pbcopy   # macOS — paste into Claude
+
+# Check all open review threads (bot comments to triage)
+gh api repos/<owner>/<repo>/pulls/42/comments --jq '.[] | {id, path, body: .body[0:300], in_reply_to_id}'
+
+# Check unresolved threads via GraphQL
+gh api graphql -f query='
+{
+  repository(owner: "<owner>", name: "<repo>") {
+    pullRequest(number: 42) {
+      reviewThreads(first: 20) {
+        nodes { id isResolved comments(first: 1) { nodes { path body } } }
+      }
+    }
+  }
+}'
+```
+
+---
+
+## Cost Impact
+
+### Principles
+
+- Every infrastructure change has a cost implication. The default is to make it visible, not to block.
+- Cost findings are informational unless the delta is significant (> $100/month unexplained) or the change disables cost controls (removes lifecycle rules, removes Spot usage, removes resource limits).
+- Resource limits missing on new workloads is a cost risk — it allows unbounded CPU/memory consumption on shared nodes.
+
+### Instance and compute costs (AWS reference)
+
+| Instance | vCPU | RAM | On-Demand (us-east-1) |
+|---|---|---|---|
+| t3.micro | 2 | 1 GB | ~$8/month |
+| t3.medium | 2 | 4 GB | ~$30/month |
+| m5.large | 2 | 8 GB | ~$70/month |
+| m5.xlarge | 4 | 16 GB | ~$140/month |
+| m5.4xlarge | 16 | 64 GB | ~$550/month |
+| c5.2xlarge | 8 | 16 GB | ~$260/month |
+
+Spot savings: 60–80% vs On-Demand for stateless workloads.
+
+### Storage cost reference
+
+| Type | Cost |
+|---|---|
+| gp2 EBS | $0.10/GB/month |
+| gp3 EBS | $0.08/GB/month (20% cheaper, same baseline perf) |
+| io1 EBS | $0.125/GB/month + $0.065/provisioned IOPS |
+| S3 Standard | $0.023/GB/month |
+| S3 Infrequent Access | $0.0125/GB/month |
+
+**Rule:** Flag any new `gp2` volume — `gp3` is cheaper at equal performance for most workloads.
+
+### Network cost reference
+
+| Resource | Cost |
+|---|---|
+| NAT Gateway | ~$32/month per AZ + $0.045/GB processed |
+| ALB | ~$22/month base + LCU ($0.008/LCU-hour) |
+| NLB | ~$16/month base + NLCU |
+| Cross-AZ data transfer | $0.01/GB (both directions) |
+| Internet egress (AWS) | $0.09/GB first 10 TB |
+
+**Rule:** Any new NAT Gateway is a significant cost addition. Verify it's not duplicating an existing one. Prefer a shared NAT Gateway per AZ over per-subnet.
+
+### Cost review checklist
+
+```
+□ Replica count changes — multiply by instance cost
+□ New PVC — check StorageClass and size; recommend gp3 over gp2
+□ New S3 bucket — lifecycle rules present? versioning enabled (doubles storage)?
+□ New NAT Gateway — is an existing one available in the same AZ?
+□ New load balancer — justify vs reusing existing ingress controller
+□ Resource requests/limits set on all new containers
+□ HPA minReplicas — what is the floor cost at minimum scale?
+□ RDS instance class — Multi-AZ doubles cost; flag if not required in dev
+□ New managed service — is there a cheaper self-hosted alternative for non-prod?
+```
+
+---
+
+## Environment Drift
+
+### Principles
+
+- Drift between environments is normal for intentional differences (resource sizing, replica counts, hostnames). It is a bug when it affects feature availability, security controls, or configuration correctness.
+- The review goal is to make drift **visible and intentional** — not to enforce identical environments.
+- Any drift in security controls, network policy, or admission policies between prod and lower environments is HIGH severity.
+
+### Common drift patterns
+
+**Silent fallback risk**
+A values key present in `values-dev.yaml` but absent from `values-prod.yaml` means prod silently uses the chart default. If the chart default is insecure or incorrect, it only manifests in prod.
+
+```yaml
+# values-dev.yaml
+ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+
+# values-prod.yaml
+ingress: {}    # ← ssl-redirect falls back to chart default (false)
+```
+
+**Overlay patch missing**
+```
+overlays/
+  dev/kustomization.yaml    # patches resource limits
+  prod/kustomization.yaml   # no resource limit patch → uses base (no limits)
+```
+
+**Module version drift**
+```hcl
+# environments/dev/main.tf
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+}
+
+# environments/prod/main.tf
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 19.0"    # ← different major — different behaviour
+}
+```
+
+### Drift review checklist
+
+```
+□ For every changed values file, check sibling environment files
+□ For every changed overlay, check sibling overlays
+□ For every changed Terraform environment, check sibling environments
+□ Feature flags enabled in staging but absent from prod equivalent
+□ Ingress annotations (TLS, CORS, rate limiting) consistent across envs
+□ NetworkPolicy present in all environments, not just prod
+□ ResourceQuota and LimitRange consistent across tenant namespaces
+□ Kyverno/OPA policies applied to all clusters, not just production
+```
+
+---
+
+## Ownership and Governance
+
+### CODEOWNERS patterns
+
+```
+# Root catch-all — every file needs at least one owner
+*                          @platform-team
+
+# Platform domains
+references/                @platform-team
+commands/                  @platform-team
+examples/kubernetes/       @kubernetes-team
+examples/terraform/        @infra-team
+
+# Protect release files
+.claude-plugin/            @platform-leads
+CHANGELOG.md               @platform-leads
+```
+
+**Rule:** Any new top-level directory with no CODEOWNERS entry means PRs touching it have no required reviewers — anyone can merge.
+
+### Kubernetes resource ownership labels
+
+Every Namespace, Deployment, StatefulSet, DaemonSet, and CronJob should carry:
+
+```yaml
+labels:
+  app.kubernetes.io/name: <service-name>
+  app.kubernetes.io/team: <team-name>
+  app.kubernetes.io/part-of: <platform-or-product>
+```
+
+Use a `ValidatingPolicy` to enforce this at admission:
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: require-team-label
+spec:
+  validationActions: [Audit]
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [apps]
+        apiVersions: [v1]
+        operations: [CREATE, UPDATE]
+        resources: [deployments, statefulsets, daemonsets]
+  validations:
+    - expression: >-
+        has(object.metadata.labels) &&
+        'app.kubernetes.io/team' in object.metadata.labels
+      message: "app.kubernetes.io/team label is required"
+```
+
+### Terraform module ownership checklist
+
+Every module directory must have:
+- `README.md` — purpose, inputs, outputs, example usage, owning team
+- `variables.tf` — every variable has a `description`
+- `outputs.tf` — every output has a `description`
+- Version tag in any consuming `source` reference
+
+### PR governance checklist
+
+```
+□ PR description explains WHY (not just what changed)
+□ Issue or ticket reference present (#123, JIRA-456, LINEAR-789)
+□ CHANGELOG updated if version bumped in any manifest
+□ CODEOWNERS covers all changed top-level paths
+□ New namespace has team label and ResourceQuota
+□ New Terraform module has README with owner
+□ All variables in new modules have descriptions
+```
+
+---
+
+## Compliance and SOC 2
+
+### Control mapping quick reference
+
+| SOC 2 Code | Platform control | Terraform resource |
+|---|---|---|
+| CC6.1 | IAM least privilege | `aws_iam_policy`, `aws_iam_role` |
+| CC6.1 | Kubernetes RBAC scoped | `kubernetes_cluster_role_binding` |
+| CC6.2 | OIDC over static keys | `aws_iam_role` assume_role_policy |
+| CC6.6 | Security groups restricted | `aws_security_group_rule` |
+| CC6.6 | No public RDS | `aws_db_instance.publicly_accessible` |
+| CC6.7 | S3 encryption | `aws_s3_bucket_server_side_encryption_configuration` |
+| CC6.7 | RDS encryption | `aws_db_instance.storage_encrypted` |
+| CC7.2 | CloudTrail enabled | `aws_cloudtrail` |
+| CC7.2 | S3 access logging | `aws_s3_bucket_logging` |
+| CC8.1 | State locking | `aws_dynamodb_table` for lock |
+| A1.2 | RDS backup retention | `aws_db_instance.backup_retention_period >= 35` |
+
+### Critical patterns (automatic blockers)
+
+```hcl
+# ❌ CC6.1 — wildcard IAM (CRITICAL)
+Statement = [{
+  Effect   = "Allow"
+  Action   = "*"
+  Resource = "*"
+}]
+
+# ✅ CC6.1 — scoped to specific actions and ARN
+Statement = [{
+  Effect = "Allow"
+  Action = ["s3:GetObject", "s3:ListBucket"]
+  Resource = [
+    "arn:aws:s3:::${var.bucket_name}",
+    "arn:aws:s3:::${var.bucket_name}/*"
+  ]
+}]
+```
+
+```hcl
+# ❌ CC6.7 — unencrypted RDS (CRITICAL)
+resource "aws_db_instance" "main" {
+  storage_encrypted = false
+}
+
+# ✅ CC6.7
+resource "aws_db_instance" "main" {
+  storage_encrypted = true
+  kms_key_id        = aws_kms_key.rds.arn
+}
+```
+
+```hcl
+# ❌ CC6.6 — public RDS (CRITICAL)
+resource "aws_db_instance" "main" {
+  publicly_accessible = true
+}
+```
+
+### Evidence collection commands
+
+```bash
+# CC6.1 — list all IAM roles and policies
+aws iam list-roles --query 'Roles[*].RoleName'
+aws iam get-role-policy --role-name <role> --policy-name <policy>
+
+# CC7.2 — verify CloudTrail is logging
+aws cloudtrail get-trail-status --name <trail-name> --query 'IsLogging'
+
+# CC6.7 — verify S3 bucket encryption
+aws s3api get-bucket-encryption --bucket <bucket>
+
+# CC6.7 — verify RDS encryption
+aws rds describe-db-instances --query 'DBInstances[*].{ID:DBInstanceIdentifier,Encrypted:StorageEncrypted}'
+
+# A1.2 — verify backup retention
+aws rds describe-db-instances --query 'DBInstances[*].{ID:DBInstanceIdentifier,Retention:BackupRetentionPeriod}'
+
+# CC6.6 — list security group rules with open ingress
+aws ec2 describe-security-groups --filters "Name=ip-permission.cidr,Values=0.0.0.0/0" \
+  --query 'SecurityGroups[*].{ID:GroupId,Name:GroupName}'
+```
+
+---
+
+## Upgrade and Version Hygiene
+
+### Kubernetes API deprecation timeline
+
+| API | Deprecated | Removed | Replacement |
+|---|---|---|---|
+| `extensions/v1beta1` Ingress | 1.14 | **1.22** | `networking.k8s.io/v1` |
+| `networking.k8s.io/v1beta1` Ingress | 1.19 | **1.22** | `networking.k8s.io/v1` |
+| `policy/v1beta1` PodSecurityPolicy | 1.21 | **1.25** | Kyverno / OPA / PSA |
+| `policy/v1beta1` PodDisruptionBudget | 1.21 | **1.25** | `policy/v1` |
+| `autoscaling/v2beta1` HPA | 1.23 | **1.26** | `autoscaling/v2` |
+| `batch/v1beta1` CronJob | 1.21 | **1.25** | `batch/v1` |
+| `apiextensions.k8s.io/v1beta1` CRD | 1.16 | **1.22** | `apiextensions.k8s.io/v1` |
+| `kyverno.io/v1` ClusterPolicy | 1.17 | **1.20** | `policies.kyverno.io/v1` |
+
+Check manifest API versions against the cluster's target upgrade version — not just the current version.
+
+```bash
+# Scan a directory for deprecated API versions
+kubectl convert --dry-run -f ./manifests/ 2>&1 | grep -i "deprecated\|removed"
+
+# Or use pluto (purpose-built tool)
+pluto detect-files -d ./manifests/ --target-versions k8s=v1.28.0
+```
+
+### Terraform version hygiene
+
+```hcl
+# ❌ Too loose — allows major version jumps
+terraform {
+  required_providers {
+    aws = { version = ">= 3.0" }
+  }
+}
+
+# ✅ Pessimistic constraint — locks major version
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = "~> 1.7"
+}
+```
+
+### GitHub Actions version hygiene
+
+```yaml
+# ❌ Floating branch — unpinned, non-reproducible
+- uses: actions/checkout@main
+
+# ❌ Major tag — can be moved by owner
+- uses: actions/checkout@v3
+
+# ✅ SHA pin — immutable
+- uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+```
+
+Current recommended versions (as of v1.12.0):
+| Action | Recommended |
+|---|---|
+| `actions/checkout` | `v4` |
+| `actions/setup-node` | `v4` |
+| `actions/setup-python` | `v5` |
+| `actions/upload-artifact` | `v4` |
+| `aws-actions/configure-aws-credentials` | `v4` |
+| `hashicorp/setup-terraform` | `v3` |
+
+### Container image hygiene
+
+```yaml
+# ❌ Mutable tag — different image on rollback
+image: nginx:latest
+image: nginx:1.25
+
+# ✅ Digest pin — immutable
+image: nginx:1.25.3@sha256:a3e2f7e2b1c4d9f8e6a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4
+```
+
+```bash
+# Get digest for an image
+docker inspect --format='{{index .RepoDigests 0}}' nginx:1.25.3
+# or
+crane digest nginx:1.25.3
+```
+
+### Upgrade review checklist
+
+```
+□ All Kubernetes apiVersions checked against target cluster version
+□ Terraform provider constraints use ~> not >=
+□ required_version set in all root modules
+□ Module source refs include a version tag
+□ GitHub Actions pinned to SHA or immutable release tag
+□ No :latest image tags
+□ Node/Python/Go runtime versions not EOL
+□ ubuntu-18.04 / ubuntu-20.04 runner replaced with ubuntu-latest or ubuntu-22.04
+□ kyverno.io/v1 ClusterPolicy replaced with policies.kyverno.io/v1
+```
+
+---
+
+## Rollback Feasibility
+
+### Rollback decision matrix
+
+| Change type | Reversibility | Notes |
+|---|---|---|
+| Kubernetes Deployment image tag | FULL | Revert commit → GitOps re-syncs |
+| ConfigMap / Secret value change | FULL | Revert commit → GitOps re-syncs |
+| Kubernetes resource rename | MANUAL | Old resource deleted, new created; clients need update |
+| HelmRelease version bump | FULL | Revert pinned version → GitOps re-installs |
+| HelmRelease with `uninstall` remediation | MANUAL | Rollback triggers full uninstall |
+| Terraform variable change | FULL | Plan shows delta; apply reverses |
+| RDS `allocated_storage` increase | NONE | AWS does not support storage decrease |
+| RDS instance class change | PARTIAL | Change requires maintenance window |
+| IAM role trust policy change | MANUAL | Services using old trust break immediately |
+| IAM role deletion | NONE | Must recreate; ARN changes if not controlled |
+| S3 bucket deletion (`force_destroy`) | NONE | Data permanently lost |
+| Database schema migration (no down) | NONE | Application must handle both old and new schema |
+| Secret rotation (no grace period) | MANUAL | Old clients fail; must re-issue old secret |
+| DNS record change | PARTIAL | TTL delay; old record may be cached |
+| Kustomization `prune: true` + resource delete | MANUAL | Resource removed from cluster; restore from Git |
+
+### Pre-merge requirements for high-risk changes
+
+**For NONE reversibility:**
+- [ ] Database backup or snapshot taken and verified before merge
+- [ ] Down migration script written and tested (for schema changes)
+- [ ] Data export confirmed for destructive storage operations
+- [ ] Explicit sign-off from owning team and/or on-call
+
+**For MANUAL reversibility with PLATFORM blast radius:**
+- [ ] Runbook written and reviewed
+- [ ] Rollback tested in a non-prod environment
+- [ ] Maintenance window scheduled
+- [ ] Stakeholders notified
+
+**For stateful Terraform changes:**
+```bash
+# Always take a state backup before applying destructive changes
+terraform state pull > terraform.tfstate.backup.$(date +%Y%m%d%H%M%S)
+
+# Verify the backup
+terraform state list
+```
+
+### GitOps rollback patterns
+
+```bash
+# Flux — force rollback to previous image
+flux suspend image updateautomation <name>
+kubectl set image deployment/<name> <container>=<previous-image>
+git revert HEAD && git push
+
+# Argo CD — rollback to previous sync
+argocd app rollback <app-name> <revision>
+
+# Helm — rollback to previous release
+helm rollback <release-name> <revision>
+helm history <release-name>  # find the revision number
+```
+
+### Rollback checklist
+
+```
+□ Every stateful resource change has a pre-merge backup requirement noted
+□ Schema migrations have a corresponding down migration
+□ Resource renames document the rollback procedure
+□ Secret rotations have a grace period defined
+□ IAM role ARN changes identify all dependent services
+□ GitOps prune behaviour understood for deleted resources
+□ HelmRelease remediation policy reviewed (uninstall vs rollback)
+□ Maintenance window identified for changes requiring it
+```
+
+---
+
+## Bot Comment Triage
+
+When a PR has open review threads from Copilot, GitHub Actions bots, Dependabot, or similar:
+
+### Evaluation steps
+
+1. **Read the comment** — understand exactly what it claims is wrong
+2. **Read the current file state** — not the diff, the actual file after all commits
+3. **Classify the comment:**
+   - **Valid** — the issue exists in the current file state → fix it
+   - **Stale** — the issue was fixed in a later commit → reply and resolve
+   - **Invalid** — the comment is technically incorrect → reply with specific reason and resolve
+
+### Resolving threads via CLI
+
+```bash
+# List all unresolved threads
+gh api graphql -f query='
+{
+  repository(owner: "<owner>", name: "<repo>") {
+    pullRequest(number: <PR>) {
+      reviewThreads(first: 20) {
+        nodes {
+          id isResolved
+          comments(first: 1) { nodes { path body } }
+        }
+      }
+    }
+  }
+}' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {id, path}'
+
+# Reply to a comment thread
+gh api repos/<owner>/<repo>/pulls/comments \
+  -X POST \
+  -F body="<reply text>" \
+  -F in_reply_to=<comment-id>
+
+# Resolve a thread
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "<thread-id>"}) {
+    thread { id isResolved }
+  }
+}'
+```
+
+### Reply templates
+
+**Valid — fixed:**
+```
+Fixed in commit <sha> — <file> updated to address this.
+```
+
+**Stale — already fixed:**
+```
+Not valid against the current code — this was already addressed in commit <sha>.
+<current file path> now reads: <relevant excerpt>.
+```
+
+**Invalid — technically incorrect:**
+```
+Not valid — <specific technical reason>.
+<cite the relevant spec, doc, or code that disproves the claim>.
+No change needed.
+```
+
+---
+
+## Related References
+
+- `references/compliance.md` — full SOC 2 Terraform patterns and Checkov rules
+- `references/terraform.md` — blast radius, state, and replacement risk
+- `references/kubernetes.md` — RBAC, namespace, and workload patterns
+- `references/github-actions.md` — workflow security and action pinning
+- `references/kyverno.md` — admission policy for ownership enforcement

--- a/references/pr-review.md
+++ b/references/pr-review.md
@@ -374,15 +374,18 @@ terraform {
 - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 ```
 
-Current recommended versions (as of v1.12.0):
-| Action | Recommended |
-|---|---|
-| `actions/checkout` | `v4` |
-| `actions/setup-node` | `v4` |
-| `actions/setup-python` | `v5` |
-| `actions/upload-artifact` | `v4` |
-| `aws-actions/configure-aws-credentials` | `v4` |
-| `hashicorp/setup-terraform` | `v3` |
+Current recommended major versions (as of v1.12.0) — use these as the comment label on your SHA-pinned lines, not as the actual ref:
+
+| Action | Minimum recommended major | Example SHA-pinned usage |
+|---|---|---|
+| `actions/checkout` | `v4` | `actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1` |
+| `actions/setup-node` | `v4` | `actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2` |
+| `actions/setup-python` | `v5` | `actions/setup-python@0a5c61591373683ec8de3e43c37e6e526f26a9b8 # v5.0.0` |
+| `actions/upload-artifact` | `v4` | `actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1` |
+| `aws-actions/configure-aws-credentials` | `v4` | `aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2` |
+| `hashicorp/setup-terraform` | `v3` | `hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1` |
+
+Always pin the `uses:` field to the full commit SHA. The major version tag in the comment is for human readability only — the SHA is what actually controls which code runs.
 
 ### Container image hygiene
 
@@ -525,8 +528,8 @@ gh api graphql -f query='
   }
 }' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | {id, path}'
 
-# Reply to a comment thread
-gh api repos/<owner>/<repo>/pulls/comments \
+# Reply to a comment thread (include PR number in path; in_reply_to makes it a reply)
+gh api repos/<owner>/<repo>/pulls/<PR>/comments \
   -X POST \
   -F body="<reply text>" \
   -F in_reply_to=<comment-id>

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -31,6 +31,7 @@ Match the task to the right layer:
 18. `Conventional Commits`: Analyze git diffs, generate commit messages that explain WHY a change was made, intelligently stage files for atomic commits, and validate messages against the Conventional Commits specification.
 19. `OPA / Conftest`: Generate Rego policies with correct rule types and namespacing, write unit tests, run the full validation pipeline (fmt → regal lint → conftest verify → integration test), explain existing policies, and debug why a rule is not firing.
 20. `Kyverno`: Write and maintain Kubernetes-native admission policies using the CEL-based types — ValidatingPolicy, MutatingPolicy, GeneratingPolicy, ImageValidatingPolicy (all `policies.kyverno.io/v1`). Covers matchConstraints, matchConditions, CEL validations/mutations, generator.Apply(), Audit→Deny promotion, PolicyException, and kyverno-cli testing.
+21. `PR Review`: Comprehensive pre-merge risk review across six dimensions — cost impact, environment drift, ownership and governance gaps, SOC 2 compliance, deprecated API / version hygiene, and rollback feasibility scoring.
 
 If a task spans multiple areas, decide which layer owns the source of truth and keep the other layers consumers of that state.
 
@@ -86,6 +87,7 @@ When asked to generate code, start from the thinnest useful slice that proves th
 - For Conventional Commits — type classification, scope rules, breaking changes, message structure, atomic commits, commitlint, husky, semantic-release, and validation rules — read [references/conventional-commits.md](references/conventional-commits.md).
 - For OPA / Conftest — Rego v1 syntax, rule types, package namespacing, input shapes, unit tests, validation pipeline (fmt/regal/verify), GitHub Actions integration, and troubleshooting — read [references/opa.md](references/opa.md).
 - For Kyverno CEL-based admission policies — ValidatingPolicy, MutatingPolicy, GeneratingPolicy, ImageValidatingPolicy, matchConstraints, matchConditions, Audit→Deny promotion, PolicyException, kyverno-cli testing, and migration from legacy ClusterPolicy — read [references/kyverno.md](references/kyverno.md).
+- For comprehensive PR review — cost impact, environment drift, ownership gaps, SOC 2 compliance, deprecated APIs, version hygiene, rollback feasibility, and bot comment triage — read [references/pr-review.md](references/pr-review.md).
 
 Load only the files needed for the current request.
 
@@ -110,3 +112,4 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:commit` — analyze diff, generate conventional commit message, stage files atomically, validate message
 - `/platform-skills:opa` — generate Rego policies, write unit tests, run fmt/regal/verify pipeline, explain or debug policies
 - `/platform-skills:kyverno` — generate, test, audit, debug, or migrate Kyverno CEL-based admission policies
+- `/platform-skills:pr-review` — comprehensive PR review: cost, drift, ownership, compliance, upgrade, rollback

--- a/tests/validate-helmcheck.sh
+++ b/tests/validate-helmcheck.sh
@@ -322,7 +322,7 @@ else
   fail "$HOW missing"
 fi
 
-for cmd in "helmcheck" "review" "terraform" "debug" "gitops" "compliance" "product" "mcp" "observability" "document" "datadog" "dynatrace" "commit" "opa" "kyverno"; do
+for cmd in "helmcheck" "review" "terraform" "debug" "gitops" "compliance" "product" "mcp" "observability" "document" "datadog" "dynatrace" "commit" "opa" "kyverno" "pr-review"; do
   if grep -q "platform-skills:$cmd" "$HOW"; then
     pass "$HOW references /platform-skills:$cmd"
   else

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -88,6 +88,7 @@ EXAMPLE_DOMAINS=(
   examples/conventional-commits
   examples/opa
   examples/kyverno
+  examples/pr-review
 )
 
 for domain in "${EXAMPLE_DOMAINS[@]}"; do

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -55,6 +55,7 @@ REQUIRED_REFERENCES=(
   references/conventional-commits.md
   references/opa.md
   references/kyverno.md
+  references/pr-review.md
 )
 
 for ref in "${REQUIRED_REFERENCES[@]}"; do


### PR DESCRIPTION
## Summary

- New Domain 21: `/platform-skills:pr-review` — comprehensive pre-merge risk review across six modes
- New `commands/pr-review.md` with full mode definitions: `cost`, `drift`, `ownership`, `compliance`, `upgrade`, `rollback`, `full`
- New `references/pr-review.md` — deep-dive reference with pricing tables, SOC 2 control mapping, Kubernetes API deprecation timeline, rollback decision matrix, and GH CLI bot comment triage patterns
- Wired into both SKILL.md files, HOW_IT_WORKS.md, COMMANDS.md, README.md, GETTING_STARTED.md, plugin.json, marketplace.json (bumped to 1.12.0), and both test scripts

## Modes

| Mode | What it reviews |
|---|---|
| `cost` | Compute, storage, and network spend delta with AWS pricing reference |
| `drift` | Environment alignment — Kustomize overlays, Helm values siblings, Terraform workspaces, GitOps sources |
| `ownership` | CODEOWNERS gaps, missing team labels, Terraform module README, PR governance checklist |
| `compliance` | SOC 2 CC6.1–CC8.1 / A1.2 impact with Terraform patterns and `aws` CLI evidence commands |
| `upgrade` | Deprecated Kubernetes APIs (removal version), loose Terraform constraints, floating action versions, `:latest` images |
| `rollback` | Reversibility (FULL/PARTIAL/MANUAL/NONE) + blast radius (LOCAL/CLUSTER/PLATFORM/DATA) per change; 🟢/🟡/🔴 Rollback Risk Score |
| `full` | All six modes with Merge Readiness Summary: blockers, recommendations, informational |

## Test plan

- [x] `bash tests/validate-skill.sh` — all checks pass including `references/pr-review.md`
- [x] `bash tests/validate-helmcheck.sh` — all checks pass including `/platform-skills:pr-review` in HOW_IT_WORKS.md
- [ ] Manual: invoke `/platform-skills:pr-review cost` against a real PR diff
- [ ] Manual: invoke `/platform-skills:pr-review full` against a PR with Terraform + Kubernetes changes