### PR TITLE
chore: release v1.13.0 — review bot comments and wiki

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP server development, observability (Prometheus/OpenTelemetry/Grafana), code documentation (OpenAPI/docstrings), SOC 2 compliance for Terraform, Datadog, Dynatrace, conventional commit message generation, OPA/Conftest Rego policies, Kyverno admission policies (ValidatingPolicy/MutatingPolicy/GeneratingPolicy/ImageValidatingPolicy, CEL expressions, Audit→Deny promotion), and comprehensive PR review (cost impact, environment drift, ownership governance, compliance, deprecated API upgrade, rollback feasibility). Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
       "author": {
         "name": "Nitin Jain"
@@ -96,7 +96,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "1559d1433481256a8fe8731f5e1142cbf4080729"
+        "sha": "5b1449d167287ce378bd96e708d4b07c0a5d042c"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-05-16
+
+### Added
+
+#### Review Bot Comment Mode
+
+Enhanced the `/platform-skills:review` command with automated PR comment support.
+
+- `commands/review.md` — adds `--bot` flag and structured GitHub-flavoured markdown output format for PR comment workflows
+- Defines `MERGE_READY / NEEDS_FIX / BLOCKED` result values based on finding severity
+- Uses `<!-- platform-skills-review -->` HTML marker so GitHub Actions can find and update the existing comment on re-push instead of posting a new one each time
+- Severity table with emoji labels (🔴 Critical, 🟡 Improvement, 🔵 Note) and file/line references
+
+#### Wiki
+
+- Full GitHub wiki published at https://github.com/nitinjain999/platform-skills/wiki
+- 50 pages covering all 18 commands and 24 domains
+- Navigation index, Quick Start, Installation, Editor Integrations, How It Works, Contributing pages
+- One page per command with Claude Code slash syntax, Copilot Chat prompts, and what gets checked
+- One page per domain with key patterns, code examples, and links to reference guides
+
 ## [1.12.0] - 2026-05-16
 
 ### Added


### PR DESCRIPTION
## Summary

- Bumps version to `1.13.0`
- Updates `marketplace.json` `source.sha` to latest main commit
- Adds CHANGELOG entry for v1.13.0

## What's in v1.13.0

**Review bot comment mode** (`commands/review.md`)
- `--bot` flag emits structured GitHub-flavoured markdown for PR comment workflows
- `MERGE_READY / NEEDS_FIX / BLOCKED` result values
- `<!-- platform-skills-review -->` marker for idempotent comment updates

**Wiki** (https://github.com/nitinjain999/platform-skills/wiki)
- 50 pages: all 18 commands + 24 domains
- Navigation, Quick Start, Installation, Editor Integrations

## Test plan

- [ ] CI passes on this branch
- [ ] `marketplace.json` version matches `1.13.0`
- [ ] CHANGELOG has `[1.13.0]` entry
- [ ] After merge: tag `v1.13.0` to trigger release workflow