### PR TITLE
docs(triage): add examples directory with 11 scenarios

### DIFF
--- a/examples/triage/README.md
+++ b/examples/triage/README.md
@@ -1,0 +1,413 @@
+# Triage Examples
+
+Realistic scenarios for the `/platform-skills:triage` command. Each example shows
+an actual PR comment, the file it refers to, the expected classification, the fix
+(if any), and the exact reply posted on the thread.
+
+## How the Command Works
+
+```
+/platform-skills:triage <PR number> <comment ID>
+/platform-skills:triage --all <PR number>
+```
+
+Claude:
+1. Fetches the comment and PR diff via `gh` CLI
+2. Classifies: `ACTIONABLE_FIX` | `INFORMATIONAL` | `NOT_APPLICABLE`
+3. If `ACTIONABLE_FIX` — reads the file, applies the minimal fix, commits and pushes
+4. Posts a reply on the thread explaining the decision
+5. Resolves the thread via GraphQL
+
+No workflow. No secrets to configure. Runs entirely inside Claude Code with `gh auth` active.
+
+---
+
+## Quick Start
+
+```bash
+# Triage a single comment (PR 42, comment ID 123456789)
+/platform-skills:triage 42 123456789
+
+# Triage every unresolved thread on PR 42 in one pass
+/platform-skills:triage --all 42
+```
+
+Get comment IDs from the PR URL or:
+
+```bash
+# List all review thread comments on a PR
+gh api graphql -f query='
+  query($owner:String!, $repo:String!, $pr:Int!) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$pr) {
+        reviewThreads(first:100) {
+          nodes {
+            isResolved
+            comments(first:1) {
+              nodes { databaseId body author { login } }
+            }
+          }
+        }
+      }
+    }
+  }' \
+  -f owner=nitinjain999 -f repo=platform-skills -F pr=42 \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+        | select(.isResolved==false)
+        | .comments.nodes[0]
+        | "\(.databaseId)  @\(.author.login)  \(.body[:80])"'
+```
+
+---
+
+## Structure
+
+```
+actionable-fix/
+  security-wildcard-iam.md          # Copilot flags wildcard IAM — fix applied
+  missing-resource-limits.md        # Reviewer flags missing limits on Deployment
+  deprecated-k8s-api.md             # Bot flags networking.k8s.io/v1beta1 Ingress
+  broken-helm-probe-path.md         # Reviewer flags wrong liveness probe path
+  plaintext-secret-in-config.md     # Copilot flags a hardcoded API key
+
+informational/
+  question-why-two-replicas.md      # "Why only 2 replicas?" — explained, no change
+  suggest-pdb-follow-up.md          # "Consider adding a PDB" — acknowledged, future work
+  ask-about-kms-rotation.md         # "Is KMS rotation enabled?" — answered with evidence
+
+not-applicable/
+  ci-status-bot.md                  # GitHub Actions pass/fail status comment
+  duplicate-thread.md               # Same issue already fixed in a later commit
+  out-of-scope-file.md              # Comment on a file not changed in this PR
+```
+
+---
+
+## Scenario: ACTIONABLE_FIX
+
+### 1. Copilot flags wildcard IAM
+
+**PR comment** (from `github-advanced-security[bot]`):
+> The IAM policy on line 12 uses a wildcard action `"s3:*"` and wildcard resource `"*"`. This grants overly broad permissions and violates least-privilege. Consider scoping to specific actions and the target bucket ARN.
+
+**File:** `examples/triage/actionable-fix/security-wildcard-iam.tf`
+
+**Before:**
+```hcl
+resource "aws_iam_policy" "app" {
+  policy = jsonencode({
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:*"]
+      Resource = ["*"]
+    }]
+  })
+}
+```
+
+**After (fix applied by triage):**
+```hcl
+resource "aws_iam_policy" "app" {
+  policy = jsonencode({
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"]
+      Resource = [
+        "arn:aws:s3:::${var.bucket_name}",
+        "arn:aws:s3:::${var.bucket_name}/*"
+      ]
+    }]
+  })
+}
+```
+
+**Commit message:** `fix(iam): scope s3 policy to explicit actions and bucket ARN`
+
+**Reply posted:**
+> Scoped the IAM policy to the four required S3 actions (`GetObject`, `PutObject`, `DeleteObject`, `ListBucket`) and replaced the wildcard resource with the bucket ARN. This satisfies SOC 2 CC6.1 least-privilege requirement.
+>
+> ✅ Fixed — thread resolved.
+
+---
+
+### 2. Reviewer flags missing resource limits
+
+**PR comment** (from `@alice`):
+> This Deployment has no resource limits set. It can consume all node memory and trigger OOM eviction of other pods.
+
+**File:** `examples/triage/actionable-fix/missing-resource-limits.yaml`
+
+**Before:**
+```yaml
+containers:
+  - name: orders
+    image: orders:1.2.3
+    ports:
+      - containerPort: 8080
+```
+
+**After (fix applied):**
+```yaml
+containers:
+  - name: orders
+    image: orders:1.2.3
+    ports:
+      - containerPort: 8080
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "256Mi"
+```
+
+**Commit message:** `fix(kubernetes): add resource requests and limits to orders Deployment`
+
+**Reply posted:**
+> Added resource requests (`100m` CPU, `128Mi` memory) and limits (`500m` CPU, `256Mi` memory) to the `orders` container. Adjust values to match your profiling data before merging to production.
+>
+> ✅ Fixed — thread resolved.
+
+---
+
+### 3. Bot flags deprecated Kubernetes API
+
+**PR comment** (from `github-actions[bot]` / kubeconform):
+> `networking.k8s.io/v1beta1` Ingress was removed in Kubernetes 1.22. This manifest will fail to apply on clusters running 1.22+.
+
+**File:** `examples/triage/actionable-fix/deprecated-k8s-api.yaml`
+
+**Before:**
+```yaml
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: orders-ingress
+spec:
+  rules:
+    - host: orders.example.com
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: orders
+              servicePort: 80
+```
+
+**After (fix applied):**
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: orders-ingress
+spec:
+  rules:
+    - host: orders.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: orders
+                port:
+                  number: 80
+```
+
+**Commit message:** `fix(kubernetes): migrate Ingress from networking.k8s.io/v1beta1 to v1`
+
+**Reply posted:**
+> Migrated the Ingress to `networking.k8s.io/v1` and updated the backend spec to the v1 format (`service.name` / `service.port.number`). Also added `pathType: Prefix` which is required in v1.
+>
+> ✅ Fixed — thread resolved.
+
+---
+
+### 4. Reviewer flags wrong probe path
+
+**PR comment** (from `@bob`):
+> The liveness probe hits `/healthz` but the app exposes `/health`. It will always fail and restart the pod.
+
+**File:** `examples/triage/actionable-fix/broken-helm-probe-path.yaml`
+
+**Before:**
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+```
+
+**After (fix applied):**
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8080
+```
+
+**Commit message:** `fix(helm): correct liveness probe path from /healthz to /health`
+
+**Reply posted:**
+> Corrected the liveness probe path to `/health` to match the actual endpoint exposed by the application.
+>
+> ✅ Fixed — thread resolved.
+
+---
+
+### 5. Copilot flags a hardcoded secret
+
+**PR comment** (from `github-advanced-security[bot]`):
+> A hardcoded API key was detected on line 8 of `config.yaml`. Secrets must not be stored in source control.
+
+**File:** `examples/triage/actionable-fix/plaintext-secret-in-config.yaml`
+
+**Before:**
+```yaml
+app:
+  stripe_api_key: "sk_live_<YOUR_KEY>"   # hardcoded secret — never do this
+```
+
+**After (fix applied):**
+```yaml
+app:
+  stripe_api_key: "${STRIPE_API_KEY}"   # inject via External Secrets Operator or env var
+```
+
+**Commit message:** `fix(config): remove hardcoded Stripe API key, reference env var instead`
+
+**Reply posted:**
+> Replaced the hardcoded key with an environment variable reference. The actual secret must be stored in your secrets manager (AWS Secrets Manager / Vault) and injected at runtime via External Secrets Operator or a Kubernetes `secretKeyRef`. See [references/secrets.md](../../references/secrets.md) for the setup pattern.
+>
+> ✅ Fixed — thread resolved.
+
+---
+
+## Scenario: INFORMATIONAL
+
+### 6. "Why only 2 replicas?"
+
+**PR comment** (from `@carol`):
+> Why is `replicas: 2`? Is that enough for production traffic? Just want to understand the reasoning.
+
+**Classification:** INFORMATIONAL — asking for context, not pointing at a bug.
+
+**No fix applied.**
+
+**Reply posted:**
+> Two replicas gives us N+1 redundancy for the expected 200 RPS load (each pod handles ~200 RPS at 60% CPU). We have HPA configured to scale up to 10 when CPU exceeds 70%, so burst traffic is covered. The PodDisruptionBudget ensures at least 1 is always available during rolling deploys.
+>
+> ℹ️ Thread resolved — no code change needed.
+
+---
+
+### 7. "Consider adding a PDB"
+
+**PR comment** (from `@dave`):
+> This Deployment has no PodDisruptionBudget. Worth adding in a follow-up to protect against simultaneous node drains.
+
+**Classification:** INFORMATIONAL — valid suggestion but out of scope for this PR.
+
+**No fix applied.**
+
+**Reply posted:**
+> Agreed — a PDB is the right call for this service. Tracked as a follow-up in issue #89. This PR only changes the image tag; adding a PDB is a separate operational change that needs load testing to set the correct `minAvailable` value first.
+>
+> ℹ️ Thread resolved — no code change needed.
+
+---
+
+### 8. "Is KMS rotation enabled?"
+
+**PR comment** (from `@eve`):
+> Does this KMS key have automatic rotation enabled? Can't see it in the diff.
+
+**Classification:** INFORMATIONAL — question about existing infrastructure, not about this diff.
+
+**No fix applied.**
+
+**Reply posted:**
+> The KMS key is managed in the `terraform/shared/kms` module (not changed in this PR). You can confirm rotation is active with:
+> ```bash
+> aws kms get-key-rotation-status --key-id <key-id>
+> ```
+> The shared module has `enable_key_rotation = true` set. If you want to verify before merging, I can paste the current `terraform plan` output for that module.
+>
+> ℹ️ Thread resolved — no code change needed.
+
+---
+
+## Scenario: NOT_APPLICABLE
+
+### 9. CI status bot comment
+
+**PR comment** (from `github-actions[bot]`):
+> ✅ All checks passed: validate (2m 14s), security (1m 03s), terraform (3m 22s)
+
+**Classification:** NOT_APPLICABLE — automated status message, no action needed.
+
+**No fix applied.**
+
+**Reply posted:**
+> Automated CI status message — no action needed.
+>
+> ❌ Not applicable — thread resolved.
+
+---
+
+### 10. Already fixed in a later commit
+
+**PR comment** (from `@frank`):
+> The `latest` image tag on line 9 needs to be pinned.
+
+**Classification:** NOT_APPLICABLE — commit `a3f91b2` on this branch already pins the tag.
+
+**No fix applied.**
+
+**Reply posted:**
+> This was already addressed in commit `a3f91b2` — image tag is now pinned to `orders:1.4.2@sha256:...`.
+>
+> ❌ Not applicable — thread resolved.
+
+---
+
+### 11. Comment on a file not in this PR
+
+**PR comment** (from `@grace`):
+> The `terraform/rds.tf` backup retention should be 35 days not 7.
+
+**Classification:** NOT_APPLICABLE — `terraform/rds.tf` was not modified in this PR.
+
+**No fix applied.**
+
+**Reply posted:**
+> `terraform/rds.tf` is not changed in this PR — this comment belongs on the PR that last modified that file, or as a standalone issue. Opening a separate issue to track the retention change.
+>
+> ❌ Not applicable — thread resolved.
+
+---
+
+## --all Mode Output
+
+When you run `/platform-skills:triage --all 42`, triage processes every unresolved thread and prints a summary table:
+
+```
+| Comment      | Author      | Classification  | Action                                        |
+|---|---|---|---|
+| #123456789   | @alice      | ACTIONABLE_FIX  | Fixed: Deployment.yaml — resource limits added, committed a1b2c3d |
+| #123456790   | @bob        | ACTIONABLE_FIX  | Fixed: ingress.yaml — migrated to networking.k8s.io/v1, committed b2c3d4e |
+| #123456791   | @carol      | INFORMATIONAL   | Replied — replica count explained, thread resolved |
+| #123456792   | @dave       | INFORMATIONAL   | Replied — PDB tracked in issue #89, thread resolved |
+| #123456793   | actions[bot]| NOT_APPLICABLE  | Replied — CI status message, thread resolved |
+
+5 comments processed. 2 fixes committed. 5 threads resolved.
+```
+
+---
+
+## See Also
+
+- [commands/triage.md](../../commands/triage.md) — full skill definition with all gh CLI commands
+- [references/pr-review.md](../../references/pr-review.md) — PR review reference with rollback matrix and SOC 2 mapping
+- `/platform-skills:pr-review full <PR number>` — run a full pre-merge review before triaging comments

--- a/examples/triage/actionable-fix/broken-helm-probe-path.yaml
+++ b/examples/triage/actionable-fix/broken-helm-probe-path.yaml
@@ -1,0 +1,50 @@
+# Example: wrong liveness probe path — triggers ACTIONABLE_FIX
+#
+# Reviewer comment: "The liveness probe hits /healthz but the app only
+# exposes /health. This will always 404 and restart the pod in a loop."
+#
+# Expected triage fix: change /healthz → /health
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payments
+  namespace: checkout
+  labels:
+    app.kubernetes.io/name: payments
+    app.kubernetes.io/team: checkout
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: payments
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: payments
+    spec:
+      containers:
+        - name: payments
+          image: payments:2.0.1
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "1000m"
+              memory: "512Mi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz   # ❌ wrong — app exposes /health, triage corrects this
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3

--- a/examples/triage/actionable-fix/deprecated-k8s-api.yaml
+++ b/examples/triage/actionable-fix/deprecated-k8s-api.yaml
@@ -1,0 +1,44 @@
+# Example: deprecated Kubernetes API — triggers ACTIONABLE_FIX
+#
+# Bot comment (kubeconform / validate workflow):
+#   "networking.k8s.io/v1beta1 Ingress was removed in Kubernetes 1.22.
+#    This manifest will fail to apply on clusters running 1.22+."
+#
+# Expected triage fix: migrate to networking.k8s.io/v1 with updated backend spec.
+
+# ❌ Before — removed in Kubernetes 1.22
+# apiVersion: networking.k8s.io/v1beta1
+# kind: Ingress
+# metadata:
+#   name: orders-ingress
+# spec:
+#   rules:
+#     - host: orders.example.com
+#       http:
+#         paths:
+#           - path: /
+#             backend:
+#               serviceName: orders
+#               servicePort: 80
+
+# ✅ After — networking.k8s.io/v1 (Kubernetes 1.19+)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: orders-ingress
+  namespace: checkout
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: orders.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix   # required in v1 — was absent in v1beta1
+            backend:
+              service:
+                name: orders
+                port:
+                  number: 80

--- a/examples/triage/actionable-fix/missing-resource-limits.yaml
+++ b/examples/triage/actionable-fix/missing-resource-limits.yaml
@@ -1,0 +1,50 @@
+# Example: Deployment with no resource limits — triggers ACTIONABLE_FIX
+#
+# Reviewer comment: "No resource limits set — this pod can consume all node
+# memory and trigger OOM eviction of other workloads."
+#
+# Expected triage fix: add resources.requests and resources.limits.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: orders
+  namespace: checkout
+  labels:
+    app.kubernetes.io/name: orders
+    app.kubernetes.io/team: checkout
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: orders
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: orders
+    spec:
+      containers:
+        - name: orders
+          image: orders:1.2.3
+          ports:
+            - containerPort: 8080
+          # ❌ Missing resources block — triage adds it:
+          # resources:
+          #   requests:
+          #     cpu: "100m"
+          #     memory: "128Mi"
+          #   limits:
+          #     cpu: "500m"
+          #     memory: "256Mi"
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10

--- a/examples/triage/actionable-fix/plaintext-secret-in-config.yaml
+++ b/examples/triage/actionable-fix/plaintext-secret-in-config.yaml
@@ -1,0 +1,43 @@
+# Example: hardcoded secret in config — triggers ACTIONABLE_FIX
+#
+# Copilot / secret-scanning bot comment:
+#   "A hardcoded API key was detected on line 7 of this file.
+#    Secrets must not be stored in source control."
+#
+# Expected triage fix: replace literal value with env var reference
+# and add comment pointing to the secrets management pattern.
+
+# ❌ Before — literal secret value in source control (do not do this)
+# app:
+#   stripe_api_key: "sk_live_<YOUR_STRIPE_KEY_HERE>"
+#   database_password: "<YOUR_DB_PASSWORD_HERE>"
+
+# ✅ After — env var references injected at runtime via External Secrets Operator
+app:
+  # Injected at runtime from AWS Secrets Manager path: prod/payments/stripe
+  # See references/secrets.md for External Secrets Operator setup
+  stripe_api_key: "${STRIPE_API_KEY}"
+  database_password: "${DATABASE_PASSWORD}"
+
+# To wire these up with External Secrets Operator:
+#
+# apiVersion: external-secrets.io/v1beta1
+# kind: ExternalSecret
+# metadata:
+#   name: payments-secrets
+# spec:
+#   refreshInterval: 1h
+#   secretStoreRef:
+#     name: aws-secretsmanager
+#     kind: SecretStore
+#   target:
+#     name: payments-secrets
+#   data:
+#     - secretKey: STRIPE_API_KEY
+#       remoteRef:
+#         key: prod/payments/stripe
+#         property: api_key
+#     - secretKey: DATABASE_PASSWORD
+#       remoteRef:
+#         key: prod/payments/database
+#         property: password

--- a/examples/triage/actionable-fix/security-wildcard-iam.tf
+++ b/examples/triage/actionable-fix/security-wildcard-iam.tf
@@ -1,0 +1,45 @@
+# Example: wildcard IAM policy — triggers ACTIONABLE_FIX classification
+#
+# Copilot / security bot will flag:
+#   Action = ["s3:*"] and Resource = ["*"] as over-permissive (SOC 2 CC6.1)
+#
+# Expected triage fix: scope to explicit actions and target bucket ARN.
+
+variable "bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket this role needs access to"
+}
+
+# ❌ Before — wildcard action and resource (what the PR originally contained)
+resource "aws_iam_policy" "app_before" {
+  name = "app-s3-policy-before"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:*"]
+      Resource = ["*"]
+    }]
+  })
+}
+
+# ✅ After — scoped to explicit actions and bucket ARN (what triage commits)
+resource "aws_iam_policy" "app" {
+  name = "app-s3-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ]
+      Resource = [
+        "arn:aws:s3:::${var.bucket_name}",
+        "arn:aws:s3:::${var.bucket_name}/*"
+      ]
+    }]
+  })
+}

--- a/examples/triage/informational/ask-about-kms-rotation.md
+++ b/examples/triage/informational/ask-about-kms-rotation.md
@@ -1,0 +1,52 @@
+# Informational: "Is KMS rotation enabled?"
+
+## Comment
+
+**Author:** `@eve` (security reviewer)
+**PR:** Adds a new RDS instance that references an existing KMS key
+
+> Does this KMS key have automatic rotation enabled?
+> I can see the key ID in the diff but the rotation setting isn't visible here.
+
+---
+
+## Classification: INFORMATIONAL
+
+**Reason:** The KMS key is managed in a separate Terraform module not modified by this PR.
+The reviewer needs reassurance, not a code change.
+
+---
+
+## Fix: none
+
+---
+
+## Reply posted on thread
+
+> The KMS key is managed in `terraform/shared/kms/main.tf` (not changed in this PR).
+> It has `enable_key_rotation = true` set, which means AWS rotates the key material
+> annually automatically.
+>
+> You can verify the live state with:
+> ```bash
+> aws kms get-key-rotation-status \
+>   --key-id $(terraform output -raw kms_key_id) \
+>   --region eu-central-1
+> # Expected: {"KeyRotationEnabled": true}
+> ```
+>
+> If you'd like the Checkov evidence for the audit trail:
+> ```bash
+> checkov -d terraform/shared/kms --check CKV_AWS_7 --compact
+> ```
+>
+> ℹ️ Thread resolved — no code change needed.
+
+---
+
+## When a human would triage this manually
+
+1. Find the KMS key in the codebase — `grep -r "enable_key_rotation" terraform/`
+2. Confirm it's set to `true`
+3. Provide the AWS CLI command to verify live state
+4. Resolve — no code change needed in this PR

--- a/examples/triage/informational/question-why-two-replicas.md
+++ b/examples/triage/informational/question-why-two-replicas.md
@@ -1,0 +1,48 @@
+# Informational: "Why only 2 replicas?"
+
+## Comment
+
+**Author:** `@carol` (human reviewer)
+**PR:** Bumps orders-service image tag to `1.4.2`
+
+> Why is `replicas: 2`? Is that enough for production traffic?
+> Just want to understand the reasoning before approving.
+
+---
+
+## Classification: INFORMATIONAL
+
+**Reason:** The reviewer is asking for context about an intentional design decision.
+The replica count is correct for the current load profile. No code change is needed.
+
+---
+
+## Fix: none
+
+---
+
+## Reply posted on thread
+
+> Two replicas gives N+1 redundancy for the expected 200 RPS baseline load
+> (each pod handles ~200 RPS at 60% CPU with the current resource limits).
+>
+> The HPA is configured to scale up to 10 replicas when CPU exceeds 70%, so
+> burst traffic is covered automatically. The PodDisruptionBudget ensures at
+> least 1 replica is always available during rolling deploys and node drains.
+>
+> If you want to verify the HPA config:
+> ```bash
+> kubectl get hpa orders -n checkout
+> ```
+>
+> ℹ️ Thread resolved — no code change needed.
+
+---
+
+## When a human would triage this manually
+
+1. Read the comment — it ends with "just want to understand", not "this needs to be changed"
+2. Look at the Deployment: HPA exists, PDB exists, resource requests are set
+3. Classify as INFORMATIONAL
+4. Answer the question with evidence (HPA max, current RPS, PDB)
+5. Resolve the thread

--- a/examples/triage/informational/suggest-pdb-follow-up.md
+++ b/examples/triage/informational/suggest-pdb-follow-up.md
@@ -1,0 +1,45 @@
+# Informational: "Consider adding a PDB"
+
+## Comment
+
+**Author:** `@dave` (human reviewer)
+**PR:** Adds a new Deployment for the notifications service
+
+> This Deployment has no PodDisruptionBudget. During a node drain,
+> all replicas could be evicted simultaneously. Worth adding in a follow-up
+> to protect against that.
+
+---
+
+## Classification: INFORMATIONAL
+
+**Reason:** The suggestion is valid but explicitly marked as "follow-up" by the reviewer.
+Adding a PDB requires knowing the correct `minAvailable` value, which requires load testing
+this new service first. Out of scope for an initial rollout PR.
+
+---
+
+## Fix: none
+
+---
+
+## Reply posted on thread
+
+> Agreed — a PDB is the right call once we have a baseline for this service.
+>
+> Adding it now would require picking a `minAvailable` value blind, which risks
+> either breaking rolling deploys (too high) or providing no real protection (too low).
+> The plan is to run load tests in staging during the first week, then add the PDB
+> in a follow-up PR with measured values.
+>
+> Tracked in issue #112.
+>
+> ℹ️ Thread resolved — no code change needed.
+
+---
+
+## When a human would triage this manually
+
+1. Reviewer said "in a follow-up" — this is a suggestion, not a blocker
+2. No existing PDB to compare against for this new service
+3. Correct response: acknowledge, explain why not now, create a tracking issue, resolve

--- a/examples/triage/not-applicable/ci-status-bot.md
+++ b/examples/triage/not-applicable/ci-status-bot.md
@@ -1,0 +1,48 @@
+# Not Applicable: CI status bot comment
+
+## Comment
+
+**Author:** `github-actions[bot]`
+**PR:** Any PR
+
+> ✅ All checks passed
+>
+> | Check | Duration | Status |
+> |---|---|---|
+> | validate | 2m 14s | ✅ passed |
+> | security | 1m 03s | ✅ passed |
+> | terraform | 3m 22s | ✅ passed |
+
+---
+
+## Classification: NOT_APPLICABLE
+
+**Reason:** This is an automated CI status summary posted by the workflow itself.
+It reports passing checks — there is no finding, question, or request to address.
+
+---
+
+## Fix: none
+
+---
+
+## Reply posted on thread
+
+> Automated CI status message — no action needed.
+>
+> ❌ Not applicable — thread resolved.
+
+---
+
+## Other bot comments that are NOT_APPLICABLE
+
+These patterns are all noise and should be resolved immediately:
+
+| Bot | Comment pattern | Why not applicable |
+|---|---|---|
+| `github-actions[bot]` | "All checks passed" / "X checks failed" | Status message, not a finding |
+| `codecov[bot]` | "Coverage decreased by 2%" | Informational metric, not a PR blocker |
+| `dependabot[bot]` | "This PR was opened by Dependabot" | Dependabot description, not a comment |
+| `renovate[bot]` | "This PR contains the following updates:" | Renovate description header |
+| `snyk[bot]` | "No new vulnerabilities" | Clean scan result |
+| `netlify[bot]` | "Deploy preview ready at https://..." | Preview URL notification |

--- a/examples/triage/not-applicable/duplicate-thread.md
+++ b/examples/triage/not-applicable/duplicate-thread.md
@@ -1,0 +1,43 @@
+# Not Applicable: already fixed in a later commit
+
+## Comment
+
+**Author:** `@frank` (human reviewer)
+**PR:** Refactors the orders service Helm chart
+**Comment posted on:** commit `a1b2c3d` (first commit on the branch)
+
+> The `latest` image tag on line 9 needs to be pinned to a specific
+> digest or version tag before this can merge.
+
+---
+
+## Classification: NOT_APPLICABLE
+
+**Reason:** Commit `a3f91b2` (three commits later on the same branch) already pins the
+image tag to `orders:1.4.2@sha256:abc123...`. The issue is resolved in the current
+HEAD of the branch — the comment is stale.
+
+---
+
+## How triage detects this
+
+```bash
+# Check current HEAD of the file the comment refers to
+git show HEAD:path/to/deployment.yaml | grep image:
+# image: orders:1.4.2@sha256:abc123def456...   ← already pinned
+
+# The comment was made on an older commit — the fix is already present
+```
+
+---
+
+## Fix: none
+
+---
+
+## Reply posted on thread
+
+> This was already addressed in commit `a3f91b2` — the image is now pinned
+> to `orders:1.4.2@sha256:abc123def456...` which is an immutable reference.
+>
+> ❌ Not applicable — thread resolved.

--- a/examples/triage/not-applicable/out-of-scope-file.md
+++ b/examples/triage/not-applicable/out-of-scope-file.md
@@ -1,0 +1,58 @@
+# Not Applicable: comment on a file not changed in this PR
+
+## Comment
+
+**Author:** `@grace` (human reviewer)
+**PR:** Adds a new S3 bucket for audit logs
+
+> The RDS backup retention in `terraform/rds.tf` should be 35 days not 7
+> to meet SOC 2 A1.2. Can you fix that here too?
+
+---
+
+## Classification: NOT_APPLICABLE
+
+**Reason:** `terraform/rds.tf` is not in the diff for this PR. The comment is valid as
+a standalone finding but does not belong on this PR — it should be tracked as a
+separate issue or raised on the PR that last modified `terraform/rds.tf`.
+
+---
+
+## How triage detects this
+
+```bash
+# Check if the referenced file is in the PR diff
+gh pr diff <pr_number> -- terraform/rds.tf
+# (empty output — file not changed in this PR)
+```
+
+---
+
+## Fix: none
+
+---
+
+## Reply posted on thread
+
+> `terraform/rds.tf` is not modified in this PR so I can't fix it here without
+> introducing unrelated scope creep.
+>
+> Opening a dedicated issue to track the retention change:
+> ```bash
+> gh issue create \
+>   --title "fix(rds): increase backup_retention_period to 35 days (SOC 2 A1.2)" \
+>   --body "RDS instance in terraform/rds.tf has backup_retention_period=7. SOC 2 A1.2 requires 35 days. Raised from PR #XX review."
+> ```
+>
+> ❌ Not applicable — thread resolved.
+
+---
+
+## Note on scope creep
+
+Applying fixes to files outside the PR diff is risky:
+- It changes the blast radius of the PR unexpectedly
+- It may fail CI checks that only cover changed files
+- It makes rollback harder (one PR now owns multiple concerns)
+
+Triage never applies fixes to files not in the PR diff. It opens an issue instead.


### PR DESCRIPTION
## Summary

Adds `examples/triage/` — fully documented examples for every classification the `/platform-skills:triage` command produces.

## Structure

```
examples/triage/
├── README.md                                  ← quick start, all 11 scenarios with full before/after
├── actionable-fix/
│   ├── security-wildcard-iam.tf               ← Copilot flags s3:* + Resource:*
│   ├── missing-resource-limits.yaml           ← reviewer flags no resource limits
│   ├── deprecated-k8s-api.yaml                ← bot flags networking.k8s.io/v1beta1
│   ├── broken-helm-probe-path.yaml            ← reviewer flags /healthz vs /health
│   └── plaintext-secret-in-config.yaml        ← secret scanning flags hardcoded key (placeholder)
├── informational/
│   ├── question-why-two-replicas.md
│   ├── suggest-pdb-follow-up.md
│   └── ask-about-kms-rotation.md
└── not-applicable/
    ├── ci-status-bot.md
    ├── duplicate-thread.md
    └── out-of-scope-file.md
```