### PR TITLE
feat(triage): add PR comment triage skill and workflow

### DIFF
--- a/.github/workflows/pr-comment-triage.yml
+++ b/.github/workflows/pr-comment-triage.yml
@@ -1,0 +1,266 @@
+name: PR Comment Triage
+
+# Fires on any new PR comment (from bots, reviewers, or CI tools).
+# Uses the /platform-skills:triage skill to classify and address each comment.
+#
+# What happens:
+#   ACTIONABLE_FIX  → applies the fix as a commit, posts reply, resolves thread
+#   INFORMATIONAL   → posts explanation reply, resolves thread
+#   NOT_APPLICABLE  → posts "not applicable" reply, resolves thread
+#
+# Required secret: ANTHROPIC_API_KEY
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write       # push fix commits
+  pull-requests: write  # post comments, resolve threads
+
+jobs:
+  triage:
+    name: Triage comment
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null) ||
+      github.event_name == 'pull_request_review_comment'
+
+    steps:
+      - name: Resolve PR number
+        id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "pr_number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch PR head branch and diff
+        id: diff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+        run: |
+          HEAD_REF=$(gh pr view "$PR_NUMBER" --json headRefName -q '.headRefName')
+          BASE_REF=$(gh pr view "$PR_NUMBER" --json baseRefName -q '.baseRefName')
+
+          echo "head_ref=${HEAD_REF}" >> "$GITHUB_OUTPUT"
+
+          git fetch origin "$HEAD_REF" "$BASE_REF" --depth=10
+          git checkout "$HEAD_REF"
+
+          # Capture diff — truncate to 300 lines to stay within context
+          git diff "origin/${BASE_REF}...HEAD" | head -300 > /tmp/pr.diff
+
+          # If the comment references a specific file, capture its content
+          COMMENT_PATH="${{ github.event.comment.path }}"
+          if [ -n "$COMMENT_PATH" ] && [ -f "$COMMENT_PATH" ]; then
+            cp "$COMMENT_PATH" /tmp/comment_file.txt
+          else
+            touch /tmp/comment_file.txt
+          fi
+
+      - name: Install Claude CLI
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          npm install -g @anthropic-ai/claude-code 2>/dev/null || true
+          # Verify claude is available
+          claude --version
+
+      - name: Install platform-skills plugin
+        run: |
+          claude plugin marketplace add https://github.com/nitinjain999/platform-skills
+          claude plugin install platform-skills
+
+      - name: Run triage skill
+        id: triage
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          COMMENT="${{ github.event.comment.body }}"
+          DIFF=$(cat /tmp/pr.diff)
+          FILE=$(cat /tmp/comment_file.txt)
+
+          # Build the argument string for the triage skill
+          INPUT="Comment from @${{ github.event.comment.user.login }}:
+
+          ${COMMENT}
+
+          --diff
+          ${DIFF}
+          --file
+          ${FILE}"
+
+          # Run the skill non-interactively; capture full output
+          claude --print \
+            --dangerously-skip-permissions \
+            "/platform-skills:triage ${INPUT}" > /tmp/triage_output.txt 2>&1
+
+          cat /tmp/triage_output.txt
+
+          # Parse labeled sections from the skill output
+          CLASSIFICATION=$(awk '/^CLASSIFICATION:/{print $2}' /tmp/triage_output.txt)
+          REPLY=$(awk '/^REPLY:/{found=1; next} found{print}' /tmp/triage_output.txt)
+          FIX_SECTION=$(awk '/^FIX:/{found=1; next} /^REPLY:/{found=0} found{print}' /tmp/triage_output.txt)
+          COMMIT_MSG=$(echo "$FIX_SECTION" | grep -E '^(fix|feat|chore|docs|refactor)\(' | head -1)
+
+          echo "classification=${CLASSIFICATION}"     >> "$GITHUB_OUTPUT"
+          echo "$REPLY"      > /tmp/reply.txt
+          echo "$FIX_SECTION" > /tmp/fix_section.txt
+          echo "$COMMIT_MSG"  > /tmp/commit_msg.txt
+
+      - name: Apply fix
+        if: steps.triage.outputs.classification == 'ACTIONABLE_FIX'
+        run: |
+          FIX=$(cat /tmp/fix_section.txt)
+          COMMIT_MSG=$(cat /tmp/commit_msg.txt)
+
+          # Extract file paths and before/after blocks from the fix section.
+          # The skill outputs blocks in the form:
+          #   File: path/to/file
+          #   Before:
+          #   <text>
+          #   After:
+          #   <text>
+          python3 << 'PYEOF'
+          import re, pathlib, sys
+
+          fix = pathlib.Path("/tmp/fix_section.txt").read_text()
+
+          # Split into per-file blocks
+          blocks = re.split(r'(?=^File:)', fix, flags=re.MULTILINE)
+
+          changed = False
+          for block in blocks:
+              if not block.strip() or not block.startswith("File:"):
+                  continue
+
+              file_match = re.search(r'^File:\s*(.+)$', block, re.MULTILINE)
+              before_match = re.search(r'Before:\n(.*?)(?=\nAfter:)', block, re.DOTALL)
+              after_match  = re.search(r'After:\n(.*?)(?=\n(?:File:|$))', block, re.DOTALL)
+
+              if not (file_match and before_match and after_match):
+                  continue
+
+              path    = file_match.group(1).strip()
+              before  = before_match.group(1).strip()
+              after   = after_match.group(1).strip()
+
+              p = pathlib.Path(path)
+              if not p.exists():
+                  print(f"⚠️  {path} not found — skipping", file=sys.stderr)
+                  continue
+
+              content = p.read_text()
+              if before not in content:
+                  print(f"⚠️  'Before' text not found in {path} — skipping", file=sys.stderr)
+                  continue
+
+              p.write_text(content.replace(before, after, 1))
+              print(f"✅ Patched {path}")
+              changed = True
+
+          sys.exit(0 if changed else 1)
+          PYEOF
+
+          if [ $? -ne 0 ]; then
+            echo "No files were patched — skipping commit"
+            exit 0
+          fi
+
+          git config user.email "nitin.solna@gmail.com"
+          git config user.name "Nitin Jain"
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Nothing staged after patch"
+          else
+            [ -z "$COMMIT_MSG" ] && COMMIT_MSG="fix: address PR comment feedback"
+            git commit -m "$COMMIT_MSG"
+            git push origin "${{ steps.diff.outputs.head_ref }}"
+            echo "✅ Fix committed and pushed"
+          fi
+
+      - name: Post reply
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          REPLY=$(cat /tmp/reply.txt)
+
+          if [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            gh api \
+              --method POST \
+              "repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments/${COMMENT_ID}/replies" \
+              --field body="$REPLY"
+          else
+            gh pr comment "$PR_NUMBER" --body "$REPLY"
+          fi
+          echo "✅ Reply posted"
+
+      - name: Resolve review thread
+        if: github.event_name == 'pull_request_review_comment'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          THREAD_ID=$(gh api graphql \
+            -f query='query($owner:String!,$repo:String!,$pr:Int!){
+              repository(owner:$owner,name:$repo){
+                pullRequest(number:$pr){
+                  reviewThreads(first:100){
+                    nodes{
+                      id isResolved
+                      comments(first:1){ nodes{ databaseId } }
+                    }
+                  }
+                }
+              }
+            }' \
+            -f owner="${{ github.repository_owner }}" \
+            -f repo="${{ github.event.repository.name }}" \
+            -F pr="$PR_NUMBER" \
+            --jq ".data.repository.pullRequest.reviewThreads.nodes[]
+                  | select(.isResolved==false)
+                  | select(.comments.nodes[0].databaseId==$COMMENT_ID)
+                  | .id" 2>/dev/null || true)
+
+          if [ -n "$THREAD_ID" ]; then
+            gh api graphql \
+              -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t}){thread{isResolved}}}' \
+              -f t="$THREAD_ID" > /dev/null
+            echo "✅ Thread resolved"
+          else
+            echo "ℹ️  Thread not found or already resolved"
+          fi
+
+      - name: Job summary
+        env:
+          CLASSIFICATION: ${{ steps.triage.outputs.classification }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## PR Comment Triage
+
+          | Field | Value |
+          |---|---|
+          | Comment author | \`${{ github.event.comment.user.login }}\` |
+          | Classification | \`${CLASSIFICATION}\` |
+
+          **Reply posted:**
+
+          $(cat /tmp/reply.txt)
+          EOF

--- a/SKILL.md
+++ b/SKILL.md
@@ -84,3 +84,4 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:linux` — Linux administration, DNS, load balancing, VPC/VNet, and connectivity troubleshooting
 - `/platform-skills:product` — product thinking, friction audits, DevEx, RFC/ADR, incident updates, post-mortems
 - `/platform-skills:pr-review` — comprehensive PR review: cost, drift, ownership, compliance, upgrade, rollback
+- `/platform-skills:triage` — triage a PR comment (bot or human): classify as ACTIONABLE_FIX / INFORMATIONAL / NOT_APPLICABLE, produce the exact fix if needed, and write the thread reply

--- a/commands/triage.md
+++ b/commands/triage.md
@@ -1,0 +1,101 @@
+---
+name: triage
+description: Triages a PR comment (from a bot, reviewer, or CI tool). Classifies the comment as actionable, informational, or not applicable. If actionable, proposes the exact fix. Always closes the thread with a reply explaining the decision.
+argument-hint: "[comment text] [--diff <diff text or file path>] [--file <file path>]"
+---
+
+You are a senior platform engineer triaging a PR comment.
+
+Input: `$ARGUMENTS`
+
+The input contains the comment text, optionally accompanied by:
+- `--diff` — the PR diff or path to a diff file
+- `--file` — the specific file the comment refers to
+
+If the diff or file content is not provided but is needed to assess the comment, say so explicitly and ask the user to paste it.
+
+---
+
+## Step 1 — Classify the comment
+
+Choose exactly one classification:
+
+**ACTIONABLE_FIX**
+The comment identifies a real, concrete problem in the changed files that should be fixed now:
+- Wrong value, missing required field, broken reference
+- Security issue (wildcard IAM, missing encryption, exposed secret)
+- Deprecated API or field that will break on upgrade
+- Broken link or incorrect file path
+- Typo in code, config, or a shell command
+- Logic error or unintended behaviour
+
+**INFORMATIONAL**
+The comment asks a question, suggests a future improvement, or flags something out of scope for this PR:
+- "Why did you choose X over Y?"
+- "Consider adding tests in a follow-up"
+- "This pattern works but there is a cleaner alternative"
+- Questions about intent that do not require a code change
+
+**NOT_APPLICABLE**
+The comment does not require any action:
+- Automated bot status messages (CI pass/fail, coverage report)
+- Already addressed in a later commit on this branch
+- Duplicate of another open thread
+- Refers to a file or line not changed in this PR
+
+---
+
+## Step 2 — If ACTIONABLE_FIX, produce the fix
+
+Show the exact change needed:
+
+```
+File: <relative/path/to/file>
+
+Before:
+<exact text to replace — copy verbatim from the file>
+
+After:
+<replacement text>
+```
+
+If multiple files need changing, repeat the block for each file.
+
+State the conventional commit message for the fix:
+```
+fix(<scope>): <what was wrong and what was corrected>
+```
+
+---
+
+## Step 3 — Write the thread reply
+
+Write the exact comment to post as a reply on the PR thread.
+
+Rules:
+- First-person, concise, no filler phrases
+- Reference the specific line or file where relevant
+- For ACTIONABLE_FIX: describe what was changed and why. End with: ✅ Fixed — thread resolved.
+- For INFORMATIONAL: answer the question or acknowledge the suggestion. Explain why no code change is needed. End with: ℹ️ Thread resolved — no code change needed.
+- For NOT_APPLICABLE: state why this does not apply. End with: ❌ Not applicable — thread resolved.
+
+---
+
+## Step 4 — Output format
+
+Respond in this structure so the GitHub Actions workflow can parse and act on it:
+
+```
+CLASSIFICATION: <ACTIONABLE_FIX | INFORMATIONAL | NOT_APPLICABLE>
+
+REASON:
+<one sentence>
+
+FIX:
+<file path, before/after blocks, and commit message — or "none" if no fix>
+
+REPLY:
+<the exact comment to post on the thread>
+```
+
+Do not use JSON. Use the labeled sections above so the workflow can extract each part with simple `sed`/`awk` parsing.


### PR DESCRIPTION
## Summary

- Adds `/platform-skills:triage` skill (`commands/triage.md`)
- Adds `.github/workflows/pr-comment-triage.yml` — wires the skill to GitHub events
- Registers the command in `SKILL.md`

## How it works

**Skill** (`/platform-skills:triage`)
- Takes the comment text + optional diff + optional file content
- Classifies: `ACTIONABLE_FIX` | `INFORMATIONAL` | `NOT_APPLICABLE`
- If `ACTIONABLE_FIX`: outputs `File / Before / After` blocks + conventional commit message
- Always outputs a `REPLY` to post on the thread

**Workflow** (`pr-comment-triage.yml`)
- Triggers on `issue_comment` and `pull_request_review_comment` (PR comments only)
- Checks out the PR head branch
- Installs platform-skills plugin, runs `/platform-skills:triage` via `claude --print`
- If `ACTIONABLE_FIX`: applies the `Before → After` patch with Python, commits and pushes
- Posts the reply comment on the thread
- Resolves the review thread via GraphQL mutation

**Required secret:** `ANTHROPIC_API_KEY`

## Test plan

- [ ] Comment on a PR with a real issue (e.g. wrong value in a YAML file) → workflow commits the fix and resolves thread
- [ ] Comment with a question → workflow replies with explanation, resolves thread
- [ ] Bot status comment → workflow replies "not applicable", resolves thread