### PR TITLE
feat(keda): KEDA event-driven autoscaling skill — v1.14.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.13.0",
-      "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP server development, observability (Prometheus/OpenTelemetry/Grafana), code documentation (OpenAPI/docstrings), SOC 2 compliance for Terraform, Datadog, Dynatrace, conventional commit message generation, OPA/Conftest Rego policies, Kyverno admission policies (ValidatingPolicy/MutatingPolicy/GeneratingPolicy/ImageValidatingPolicy, CEL expressions, Audit→Deny promotion), comprehensive PR review (cost impact, environment drift, ownership governance, compliance, deprecated API upgrade, rollback feasibility), and PR comment triage. Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
+      "version": "1.14.0",
+      "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP server development, observability (Prometheus/OpenTelemetry/Grafana), code documentation (OpenAPI/docstrings), SOC 2 compliance for Terraform, Datadog, Dynatrace, conventional commit message generation, OPA/Conftest Rego policies, Kyverno admission policies (ValidatingPolicy/MutatingPolicy/GeneratingPolicy/ImageValidatingPolicy, CEL expressions, Audit→Deny promotion), comprehensive PR review (cost impact, environment drift, ownership governance, compliance, deprecated API upgrade, rollback feasibility), PR comment triage, and KEDA event-driven autoscaling (ScaledObject, ScaledJob, TriggerAuthentication, Prometheus/SQS/Kafka/Redis/Cron/HTTP/Azure scalers, scale-to-zero, IRSA). Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
       "author": {
         "name": "Nitin Jain"
       },
@@ -94,7 +94,20 @@
         "governance",
         "triage",
         "pr-comment-triage",
-        "review-thread"
+        "review-thread",
+        "keda",
+        "kubernetes-event-driven-autoscaling",
+        "scaledobject",
+        "scaledjob",
+        "triggerauthentication",
+        "scale-to-zero",
+        "event-driven",
+        "autoscaling",
+        "hpa",
+        "sqs-scaler",
+        "kafka-scaler",
+        "prometheus-scaler",
+        "cron-scaler"
       ],
       "source": {
         "source": "url",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "platform-skills",
-  "version": "1.13.0",
-  "description": "Practical guidance for platform engineers: Kubernetes, Kyverno admission policies, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP development, observability, code documentation, SOC 2 compliance, comprehensive PR review, and PR comment triage.",
+  "version": "1.14.0",
+  "description": "Practical guidance for platform engineers: Kubernetes, Kyverno admission policies, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP development, observability, code documentation, SOC 2 compliance, comprehensive PR review, PR comment triage, and KEDA event-driven autoscaling.",
   "author": {
     "name": "Nitin Jain",
     "email": "nitin.solna@gmail.com",
@@ -44,7 +44,13 @@
     "rollback",
     "upgrade-safety",
     "triage",
-    "pr-comment-triage"
+    "pr-comment-triage",
+    "keda",
+    "kubernetes-event-driven-autoscaling",
+    "scaledobject",
+    "scaledjob",
+    "autoscaling",
+    "scale-to-zero"
   ],
   "skills": [
     "./skills/platform-skills"
@@ -68,6 +74,7 @@
     "./commands/opa.md",
     "./commands/kyverno.md",
     "./commands/pr-review.md",
-    "./commands/triage.md"
+    "./commands/triage.md",
+    "./commands/keda.md"
   ]
 }

--- a/.cursor/rules/keda.mdc
+++ b/.cursor/rules/keda.mdc
@@ -1,0 +1,114 @@
+---
+description: KEDA ScaledObject and ScaledJob generation rules — auth patterns, scaling safety, best practices
+globs: ["**/scaledobject*.yaml", "**/scaledjob*.yaml", "**/keda*.yaml", "**/triggerauth*.yaml", "**/scaled-object*.yaml", "**/scaled-job*.yaml"]
+alwaysApply: false
+---
+
+# KEDA Rules
+
+Always generate ScaledObject and ScaledJob resources with all of the following. Missing any item is a Critical finding.
+
+## Required fields on every ScaledObject
+
+```yaml
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1           # Always explicit — don't rely on the default
+    kind: Deployment              # Or StatefulSet — be explicit
+    name: <exact-deployment-name>
+
+  minReplicaCount: 1              # Use 0 only when cold-start latency is acceptable and documented
+  maxReplicaCount: <N>            # Always set — never omit the ceiling
+
+  pollingInterval: 30             # 30s is a safe default; lower only for latency-sensitive queues
+  cooldownPeriod: 300             # 5-minute cooldown prevents thrashing
+
+  advanced:
+    restoreToOriginalReplicaCount: true   # Always set — restores replicas on ScaledObject deletion
+```
+
+## Required on every trigger
+
+```yaml
+triggers:
+  - type: <scaler>
+    metadata:
+      activationThreshold: "<N>"  # or activationQueueLength / activationLagThreshold
+      # Prevents activation on noise/sparse events
+    authenticationRef:
+      name: <trigger-auth-name>   # Always use TriggerAuthentication — never inline credentials
+```
+
+## TriggerAuthentication: prefer Pod Identity
+
+```yaml
+# ✅ Best practice — no static credentials
+spec:
+  podIdentity:
+    provider: aws                 # aws | azure | gcp | aws-eks
+
+# ⚠️ Only when Pod Identity is unavailable — rotate keys; scope the Secret tightly
+spec:
+  secretTargetRef:
+    - parameter: <param>
+      name: <secret-name>
+      key: <key>
+```
+
+## Scaler-specific minimum IAM permissions (least privilege)
+
+| Scaler | Minimum permission |
+|---|---|
+| `aws-sqs-queue` | `sqs:GetQueueAttributes`, `sqs:GetQueueUrl` — NOT `sqs:ReceiveMessage` |
+| `kafka` | consumer group describe + offset fetch — NOT produce |
+| `azure-servicebus` | `Listen` on the specific queue or subscription only |
+| `prometheus` | No auth for cluster-internal Prometheus |
+
+## Cron scaler rules
+
+```yaml
+# Cron windows must not overlap.
+# Always pair with a Prometheus/queue trigger as a safety net for unexpected spikes.
+# Use idleReplicaCount or minReplicaCount >= 1 to keep a warm pod during off-hours.
+# Always set timezone explicitly — never rely on UTC as an unstated assumption.
+- type: cron
+  metadata:
+    timezone: Europe/Berlin       # IANA timezone — always explicit
+    start: "0 8 * * 1-5"
+    end: "0 20 * * 1-5"
+    desiredReplicas: "10"
+```
+
+## ScaledJob required fields
+
+```yaml
+spec:
+  jobTargetRef:
+    template:
+      spec:
+        restartPolicy: Never      # Required — Jobs must not use OnFailure with KEDA
+        activeDeadlineSeconds: 3600  # Required — prevents zombie jobs
+        containers:
+          - resources:
+              requests: { cpu: "500m", memory: "512Mi" }
+              limits: { memory: "2Gi" }   # memory limit required; omit cpu limit
+```
+
+## Never generate
+
+- Static credentials inlined directly in `ScaledObject` metadata — always use `TriggerAuthentication`
+- `SQS` scaler with `sqs:ReceiveMessage` — KEDA only reads depth, it does not consume
+- A separate `HorizontalPodAutoscaler` targeting the same Deployment — KEDA manages its own HPA
+- `minReplicaCount: 0` without a comment explaining cold-start acceptance
+- Overlapping cron windows — they produce undefined behavior
+- `pollingInterval < 10` on SQS — each poll is a billable AWS API call
+- Kafka scaler without `lagThreshold` set — defaults are rarely appropriate
+
+## HPA conflict check
+
+Before generating a ScaledObject, note if an HPA already targets the same Deployment. If it does, include:
+
+```bash
+# Delete existing HPA before applying ScaledObject
+kubectl delete hpa <existing-hpa> -n <namespace>
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-05-16
+
+### Added
+
+#### KEDA — Kubernetes Event-Driven Autoscaling
+
+New Domain 23: `KEDA` — design, generate, debug, and review event-driven autoscaling with KEDA v2.14.
+
+- `references/keda.md` — comprehensive reference guide covering:
+  - KEDA vs HPA decision matrix (when to use each)
+  - Architecture (operator, metrics adapter, webhook)
+  - Helm installation with resource limits
+  - `ScaledObject` spec: minReplicaCount, maxReplicaCount, pollingInterval, cooldownPeriod, advanced HPA behavior overrides, scale-to-zero with cold-start guidance
+  - `ScaledJob` spec: batch processing per message with scaling strategies (accurate/default/custom)
+  - `TriggerAuthentication` and `ClusterTriggerAuthentication`: Kubernetes Secret reference, IRSA (AWS), Azure Workload Identity, GCP Workload Identity
+  - Scalers with full metadata reference: Prometheus, AWS SQS, Apache Kafka (SASL/TLS), Redis List, Cron, Azure Service Bus, HTTP Add-on
+  - Scaling lifecycle and tuning table (pollingInterval/cooldownPeriod by scenario)
+  - Security patterns: least-privilege IAM per scaler, namespace-scoped vs cluster-scoped auth, RBAC for ScaledObject management
+  - GitOps integration: Flux Kustomization with health checks, Argo CD ordering, ExternalSecret pairing
+  - Troubleshooting: 7 common failure patterns with diagnostic commands and exact fixes
+  - Observability: KEDA Prometheus metrics, Grafana dashboard import
+  - Version compatibility matrix and upgrade checklist
+- `/platform-skills:keda` (`commands/keda.md`) — four modes:
+  - `generate` — write a production-ready ScaledObject or ScaledJob from a description
+  - `debug` — diagnose scaling failures with a structured checklist
+  - `review` — correctness, security, and operational safety review
+  - `scale` — design the scaling strategy for a workload from requirements
+- `examples/keda/` — four working examples:
+  - `scaledobject-sqs.yaml` — SQS queue trigger with IRSA, scale-to-zero, HPA stabilization
+  - `scaledobject-prometheus.yaml` — HTTP request rate trigger with Cron floor for business hours
+  - `scaledobject-kafka.yaml` — Kafka consumer lag trigger with SASL/TLS auth
+  - `scaledjob-sqs.yaml` — batch ScaledJob (one Job per SQS message) with security hardening
+
 ## [1.13.0] - 2026-05-16
 
 ### Added

--- a/EDITOR_INTEGRATIONS.md
+++ b/EDITOR_INTEGRATIONS.md
@@ -226,7 +226,7 @@ gh copilot suggest "$(cat your-deployment.yaml) — review this for production r
 
 ## Skill commands in Copilot Chat
 
-Platform skills ships 18 command workflows. In Claude Code they are slash commands (`/platform-skills:review`). In Copilot Chat you phrase them as natural language — the instructions file makes Copilot apply the same structured output.
+Platform skills ships 19 command workflows. In Claude Code they are slash commands (`/platform-skills:review`). In Copilot Chat you phrase them as natural language — the instructions file makes Copilot apply the same structured output.
 
 ### review — production-readiness check on any file
 
@@ -373,6 +373,41 @@ Explain this Rego policy rule by rule in plain English. Map each input field to 
 
 ```
 My deny rule produces no output when I run conftest test. What are the common causes and how do I check each?
+```
+
+---
+
+### keda — event-driven autoscaling
+
+**Generate a ScaledObject:**
+```
+Generate a KEDA ScaledObject for the orders-processor Deployment. Trigger: AWS SQS queue at https://sqs.eu-central-1.amazonaws.com/123456789/orders. Scale to zero when empty, max 20 replicas. Use IRSA for authentication — no static credentials.
+```
+
+**Cron-based scheduled scaling:**
+```
+Generate a KEDA ScaledObject for the checkout-api Deployment that scales on a schedule: 10 replicas weekday 08:00–20:00 Europe/Berlin, 2 replicas outside those hours. Add a Prometheus safety-net trigger for unexpected traffic spikes. Apply all KEDA best practices.
+```
+
+**Multiple triggers (queue + schedule):**
+```
+Generate a KEDA ScaledObject with two triggers: SQS queue depth (scale at 5 messages/replica) and a Cron floor of 3 replicas during business hours (08:00–18:00 Mon-Fri, Europe/London). Explain the OR-max semantics.
+```
+
+**Debug why a ScaledObject isn't scaling:**
+```
+My KEDA ScaledObject shows Active: false and the Deployment stays at 0 replicas. The SQS queue has 50 messages. Give me the diagnostic commands in order and the most likely causes.
+```
+
+**Review for security and safety:**
+```
+Review this ScaledObject and TriggerAuthentication for security issues. Check: are static credentials used instead of IRSA? Is the IAM policy least-privilege? Is activationQueueLength set? Is there an HPA conflict?
+[paste YAML]
+```
+
+**ScaledJob for batch processing:**
+```
+Generate a KEDA ScaledJob that processes SQS messages as batch Kubernetes Jobs — one Job per message. Use IRSA, set activeDeadlineSeconds to prevent zombie jobs, and apply container security hardening.
 ```
 
 ---
@@ -533,6 +568,7 @@ Audit our developer experience using the SPACE framework. Engineers spend 45 min
 | `.cursor/rules/platform-skills.mdc` | Cursor always-on umbrella rule | Cursor 0.44+ |
 | `.cursor/rules/kubernetes.mdc` | Scoped to `*.yaml` / `*.yml` | Cursor 0.44+ |
 | `.cursor/rules/terraform.mdc` | Scoped to `*.tf` / `*.tfvars` | Cursor 0.44+ |
+| `.cursor/rules/keda.mdc` | Scoped to `scaledobject*.yaml`, `scaledjob*.yaml`, `keda*.yaml` | Cursor 0.44+ |
 
 ---
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -60,7 +60,7 @@ claude plugin install platform-skills
 
 ```bash
 claude plugin list
-# platform-skills  v1.13.0  enabled
+# platform-skills  v1.14.0  enabled
 ```
 
 **Upgrade:**

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Both layers work independently. The plugin is optional.
 | 📋 OPA / Conftest | [references/opa.md](references/opa.md) | Rego v1 syntax, rule types, unit tests, fmt/regal/verify validation pipeline, GitHub Actions integration |
 | 🔍 PR Review | [references/pr-review.md](references/pr-review.md) | Cost impact, environment drift, ownership gaps, SOC 2 compliance, deprecated API / version hygiene, rollback feasibility |
 | 🧵 PR Comment Triage | [commands/triage.md](commands/triage.md) | `/platform-skills:triage` classifies PR comments, applies valid fixes, replies, and resolves review threads |
-| ⚡ KEDA | [references/keda.md](references/keda.md) | ScaledObject, ScaledJob, TriggerAuthentication, Prometheus/SQS/Kafka/Redis/Cron/HTTP/Azure scalers, scale-to-zero, IRSA, GitOps integration, troubleshooting |
+| ⚡ KEDA | [references/keda.md](references/keda.md) | ScaledObject, ScaledJob, TriggerAuthentication, Prometheus/SQS/Kafka/Redis/Cron/HTTP/Azure scalers, scale-to-zero, IRSA, GitOps integration, troubleshooting — `/platform-skills:keda` |
 
 ## Core principles
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Both layers work independently. The plugin is optional.
 | 📋 OPA / Conftest | [references/opa.md](references/opa.md) | Rego v1 syntax, rule types, unit tests, fmt/regal/verify validation pipeline, GitHub Actions integration |
 | 🔍 PR Review | [references/pr-review.md](references/pr-review.md) | Cost impact, environment drift, ownership gaps, SOC 2 compliance, deprecated API / version hygiene, rollback feasibility |
 | 🧵 PR Comment Triage | [commands/triage.md](commands/triage.md) | `/platform-skills:triage` classifies PR comments, applies valid fixes, replies, and resolves review threads |
+| ⚡ KEDA | [references/keda.md](references/keda.md) | ScaledObject, ScaledJob, TriggerAuthentication, Prometheus/SQS/Kafka/Redis/Cron/HTTP/Azure scalers, scale-to-zero, IRSA, GitOps integration, troubleshooting |
 
 ## Core principles
 
@@ -153,7 +154,8 @@ platform-skills/
 │   ├── platform-mindset.md
 │   ├── compliance.md                   # SOC 2 controls in Terraform (v1.6.0)
 │   ├── helm.md                         # Helm chart patterns, lint pipeline, values design
-│   └── pr-review.md                    # PR review: cost, drift, ownership, compliance, upgrade, rollback (v1.12.0)
+│   ├── pr-review.md                    # PR review: cost, drift, ownership, compliance, upgrade, rollback (v1.12.0)
+│   └── keda.md                         # KEDA event-driven autoscaling (v1.14.0)
 │
 ├── examples/                           # Working examples and handbook snippets
 │   ├── flux/basic-monorepo/            # Complete Flux CD monorepo structure
@@ -167,6 +169,7 @@ platform-skills/
 │   ├── github-actions/                 # CI/CD, Flux sync, container build workflows
 │   ├── helm/web-service/               # Production Helm chart: Deployment, HPA, PDB, NetworkPolicy, schema
 │   ├── triage/                         # PR comment triage scenarios and fixtures (v1.13.0)
+│   ├── keda/                           # ScaledObject, ScaledJob, TriggerAuthentication examples (v1.14.0)
 │   └── compliance/                     # SOC 2 Terraform examples (v1.6.0)
 │       ├── checkov-config.yaml         # Checkov config grouped by SOC 2 criterion
 │       ├── iam/                        # CC6.1/CC6.2: IAM, IRSA, OIDC, SCPs
@@ -203,6 +206,7 @@ platform-skills/
 - [x] v1.11.0 — Kyverno: ValidatingPolicy/MutatingPolicy/GeneratingPolicy/ImageValidatingPolicy (policies.kyverno.io/v1), CEL expressions, Audit→Deny promotion, PolicyException, PolicyReport analysis, kyverno-cli testing, PSP and Gatekeeper migration
 - [x] v1.12.0 — PR Review: cost impact, environment drift, ownership and governance gaps, SOC 2 compliance, deprecated API / version hygiene, rollback feasibility scoring
 - [x] v1.13.0 — PR Comment Triage: classify bot or human review comments, apply valid fixes, reply, and resolve threads with `gh`
+- [x] v1.14.0 — KEDA: ScaledObject, ScaledJob, TriggerAuthentication, scalers (Prometheus/SQS/Kafka/Redis/Cron/HTTP/Azure Service Bus), scale-to-zero, IRSA, GitOps integration, troubleshooting
 
 **Planned**
 - [ ] GCP: landing zone, GKE, Workload Identity, and IAM patterns

--- a/README.md
+++ b/README.md
@@ -3,8 +3,12 @@
 > A practical handbook for developers and DevOps engineers working with Kubernetes, GitOps, Terraform, GitHub Actions, cloud infrastructure, and secrets management — with an optional Claude plugin layer for interactive guidance.
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Claude Code](https://img.shields.io/badge/Claude-Code%20Skill-purple)](https://claude.ai/code)
-[![GitHub Stars](https://img.shields.io/github/stars/nitinjain999/platform-skills?style=social)](https://github.com/nitinjain999/platform-skills/stargazers)
+[![Domains](https://img.shields.io/badge/Domains-25-4c8eda)](references/)
+[![Commands](https://img.shields.io/badge/Commands-20-e87c2b)](commands/)
+[![Examples](https://img.shields.io/badge/Examples-21-6f42c1)](examples/)
+[![Editors](https://img.shields.io/badge/Editors-VSCode%20%7C%20Cursor%20%7C%20Copilot-2ea44f)](EDITOR_INTEGRATIONS.md)
+[![GitHub Stars](https://img.shields.io/github/stars/nitinjain999/platform-skills?style=flat&label=Stars&color=0e1117)](https://github.com/nitinjain999/platform-skills/stargazers)
+[![Skill Check](https://img.shields.io/badge/SkillCheck-Validated-brightgreen)](tests/validate-skill.sh)
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platform-skills
-description: Hands-on guidance for platform and DevOps engineers working with Kubernetes, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, and compliance. Use when designing or troubleshooting Kubernetes workloads and RBAC, writing Terraform modules, configuring Flux or Argo CD, setting up CI/CD pipelines, managing cloud identity and IAM, handling secrets, diagnosing DNS or VPC connectivity, operating a service mesh, applying product thinking to developer experience, or implementing SOC 2 compliance controls in Terraform — at any scale, for any team size.
+description: Hands-on guidance for platform and DevOps engineers working with Kubernetes, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, compliance, and KEDA event-driven autoscaling. Use when designing or troubleshooting Kubernetes workloads and RBAC, writing Terraform modules, configuring Flux or Argo CD, setting up CI/CD pipelines, managing cloud identity and IAM, handling secrets, diagnosing DNS or VPC connectivity, operating a service mesh, applying product thinking to developer experience, implementing SOC 2 compliance controls in Terraform, or scaling workloads with KEDA scalers (SQS, Kafka, Prometheus, Cron, HTTP) — at any scale, for any team size.
 ---
 
 # Platform Skills
@@ -33,6 +33,7 @@ Match the task to the right layer:
 20. `Kyverno`: Write and maintain Kubernetes-native admission policies using the CEL-based types — ValidatingPolicy, MutatingPolicy, GeneratingPolicy, ImageValidatingPolicy (all `policies.kyverno.io/v1`). Covers matchConstraints, matchConditions, CEL validations/mutations, generator.Apply(), Audit→Deny promotion, PolicyException, and kyverno-cli testing.
 21. `PR Review`: Comprehensive pre-merge risk review across six dimensions — cost impact, environment drift, ownership and governance gaps, SOC 2 compliance, deprecated API / version hygiene, and rollback feasibility scoring.
 22. `PR Comment Triage`: Triage bot or human PR comments, classify them as ACTIONABLE_FIX / INFORMATIONAL / NOT_APPLICABLE, make the minimal fix when valid, reply on the thread, and resolve it through `gh`.
+23. `KEDA`: Design, generate, debug, and review KEDA ScaledObject and ScaledJob resources. Covers all major scalers (Prometheus, SQS, Kafka, Redis, Cron, HTTP Add-on, Azure Service Bus), TriggerAuthentication with IRSA/Workload Identity, scaling lifecycle tuning, scale-to-zero patterns, and GitOps integration.
 
 If a task spans multiple areas, decide which layer owns the source of truth and keep the other layers consumers of that state.
 
@@ -89,6 +90,7 @@ When asked to generate code, start from the thinnest useful slice that proves th
 - For OPA / Conftest — Rego v1 syntax, rule types, package namespacing, input shapes, unit tests, validation pipeline (fmt/regal/verify), GitHub Actions integration, and troubleshooting — read [references/opa.md](references/opa.md).
 - For Kyverno CEL-based admission policies — ValidatingPolicy, MutatingPolicy, GeneratingPolicy, ImageValidatingPolicy, matchConstraints, matchConditions, Audit→Deny promotion, PolicyException, kyverno-cli testing, and migration from legacy ClusterPolicy — read [references/kyverno.md](references/kyverno.md).
 - For comprehensive PR review — cost impact, environment drift, ownership gaps, SOC 2 compliance, deprecated APIs, version hygiene, rollback feasibility, and bot comment triage — read [references/pr-review.md](references/pr-review.md).
+- For KEDA event-driven autoscaling — ScaledObject, ScaledJob, TriggerAuthentication, IRSA, scalers (Prometheus, SQS, Kafka, Redis, Cron, HTTP Add-on, Azure Service Bus), scaling lifecycle, security patterns, and troubleshooting — read [references/keda.md](references/keda.md).
 
 Load only the files needed for the current request.
 
@@ -115,3 +117,4 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:kyverno` — generate, test, audit, debug, or migrate Kyverno CEL-based admission policies
 - `/platform-skills:pr-review` — comprehensive PR review: cost, drift, ownership, compliance, upgrade, rollback
 - `/platform-skills:triage` — triage a PR comment (bot or human): classify as ACTIONABLE_FIX / INFORMATIONAL / NOT_APPLICABLE, produce the exact fix if needed, and write the thread reply
+- `/platform-skills:keda` — design, generate, debug, or review KEDA ScaledObject/ScaledJob autoscaling

--- a/commands/keda.md
+++ b/commands/keda.md
@@ -1,0 +1,116 @@
+---
+name: keda
+description: Design, debug, and review KEDA ScaledObject/ScaledJob autoscaling. Covers all major scalers (Prometheus, SQS, Kafka, Redis, Cron, HTTP Add-on, Azure Service Bus), TriggerAuthentication, scaling lifecycle tuning, GitOps integration, and troubleshooting. Use when asked to "add KEDA autoscaling", "debug why my ScaledObject isn't scaling", "review my KEDA config", or "generate a ScaledObject for <trigger>".
+argument-hint: "[scale|debug|review|generate] [description or file path]"
+---
+
+Design, debug, and review KEDA (Kubernetes Event-Driven Autoscaling) ScaledObject and ScaledJob resources.
+
+## Mode: generate
+
+Write a production-ready ScaledObject or ScaledJob from a description.
+
+Steps:
+1. Identify: target workload kind (Deployment / StatefulSet / Job), trigger type, and whether scale-to-zero is acceptable
+2. Choose the right resource kind:
+   - Long-running service → `ScaledObject`
+   - Batch processing per message → `ScaledJob`
+3. Generate with:
+   - `apiVersion: keda.sh/v1alpha1`
+   - `scaleTargetRef.name` matching the exact Deployment/StatefulSet/Job name
+   - `minReplicaCount: 0` only if the service can tolerate cold-start latency; otherwise `minReplicaCount: 1`
+   - `pollingInterval` and `cooldownPeriod` sized to the workload pattern (see table in `references/keda.md`)
+   - Trigger-specific `metadata` with `activationThreshold`/`activationQueueLength` set to avoid flapping on sparse events
+   - `authenticationRef` pointing to a `TriggerAuthentication` — never inline credentials in the ScaledObject
+   - For AWS: prefer IRSA (`podIdentity.provider: aws`) over static key/secret pairs
+4. Generate the companion `TriggerAuthentication` or `ClusterTriggerAuthentication`
+5. Show validation command: `kubectl describe scaledobject <name> -n <ns>` and the expected `Active: true` condition
+
+Reference: `references/keda.md` → ScaledObject, ScaledJob, TriggerAuthentication
+
+## Mode: debug
+
+Diagnose why a ScaledObject or ScaledJob is not scaling as expected.
+
+Steps:
+1. Collect:
+   ```bash
+   kubectl get scaledobject -n <namespace>
+   kubectl describe scaledobject <name> -n <namespace>
+   kubectl get hpa -n <namespace>
+   kubectl describe hpa keda-hpa-<scaledobject-name> -n <namespace>
+   kubectl logs -n keda -l app.kubernetes.io/name=keda-operator --tail=100
+   kubectl logs -n keda -l app.kubernetes.io/name=keda-operator-metrics-apiserver --tail=100
+   ```
+2. Check the ScaledObject `Conditions` block:
+   - `Active: false` → scaler is not detecting events (check trigger config and auth)
+   - `Ready: false` → KEDA cannot reach the target deployment (check `scaleTargetRef.name`)
+   - `Fallback: true` → metric fetch is failing; KEDA is using fallback replicas
+3. Check HPA for `<unknown>` targets — indicates metrics adapter cannot reach the external source
+4. Work through this checklist in order:
+   - External source reachable from the KEDA namespace?
+   - TriggerAuthentication secret exists and has correct keys?
+   - `activationThreshold` too high for current event volume?
+   - `minReplicaCount` preventing scale-to-zero?
+   - Conflicting HPA on the same Deployment?
+   - `cooldownPeriod` not yet elapsed?
+5. State the most likely root cause with the exact field or resource to fix
+6. Show the corrected spec section and the command to verify it
+
+Reference: `references/keda.md` → Troubleshooting
+
+## Mode: review
+
+Review an existing ScaledObject or ScaledJob for correctness, security, and operational safety.
+
+Review in this priority order:
+
+**Correctness**
+- Does `scaleTargetRef.name` match an existing Deployment/StatefulSet?
+- Are `minReplicaCount` and `maxReplicaCount` consistent with the workload SLA?
+- Is `pollingInterval` appropriate for the trigger type (SQS charges per API call)?
+- Does the trigger `metadata` use the right field names for this scaler version?
+
+**Security**
+- Are credentials stored in TriggerAuthentication, not inlined in ScaledObject?
+- Is IRSA / Workload Identity used instead of static access keys?
+- Is TriggerAuthentication namespace-scoped unless cluster-wide sharing is justified?
+- Does the IAM policy grant only the minimum permissions needed (read queue depth, not consume)?
+
+**Operational safety**
+- Is `minReplicaCount: 0` justified? What is the cold-start latency?
+- Is `cooldownPeriod` long enough to prevent thrashing?
+- Is `advanced.restoreToOriginalReplicaCount: true` set if the ScaledObject may be deleted?
+- Are `activationThreshold`/`activationQueueLength` set to prevent premature activation on sparse events?
+- Is HPA `scaleDown.stabilizationWindowSeconds` configured for latency-sensitive services?
+
+**GitOps safety**
+- Does the Flux/Argo Kustomization depend on KEDA CRDs being installed first?
+- Is the TriggerAuthentication Secret rendered by External Secrets Operator (not committed to Git)?
+
+Separate findings into:
+- **Critical** — must fix before deploying (missing auth, wrong target, wildcard IAM permissions)
+- **Improvement** — should fix (tune cooldownPeriod, add activationThreshold)
+- **Note** — informational (consider IRSA, document cold-start expectations)
+
+Reference: `references/keda.md` → Security Patterns, Scaling Lifecycle
+
+## Mode: scale
+
+Design the scaling strategy for a workload from requirements.
+
+Steps:
+1. Ask for (or infer from context):
+   - Workload type: background job or synchronous service?
+   - Event source: queue service, stream, metrics, time-based, HTTP?
+   - Expected event volume range (min/max per minute)
+   - Acceptable cold-start latency (drives min replicas decision)
+   - Cloud provider (for auth pattern: IRSA vs Workload Identity vs static)
+2. Apply the KEDA vs HPA decision matrix from `references/keda.md`
+3. Recommend the trigger type(s) and explain why
+4. Size `pollingInterval`, `cooldownPeriod`, and `minReplicaCount` based on the workload pattern
+5. Recommend the authentication pattern (IRSA preferred on AWS, no static credentials)
+6. If multiple triggers are needed (e.g., queue depth + cron business hours), explain the OR-max semantics
+7. Output the complete ScaledObject, TriggerAuthentication, and IAM policy skeleton
+
+Reference: `references/keda.md` → KEDA vs HPA decision matrix, Scalers

--- a/examples/keda/README.md
+++ b/examples/keda/README.md
@@ -1,5 +1,7 @@
 # KEDA Examples
 
+Status: Stable
+
 Working examples for KEDA (Kubernetes Event-Driven Autoscaling) ScaledObject and ScaledJob configurations.
 
 ## Files

--- a/examples/keda/README.md
+++ b/examples/keda/README.md
@@ -1,0 +1,34 @@
+# KEDA Examples
+
+Working examples for KEDA (Kubernetes Event-Driven Autoscaling) ScaledObject and ScaledJob configurations.
+
+## Files
+
+| File | Trigger | Use case |
+|---|---|---|
+| [scaledobject-sqs.yaml](scaledobject-sqs.yaml) | AWS SQS + IRSA | Scale a Deployment based on SQS queue depth |
+| [scaledobject-prometheus.yaml](scaledobject-prometheus.yaml) | Prometheus + Cron | Scale on HTTP request rate with business-hours floor |
+| [scaledobject-kafka.yaml](scaledobject-kafka.yaml) | Kafka SASL/TLS | Scale on consumer group lag |
+| [scaledjob-sqs.yaml](scaledjob-sqs.yaml) | AWS SQS + IRSA | Create one Job per SQS message (batch processing) |
+
+## Quick start
+
+```bash
+# Install KEDA
+helm repo add kedacore https://kedacore.github.io/charts
+helm upgrade --install keda kedacore/keda \
+  --namespace keda --create-namespace --version 2.14.0
+
+# Apply a ScaledObject
+kubectl apply -f scaledobject-sqs.yaml
+
+# Check status
+kubectl get scaledobject -n orders
+kubectl describe scaledobject orders-processor -n orders
+```
+
+## Auth patterns
+
+All examples use either IRSA (AWS) or a TriggerAuthentication referencing a Kubernetes Secret. Never commit static credentials to Git — use External Secrets Operator to render the Secret at runtime.
+
+See [references/keda.md](../../references/keda.md) for the full reference guide.

--- a/examples/keda/README.md
+++ b/examples/keda/README.md
@@ -9,6 +9,7 @@ Working examples for KEDA (Kubernetes Event-Driven Autoscaling) ScaledObject and
 | [scaledobject-sqs.yaml](scaledobject-sqs.yaml) | AWS SQS + IRSA | Scale a Deployment based on SQS queue depth |
 | [scaledobject-prometheus.yaml](scaledobject-prometheus.yaml) | Prometheus + Cron | Scale on HTTP request rate with business-hours floor |
 | [scaledobject-kafka.yaml](scaledobject-kafka.yaml) | Kafka SASL/TLS | Scale on consumer group lag |
+| [scaledobject-cron.yaml](scaledobject-cron.yaml) | Cron + Prometheus safety net | Scheduled scaling with weekday/weekend windows + spike protection |
 | [scaledjob-sqs.yaml](scaledjob-sqs.yaml) | AWS SQS + IRSA | Create one Job per SQS message (batch processing) |
 
 ## Quick start

--- a/examples/keda/keda-validate.sh
+++ b/examples/keda/keda-validate.sh
@@ -18,6 +18,7 @@ MANIFESTS=(
   scaledobject-sqs.yaml
   scaledobject-prometheus.yaml
   scaledobject-kafka.yaml
+  scaledobject-cron.yaml
   scaledjob-sqs.yaml
 )
 
@@ -136,6 +137,35 @@ if [ -f "$KAFKA_FILE" ]; then
     pass "scaledobject-kafka.yaml uses authenticationRef for SASL/TLS credentials"
   else
     fail "scaledobject-kafka.yaml missing authenticationRef"
+  fi
+fi
+
+# Cron: verify timezone, multiple windows, safety-net trigger, and restoreToOriginalReplicaCount
+CRON_FILE="$SCRIPT_DIR/scaledobject-cron.yaml"
+if [ -f "$CRON_FILE" ]; then
+  if grep -q "timezone:" "$CRON_FILE"; then
+    pass "scaledobject-cron.yaml has explicit timezone"
+  else
+    fail "scaledobject-cron.yaml missing explicit timezone (UTC assumption is a bug)"
+  fi
+
+  CRON_WINDOW_COUNT=$(grep -c "type: cron" "$CRON_FILE" || true)
+  if [ "$CRON_WINDOW_COUNT" -ge 2 ]; then
+    pass "scaledobject-cron.yaml has multiple cron windows ($CRON_WINDOW_COUNT)"
+  else
+    fail "scaledobject-cron.yaml should define multiple non-overlapping time windows"
+  fi
+
+  if grep -qE "type: prometheus|type: aws-sqs|type: kafka|type: redis" "$CRON_FILE"; then
+    pass "scaledobject-cron.yaml has safety-net trigger alongside Cron"
+  else
+    fail "scaledobject-cron.yaml missing safety-net trigger — unexpected spikes will not scale up"
+  fi
+
+  if grep -q "restoreToOriginalReplicaCount" "$CRON_FILE"; then
+    pass "scaledobject-cron.yaml has restoreToOriginalReplicaCount"
+  else
+    fail "scaledobject-cron.yaml missing restoreToOriginalReplicaCount"
   fi
 fi
 

--- a/examples/keda/keda-validate.sh
+++ b/examples/keda/keda-validate.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Validates KEDA example manifests for structural correctness.
+# Runs kubectl apply --dry-run=client when a cluster is available,
+# falls back to field-level grep checks when it is not.
+#
+# Usage: bash examples/keda/keda-validate.sh
+# Requires: kubectl (for cluster validation, with KEDA CRDs installed)
+
+set -euo pipefail
+
+ERRORS=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; ERRORS=$((ERRORS + 1)); }
+
+MANIFESTS=(
+  scaledobject-sqs.yaml
+  scaledobject-prometheus.yaml
+  scaledobject-kafka.yaml
+  scaledjob-sqs.yaml
+)
+
+# Offline field checks — run when no cluster is available
+_check_yaml_fields() {
+  local name="$1"
+  local file="$2"
+
+  if grep -q "keda.sh/v1alpha1" "$file"; then
+    pass "$name — has keda.sh/v1alpha1 apiVersion"
+  else
+    fail "$name — missing keda.sh/v1alpha1 apiVersion"
+  fi
+
+  if grep -qE "^kind: (ScaledObject|ScaledJob|TriggerAuthentication|ClusterTriggerAuthentication)$" "$file"; then
+    pass "$name — has valid KEDA kind"
+  else
+    fail "$name — missing valid KEDA kind"
+  fi
+
+  if grep -qE "^kind: (ScaledObject|ScaledJob)$" "$file"; then
+    if grep -q "triggers:" "$file"; then
+      pass "$name — has triggers block"
+    else
+      fail "$name — ScaledObject/ScaledJob missing triggers block"
+    fi
+  fi
+
+  # Flag inline passwords longer than 20 chars (looks like a real credential)
+  if grep -qE "^\s+password:\s+[A-Za-z0-9+/]{20,}" "$file"; then
+    fail "$name — possible plaintext credential (use TriggerAuthentication)"
+  else
+    pass "$name — no plaintext credentials detected"
+  fi
+}
+
+echo ""
+echo "=== KEDA example manifest validation ==="
+
+# Use kubectl dry-run if a cluster with KEDA CRDs is available
+USE_KUBECTL=false
+if kubectl cluster-info >/dev/null 2>&1; then
+  if kubectl get crd scaledobjects.keda.sh >/dev/null 2>&1; then
+    echo "  Mode: kubectl apply --dry-run=client (cluster + KEDA CRDs available)"
+    USE_KUBECTL=true
+  else
+    echo "  Mode: offline field checks (cluster available but KEDA CRDs not installed)"
+    echo "        To enable full validation: helm install keda kedacore/keda -n keda --create-namespace"
+  fi
+else
+  echo "  Mode: offline field checks (no cluster)"
+fi
+
+echo ""
+
+for manifest in "${MANIFESTS[@]}"; do
+  filepath="$SCRIPT_DIR/$manifest"
+
+  if [ ! -f "$filepath" ]; then
+    fail "$manifest — file not found"
+    continue
+  fi
+
+  if [ "$USE_KUBECTL" = "true" ]; then
+    if kubectl apply --dry-run=client -f "$filepath" >/dev/null 2>&1; then
+      pass "$manifest — kubectl dry-run passed"
+    else
+      fail "$manifest — kubectl dry-run failed"
+      kubectl apply --dry-run=client -f "$filepath" 2>&1 | sed 's/^/    /'
+    fi
+  else
+    _check_yaml_fields "$manifest" "$filepath"
+  fi
+done
+
+echo ""
+echo "=== KEDA example content checks ==="
+echo ""
+
+# SQS: verify IRSA pattern (no static keys)
+SQS_FILE="$SCRIPT_DIR/scaledobject-sqs.yaml"
+if [ -f "$SQS_FILE" ]; then
+  if grep -q "provider: aws" "$SQS_FILE"; then
+    pass "scaledobject-sqs.yaml uses IRSA (podIdentity.provider: aws)"
+  else
+    fail "scaledobject-sqs.yaml should use IRSA not static credentials"
+  fi
+
+  if grep -q "activationQueueLength" "$SQS_FILE"; then
+    pass "scaledobject-sqs.yaml has activationQueueLength (prevents flapping on empty queue)"
+  else
+    fail "scaledobject-sqs.yaml missing activationQueueLength"
+  fi
+fi
+
+# Prometheus: verify activationThreshold and Cron floor
+PROM_FILE="$SCRIPT_DIR/scaledobject-prometheus.yaml"
+if [ -f "$PROM_FILE" ]; then
+  if grep -q "activationThreshold" "$PROM_FILE"; then
+    pass "scaledobject-prometheus.yaml has activationThreshold"
+  else
+    fail "scaledobject-prometheus.yaml missing activationThreshold"
+  fi
+
+  if grep -q "type: cron" "$PROM_FILE"; then
+    pass "scaledobject-prometheus.yaml has Cron trigger for business-hours replica floor"
+  else
+    fail "scaledobject-prometheus.yaml missing Cron trigger"
+  fi
+fi
+
+# Kafka: verify authenticationRef present
+KAFKA_FILE="$SCRIPT_DIR/scaledobject-kafka.yaml"
+if [ -f "$KAFKA_FILE" ]; then
+  if grep -q "authenticationRef" "$KAFKA_FILE"; then
+    pass "scaledobject-kafka.yaml uses authenticationRef for SASL/TLS credentials"
+  else
+    fail "scaledobject-kafka.yaml missing authenticationRef"
+  fi
+fi
+
+# ScaledJob: verify required Job fields
+JOB_FILE="$SCRIPT_DIR/scaledjob-sqs.yaml"
+if [ -f "$JOB_FILE" ]; then
+  if grep -q "restartPolicy: Never" "$JOB_FILE"; then
+    pass "scaledjob-sqs.yaml has restartPolicy: Never (required for Kubernetes Jobs)"
+  else
+    fail "scaledjob-sqs.yaml missing restartPolicy: Never"
+  fi
+
+  if grep -q "activeDeadlineSeconds" "$JOB_FILE"; then
+    pass "scaledjob-sqs.yaml has activeDeadlineSeconds (prevents zombie jobs)"
+  else
+    fail "scaledjob-sqs.yaml missing activeDeadlineSeconds"
+  fi
+fi
+
+echo ""
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "FAIL: $ERRORS validation error(s)"
+  exit 1
+fi
+
+echo "PASS: all KEDA example checks passed"

--- a/examples/keda/scaledjob-sqs.yaml
+++ b/examples/keda/scaledjob-sqs.yaml
@@ -1,0 +1,79 @@
+---
+# ScaledJob: AWS SQS trigger for batch processing
+#
+# Creates one Job per SQS message (or group of messages).
+# Use for batch workloads where each message requires a dedicated pod.
+# Unlike ScaledObject, ScaledJob does not use HPA — KEDA manages Jobs directly.
+
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-sqs-auth
+  namespace: reports
+spec:
+  podIdentity:
+    provider: aws                   # IRSA — no static credentials
+
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: report-generator
+  namespace: reports
+spec:
+  jobTargetRef:
+    parallelism: 1
+    completions: 1
+    backoffLimit: 2                 # Retry failed job pods twice
+    activeDeadlineSeconds: 3600     # Kill jobs that run > 1 hour (prevent zombie jobs)
+    template:
+      metadata:
+        labels:
+          app: report-generator
+      spec:
+        serviceAccountName: report-generator
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          fsGroup: 1000
+        containers:
+          - name: report-generator
+            image: myregistry.io/report-generator:1.2.0
+            env:
+              - name: SQS_QUEUE_URL
+                value: https://sqs.eu-central-1.amazonaws.com/123456789012/reports
+              - name: AWS_REGION
+                value: eu-central-1
+            resources:
+              requests:
+                cpu: 500m
+                memory: 512Mi
+              limits:
+                cpu: 2
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+        restartPolicy: Never
+
+  minReplicaCount: 0
+  maxReplicaCount: 10               # Max concurrent report jobs at any time
+  pollingInterval: 30
+  successfulJobsHistoryLimit: 3     # Keep 3 completed job objects for debugging
+  failedJobsHistoryLimit: 5
+
+  scalingStrategy:
+    strategy: accurate              # Re-query queue on every poll for precise job count
+    customScalingQueueLengthDeduction: 0
+    customScalingRunningJobPercentage: "1.0"
+
+  triggers:
+    - type: aws-sqs-queue
+      metadata:
+        queueURL: https://sqs.eu-central-1.amazonaws.com/123456789012/reports
+        queueLength: "1"            # 1 message = 1 job
+        awsRegion: eu-central-1
+        scaleOnInFlight: "false"    # Don't count in-flight — each job processes exactly one message
+        activationQueueLength: "1"
+      authenticationRef:
+        name: keda-sqs-auth

--- a/examples/keda/scaledjob-sqs.yaml
+++ b/examples/keda/scaledjob-sqs.yaml
@@ -49,8 +49,7 @@ spec:
                 cpu: 500m
                 memory: 512Mi
               limits:
-                cpu: 2
-                memory: 2Gi
+                memory: 2Gi             # Omit cpu limit — it causes throttling
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/examples/keda/scaledobject-cron.yaml
+++ b/examples/keda/scaledobject-cron.yaml
@@ -1,0 +1,128 @@
+---
+# ScaledObject: Cron-based scheduled scaling
+#
+# Use case: predictable, time-based workloads where replica count should
+# follow a schedule (business hours, batch windows, maintenance periods).
+#
+# Cron scaler does NOT use HPA internally — it drives replicas directly
+# by setting the ScaledObject's desiredReplicas at the scheduled time.
+#
+# Best practices applied:
+# - Multiple non-overlapping windows for fine-grained schedule control
+# - idleReplicaCount: 1 keeps one warm replica outside schedule windows
+#   (avoids cold-start latency on first request after off-hours)
+# - cooldownPeriod ignored for cron trigger — replica count is set directly
+# - restoreToOriginalReplicaCount: true ensures a clean state on deletion
+# - Combined with Prometheus trigger so unexpected traffic spikes still scale up
+
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: checkout-api
+  namespace: checkout
+  annotations:
+    # Document the schedule so the next engineer understands the intent
+    scaledobject.keda.sh/schedule: "weekday 08:00-10:00 Berlin=10r, 10:00-20:00=20r, 20:00-08:00=2r; weekend=2r"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: checkout-api
+
+  minReplicaCount: 1              # Never go below 1 — keep one warm replica
+  maxReplicaCount: 30             # Hard ceiling; prevents runaway scaling
+
+  pollingInterval: 30             # How often KEDA evaluates non-cron triggers
+  cooldownPeriod: 300             # 5-minute cooldown for non-cron triggers
+
+  advanced:
+    restoreToOriginalReplicaCount: true   # On ScaledObject deletion, restore previous replica count
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300   # Don't shed replicas too aggressively
+          policies:
+            - type: Percent
+              value: 25
+              periodSeconds: 60
+
+  triggers:
+    # --- Cron triggers ---
+    # KEDA picks the trigger with the highest desiredReplicas (OR-max semantics).
+    # Windows must not overlap within a single trigger type — use separate entries.
+
+    # Weekday morning ramp-up: 08:00–10:00 (Europe/Berlin)
+    - type: cron
+      metadata:
+        timezone: Europe/Berlin
+        start: "0 8 * * 1-5"     # Cron syntax: minute hour dom month dow
+        end: "0 10 * * 1-5"
+        desiredReplicas: "10"
+
+    # Weekday peak hours: 10:00–20:00 (Europe/Berlin)
+    - type: cron
+      metadata:
+        timezone: Europe/Berlin
+        start: "0 10 * * 1-5"
+        end: "0 20 * * 1-5"
+        desiredReplicas: "20"
+
+    # Weekday evening wind-down: 20:00–midnight (Europe/Berlin)
+    - type: cron
+      metadata:
+        timezone: Europe/Berlin
+        start: "0 20 * * 1-5"
+        end: "59 23 * * 1-5"
+        desiredReplicas: "2"
+
+    # Weekend low: all day Saturday and Sunday
+    - type: cron
+      metadata:
+        timezone: Europe/Berlin
+        start: "0 0 * * 6"       # Saturday midnight
+        end: "59 23 * * 0"       # Sunday 23:59
+        desiredReplicas: "2"
+
+    # --- Prometheus trigger (safety net) ---
+    # If traffic spikes outside scheduled windows or exceeds cron desiredReplicas,
+    # the Prometheus trigger takes over and scales beyond the cron floor.
+    # KEDA uses whichever trigger demands the most replicas.
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus-operated.monitoring.svc.cluster.local:9090
+        metricName: checkout_request_rate
+        query: sum(rate(http_requests_total{namespace="checkout",service="checkout-api"}[2m]))
+        threshold: "50"           # Replicas = ceil(rate / 50) — scale at 50 req/s per pod
+        activationThreshold: "5"  # Don't activate unless > 5 req/s
+
+---
+# PodDisruptionBudget: protect availability during node drains and rolling updates
+# Without this, Kubernetes may evict all pods simultaneously during scale-down.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: checkout-api
+  namespace: checkout
+spec:
+  minAvailable: 2               # Always keep at least 2 pods running
+  selector:
+    matchLabels:
+      app: checkout-api
+
+---
+# KEDA scales the Deployment but does not control the Deployment's own HPA.
+# Do NOT create a separate HPA targeting checkout-api — KEDA manages that internally.
+#
+# Validation commands:
+#
+#   kubectl get scaledobject checkout-api -n checkout
+#   # Expected: READY=True, ACTIVE=True
+#
+#   kubectl get hpa -n checkout
+#   # KEDA creates: keda-hpa-checkout-api
+#
+#   # Watch replicas change at scheduled boundaries:
+#   watch -n5 kubectl get deployment checkout-api -n checkout
+#
+#   # Check which trigger is currently driving replicas:
+#   kubectl describe scaledobject checkout-api -n checkout | grep -A5 "Trigger Authentications"

--- a/examples/keda/scaledobject-kafka.yaml
+++ b/examples/keda/scaledobject-kafka.yaml
@@ -3,20 +3,43 @@
 #
 # Scales the event-processor Deployment based on consumer group lag.
 # Scale-to-zero when lag is 0; scale up when messages accumulate.
+#
+# Secret management: do NOT commit Kafka credentials to Git.
+# Use External Secrets Operator to render the Secret from your vault:
+#
+#   apiVersion: external-secrets.io/v1beta1
+#   kind: ExternalSecret
+#   metadata:
+#     name: kafka-credentials
+#     namespace: events
+#   spec:
+#     refreshInterval: 1h
+#     secretStoreRef:
+#       name: vault-backend          # or aws-secretsmanager, etc.
+#       kind: ClusterSecretStore
+#     target:
+#       name: kafka-credentials      # name of the Kubernetes Secret to create
+#     data:
+#       - secretKey: sasl
+#         remoteRef:
+#           key: platform/kafka/keda-consumer
+#           property: sasl
+#       - secretKey: username
+#         remoteRef:
+#           key: platform/kafka/keda-consumer
+#           property: username
+#       - secretKey: password
+#         remoteRef:
+#           key: platform/kafka/keda-consumer
+#           property: password
+#       - secretKey: tls
+#         remoteRef:
+#           key: platform/kafka/keda-consumer
+#           property: tls
+#
+# The Secret 'kafka-credentials' is created at runtime by ESO — never commit it.
+# See references/keda.md → "Storing TriggerAuthentication in Git safely".
 
-apiVersion: v1
-kind: Secret
-metadata:
-  name: kafka-credentials
-  namespace: events
-type: Opaque
-stringData:
-  sasl: scram_sha512                # plaintext | scram_sha256 | scram_sha512
-  username: keda-consumer
-  password: <YOUR_KAFKA_PASSWORD>   # Replace with secret from your vault
-  tls: enable
-
----
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
@@ -25,7 +48,7 @@ metadata:
 spec:
   secretTargetRef:
     - parameter: sasl
-      name: kafka-credentials
+      name: kafka-credentials        # Rendered by ExternalSecret at runtime
       key: sasl
     - parameter: username
       name: kafka-credentials
@@ -45,6 +68,8 @@ metadata:
   namespace: events
 spec:
   scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
     name: event-processor
 
   minReplicaCount: 0
@@ -52,15 +77,18 @@ spec:
   pollingInterval: 15
   cooldownPeriod: 60
 
+  advanced:
+    restoreToOriginalReplicaCount: true
+
   triggers:
     - type: kafka
       metadata:
         bootstrapServers: kafka.kafka.svc.cluster.local:9093
         consumerGroup: event-processor-group
         topic: platform-events
-        lagThreshold: "20"          # Target: 20 messages of lag per replica
-        activationLagThreshold: "5" # Don't activate unless lag > 5
-        offsetResetPolicy: latest   # latest | earliest
+        lagThreshold: "20"            # Target: 20 messages of lag per replica
+        activationLagThreshold: "5"   # Don't activate unless lag > 5
+        offsetResetPolicy: latest     # latest | earliest
         saslType: scram_sha512
         tls: enable
       authenticationRef:

--- a/examples/keda/scaledobject-kafka.yaml
+++ b/examples/keda/scaledobject-kafka.yaml
@@ -1,0 +1,67 @@
+---
+# ScaledObject: Apache Kafka trigger with SASL/TLS authentication
+#
+# Scales the event-processor Deployment based on consumer group lag.
+# Scale-to-zero when lag is 0; scale up when messages accumulate.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kafka-credentials
+  namespace: events
+type: Opaque
+stringData:
+  sasl: scram_sha512                # plaintext | scram_sha256 | scram_sha512
+  username: keda-consumer
+  password: <YOUR_KAFKA_PASSWORD>   # Replace with secret from your vault
+  tls: enable
+
+---
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-kafka-auth
+  namespace: events
+spec:
+  secretTargetRef:
+    - parameter: sasl
+      name: kafka-credentials
+      key: sasl
+    - parameter: username
+      name: kafka-credentials
+      key: username
+    - parameter: password
+      name: kafka-credentials
+      key: password
+    - parameter: tls
+      name: kafka-credentials
+      key: tls
+
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: event-processor
+  namespace: events
+spec:
+  scaleTargetRef:
+    name: event-processor
+
+  minReplicaCount: 0
+  maxReplicaCount: 10
+  pollingInterval: 15
+  cooldownPeriod: 60
+
+  triggers:
+    - type: kafka
+      metadata:
+        bootstrapServers: kafka.kafka.svc.cluster.local:9093
+        consumerGroup: event-processor-group
+        topic: platform-events
+        lagThreshold: "20"          # Target: 20 messages of lag per replica
+        activationLagThreshold: "5" # Don't activate unless lag > 5
+        offsetResetPolicy: latest   # latest | earliest
+        saslType: scram_sha512
+        tls: enable
+      authenticationRef:
+        name: keda-kafka-auth

--- a/examples/keda/scaledobject-prometheus.yaml
+++ b/examples/keda/scaledobject-prometheus.yaml
@@ -1,0 +1,51 @@
+---
+# ScaledObject: Prometheus trigger
+#
+# Scales the api-gateway Deployment based on HTTP request rate.
+# No external auth needed — Prometheus is cluster-internal.
+# Keeps minimum 2 replicas during business hours via Cron trigger.
+
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: api-gateway
+  namespace: platform
+spec:
+  scaleTargetRef:
+    name: api-gateway
+
+  minReplicaCount: 1                # Keep at least 1 replica at all times
+  maxReplicaCount: 30
+  pollingInterval: 30
+  cooldownPeriod: 300               # 5 min cooldown prevents rapid scale-down
+
+  advanced:
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 0      # Fast scale-up on traffic spike
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 15
+        scaleDown:
+          stabilizationWindowSeconds: 300    # Slow scale-down
+
+  triggers:
+    # Primary trigger: HTTP request rate from Prometheus
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus-operated.monitoring.svc.cluster.local:9090
+        metricName: http_request_rate
+        # rate() over 2 minutes smooths out short spikes
+        query: sum(rate(http_requests_total{namespace="platform",service="api-gateway"}[2m]))
+        threshold: "100"            # Target: 100 req/s per replica
+        activationThreshold: "10"   # Don't activate unless rate > 10 req/s
+
+    # Secondary trigger: ensure minimum 3 replicas during business hours
+    - type: cron
+      metadata:
+        timezone: Europe/Berlin
+        start: "0 8 * * 1-5"       # 08:00 Mon-Fri
+        end: "0 20 * * 1-5"        # 20:00 Mon-Fri
+        desiredReplicas: "3"

--- a/examples/keda/scaledobject-sqs.yaml
+++ b/examples/keda/scaledobject-sqs.yaml
@@ -1,0 +1,75 @@
+---
+# ScaledObject: AWS SQS trigger with IRSA authentication
+#
+# Scales the orders-processor Deployment based on SQS queue depth.
+# Scale-to-zero when queue is empty; max 20 replicas when busy.
+#
+# Prerequisites:
+# - KEDA installed: helm install keda kedacore/keda -n keda
+# - IRSA role created with sqs:GetQueueAttributes + sqs:GetQueueUrl
+# - KEDA operator SA annotated: eks.amazonaws.com/role-arn=<role-arn>
+
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-sqs-auth
+  namespace: orders
+spec:
+  # IRSA: no static credentials — role assumed via OIDC federation
+  podIdentity:
+    provider: aws
+
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: orders-processor
+  namespace: orders
+spec:
+  scaleTargetRef:
+    name: orders-processor          # Must match Deployment metadata.name exactly
+
+  minReplicaCount: 0                # Scale-to-zero when queue is empty
+  maxReplicaCount: 20
+  pollingInterval: 30               # Check SQS every 30s (each poll = 1 SQS API call)
+  cooldownPeriod: 120               # Wait 2 min after queue drains before scaling to 0
+
+  advanced:
+    restoreToOriginalReplicaCount: true  # Restore to pre-KEDA replica count on deletion
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300  # Prevent thrashing on variable queue depth
+          policies:
+            - type: Percent
+              value: 25
+              periodSeconds: 60
+
+  triggers:
+    - type: aws-sqs-queue
+      metadata:
+        queueURL: https://sqs.eu-central-1.amazonaws.com/123456789012/orders
+        queueLength: "5"            # Target: 5 messages per replica
+        awsRegion: eu-central-1
+        scaleOnInFlight: "true"     # Count in-flight messages to avoid under-scaling
+        activationQueueLength: "1"  # Don't activate unless at least 1 message exists
+      authenticationRef:
+        name: keda-sqs-auth
+
+---
+# IAM policy for the IRSA role (attach to the KEDA operator role)
+# Only grants what KEDA needs: read queue depth, not consume messages
+#
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Effect": "Allow",
+#       "Action": [
+#         "sqs:GetQueueAttributes",
+#         "sqs:GetQueueUrl"
+#       ],
+#       "Resource": "arn:aws:sqs:eu-central-1:123456789012:orders"
+#     }
+#   ]
+# }

--- a/references/keda.md
+++ b/references/keda.md
@@ -441,17 +441,71 @@ triggers:
 
 ### Cron (scheduled scaling)
 
+Use when replica count should follow a predictable time-based pattern. Cron does not use HPA internally — KEDA sets the replica count directly at the scheduled boundary.
+
 ```yaml
 triggers:
   - type: cron
     metadata:
-      timezone: Europe/Berlin      # IANA timezone
+      timezone: Europe/Berlin      # IANA timezone — always explicit, never rely on UTC
       start: "0 8 * * 1-5"        # Scale up: 08:00 Mon-Fri
       end: "0 20 * * 1-5"         # Scale down: 20:00 Mon-Fri
-      desiredReplicas: "5"
+      desiredReplicas: "10"
 ```
 
-Cron scaler always runs alongside other triggers. KEDA picks the maximum of all trigger desired replica counts.
+#### Multiple non-overlapping windows
+
+Define a separate trigger entry for each time band. Overlapping windows produce undefined behavior.
+
+```yaml
+triggers:
+  # Weekday morning ramp-up
+  - type: cron
+    metadata:
+      timezone: Europe/Berlin
+      start: "0 8 * * 1-5"
+      end: "0 10 * * 1-5"
+      desiredReplicas: "5"
+
+  # Weekday peak
+  - type: cron
+    metadata:
+      timezone: Europe/Berlin
+      start: "0 10 * * 1-5"
+      end: "0 20 * * 1-5"
+      desiredReplicas: "20"
+
+  # Weekday evening wind-down
+  - type: cron
+    metadata:
+      timezone: Europe/Berlin
+      start: "0 20 * * 1-5"
+      end: "59 23 * * 1-5"
+      desiredReplicas: "3"
+```
+
+#### Best practices
+
+| Practice | Reason |
+|---|---|
+| Always set `timezone` explicitly | KEDA defaults to UTC — business-hours windows in other timezones will fire at wrong times |
+| Always pair with a queue/Prometheus trigger | Cron only handles scheduled load; unexpected spikes need a real-time trigger as safety net |
+| Keep `minReplicaCount: 1` | Outside any scheduled window KEDA returns to `minReplicaCount`; use 1 to keep a warm pod |
+| Set `restoreToOriginalReplicaCount: true` | On ScaledObject deletion, restores the previous replica count instead of leaving it at the last cron value |
+| Annotate the schedule intent | Future engineers should not need to decode cron syntax to understand the scaling intent |
+
+#### Outside scheduled windows
+
+When no cron window is active, KEDA scales back to `minReplicaCount`. If other triggers (Prometheus, SQS) are also defined, KEDA uses whichever trigger demands the most replicas — the cron floor and event-driven ceiling work together.
+
+```
+08:00                      20:00
+  │────── cron: 20 replicas ────│
+  │                             │ ← event spike: Prometheus takes over → 30 replicas
+  │                             │────── cron inactive: back to minReplicaCount: 1 ────
+```
+
+See [examples/keda/scaledobject-cron.yaml](../examples/keda/scaledobject-cron.yaml) for a full working example with weekday/weekend windows, a Prometheus safety-net trigger, and a PodDisruptionBudget.
 
 ### Azure Service Bus
 

--- a/references/keda.md
+++ b/references/keda.md
@@ -224,8 +224,7 @@ spec:
                 cpu: 500m
                 memory: 512Mi
               limits:
-                cpu: 2
-                memory: 2Gi
+                memory: 2Gi             # Omit cpu limit — it causes throttling
         restartPolicy: Never
   minReplicaCount: 0
   maxReplicaCount: 10               # Max concurrent jobs

--- a/references/keda.md
+++ b/references/keda.md
@@ -1,0 +1,792 @@
+# KEDA Reference
+
+Covers KEDA (Kubernetes Event-Driven Autoscaling) v2.x — ScaledObject, ScaledJob, TriggerAuthentication, ClusterTriggerAuthentication, scalers (CPU, memory, Prometheus, Kafka, SQS, Redis, Cron, HTTP Add-on, Azure Service Bus), scaling lifecycle, security patterns, GitOps integration, and troubleshooting.
+
+> **KEDA version baseline**
+> This guide targets KEDA v2.14+ (stable). ScaledObject and ScaledJob use `keda.sh/v1alpha1`. The HTTP Add-on is a separate Helm chart (`kedacore/keda-add-ons-http`).
+
+---
+
+## What is KEDA?
+
+KEDA extends Kubernetes HPA by adding an event-driven trigger layer. It:
+
+1. Reads metrics from external sources (queues, topics, databases, custom APIs)
+2. Converts those metrics into HPA-compatible values
+3. Drives replicas from 0 → N (scale-from-zero) and back to 0 (scale-to-zero)
+
+KEDA works alongside the Kubernetes HPA — it creates and manages an HPA object on your behalf. Do not create your own HPA for the same deployment.
+
+### KEDA vs standard HPA decision matrix
+
+| Scenario | Use | Reason |
+|---|---|---|
+| Scale on CPU or memory only | HPA directly | No external metric source needed |
+| Scale on queue depth (SQS, Kafka, RabbitMQ) | KEDA | HPA cannot reach external APIs |
+| Scale-from-zero (0 replicas when idle) | KEDA | HPA min replicas = 1 |
+| Scale based on Prometheus query | KEDA | Prometheus scaler handles metric fetch |
+| Scheduled scaling (time-based) | KEDA Cron scaler | HPA has no time concept |
+| Batch job triggered by queue message | KEDA ScaledJob | HPA targets Deployments, not Jobs |
+| Long-running service with custom metrics | Either | Prefer KEDA for simpler auth and multi-trigger |
+
+---
+
+## Architecture
+
+```
+External source (SQS, Kafka, Prometheus...)
+          │
+          ▼
+    KEDA Metrics Adapter  ◄──  ScaledObject spec
+          │
+          ▼
+    Kubernetes HPA  ──►  Deployment / StatefulSet / ReplicaSet
+          │
+          ▼
+    Pod replicas (0 → maxReplicas)
+```
+
+KEDA installs three components:
+
+| Component | Purpose |
+|---|---|
+| `keda-operator` | Watches ScaledObject/ScaledJob, creates HPA, runs scale-to-zero |
+| `keda-operator-metrics-apiserver` | Serves external metrics to the HPA |
+| `keda-admission-webhooks` | Validates ScaledObject/ScaledJob on admission |
+
+---
+
+## Installation
+
+### Helm (recommended)
+
+```bash
+helm repo add kedacore https://kedacore.github.io/charts
+helm repo update
+
+helm upgrade --install keda kedacore/keda \
+  --namespace keda \
+  --create-namespace \
+  --version 2.14.0 \
+  --set watchNamespace="" \
+  --set resources.operator.requests.cpu=100m \
+  --set resources.operator.requests.memory=100Mi \
+  --set resources.operator.limits.cpu=1 \
+  --set resources.operator.limits.memory=1000Mi \
+  --set resources.metricServer.requests.cpu=100m \
+  --set resources.metricServer.requests.memory=100Mi \
+  --set resources.metricServer.limits.cpu=1 \
+  --set resources.metricServer.limits.memory=1000Mi
+```
+
+`watchNamespace=""` means KEDA watches all namespaces. Set to a specific namespace for single-tenant installs.
+
+### Verify
+
+```bash
+kubectl get pods -n keda
+# keda-operator-xxx                Ready
+# keda-operator-metrics-apiserver-xxx  Ready
+
+kubectl get crd | grep keda.sh
+# scaledobjects.keda.sh
+# scaledjobs.keda.sh
+# triggerauthentications.keda.sh
+# clustertriggerauthentications.keda.sh
+```
+
+---
+
+## ScaledObject
+
+Drives autoscaling for a Deployment, StatefulSet, or any resource implementing `scale` subresource.
+
+### Minimal example (Prometheus scaler)
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: orders-processor
+  namespace: orders
+spec:
+  scaleTargetRef:
+    name: orders-processor          # Deployment name
+  minReplicaCount: 1                # 0 = scale-to-zero
+  maxReplicaCount: 20
+  pollingInterval: 30               # Seconds between metric polls
+  cooldownPeriod: 300               # Seconds to wait before scaling to 0
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://prometheus.monitoring.svc.cluster.local:9090
+        metricName: orders_queue_depth
+        query: sum(orders_queue_depth)
+        threshold: "10"             # Scale up when depth > 10 per replica
+```
+
+### Scale-to-zero (minReplicaCount: 0)
+
+```yaml
+spec:
+  minReplicaCount: 0
+  cooldownPeriod: 120    # Wait 120s after last event before scaling to 0
+  triggers:
+    - type: aws-sqs-queue
+      metadata:
+        queueURL: https://sqs.eu-central-1.amazonaws.com/123456789/orders
+        queueLength: "5"
+        awsRegion: eu-central-1
+      authenticationRef:
+        name: keda-sqs-auth
+```
+
+> **Cold-start latency**: scale-to-zero means the first request after idle may queue until a pod starts (usually 10–30 s depending on image pull and init time). Use `minReplicaCount: 1` for latency-sensitive services.
+
+### Multiple triggers (OR logic)
+
+When multiple triggers are defined, KEDA uses the trigger producing the highest desired replica count. Triggers do not all need to fire simultaneously.
+
+```yaml
+spec:
+  triggers:
+    - type: aws-sqs-queue
+      metadata:
+        queueURL: https://sqs.eu-central-1.amazonaws.com/123456789/orders
+        queueLength: "5"
+        awsRegion: eu-central-1
+      authenticationRef:
+        name: keda-sqs-auth
+    - type: cron
+      metadata:
+        timezone: Europe/Berlin
+        start: "0 9 * * 1-5"       # Ensure min replicas during business hours
+        end: "0 18 * * 1-5"
+        desiredReplicas: "3"
+```
+
+### Advanced spec fields
+
+```yaml
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1             # Default; override for custom resources
+    kind: Deployment
+    name: orders-processor
+  minReplicaCount: 0
+  maxReplicaCount: 50
+  pollingInterval: 15
+  cooldownPeriod: 300
+  idleReplicaCount: 0               # When no events, stay at this replica count
+  initialCooldownPeriod: 120        # Don't scale-to-zero for first N seconds after creation
+  advanced:
+    restoreToOriginalReplicaCount: true  # Restore replicas on ScaledObject deletion
+    horizontalPodAutoscalerConfig:
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 300   # Slow scale-down
+          policies:
+            - type: Percent
+              value: 25
+              periodSeconds: 60
+        scaleUp:
+          stabilizationWindowSeconds: 0     # Fast scale-up
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 15
+```
+
+---
+
+## ScaledJob
+
+Triggers Kubernetes `Job` creation in response to events — each message spawns one (or more) Job pods. Use for batch workloads.
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+  name: report-generator
+  namespace: reports
+spec:
+  jobTargetRef:
+    parallelism: 1
+    completions: 1
+    backoffLimit: 2
+    template:
+      spec:
+        containers:
+          - name: report-generator
+            image: myregistry.io/report-generator:1.2.0
+            resources:
+              requests:
+                cpu: 500m
+                memory: 512Mi
+              limits:
+                cpu: 2
+                memory: 2Gi
+        restartPolicy: Never
+  minReplicaCount: 0
+  maxReplicaCount: 10               # Max concurrent jobs
+  pollingInterval: 30
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  scalingStrategy:
+    strategy: accurate              # accurate | default | custom
+  triggers:
+    - type: aws-sqs-queue
+      metadata:
+        queueURL: https://sqs.eu-central-1.amazonaws.com/123456789/reports
+        queueLength: "1"            # 1 message = 1 job
+        awsRegion: eu-central-1
+      authenticationRef:
+        name: keda-sqs-auth
+```
+
+### Scaling strategies
+
+| Strategy | Behavior |
+|---|---|
+| `default` | Create (messages - running jobs) jobs |
+| `accurate` | Query queue depth on every poll cycle — more accurate but more API calls |
+| `custom` | Custom function using `customScalingQueueLengthDeduction` and `customScalingRunningJobPercentage` |
+
+---
+
+## TriggerAuthentication
+
+Stores credentials for scalers. Supports Kubernetes Secrets, Pod Identity (IRSA, Workload Identity, Azure AD), HashiCorp Vault, and environment variables.
+
+### Kubernetes Secret reference
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-sqs-auth
+  namespace: orders
+spec:
+  secretTargetRef:
+    - parameter: awsAccessKeyID
+      name: keda-aws-credentials
+      key: AWS_ACCESS_KEY_ID
+    - parameter: awsSecretAccessKey
+      name: keda-aws-credentials
+      key: AWS_SECRET_ACCESS_KEY
+```
+
+> **Prefer Pod Identity over static credentials.** Static AWS keys require rotation and grant cluster-wide access if the Secret is over-permissioned. Pod Identity scopes credentials to the specific pod SA.
+
+### IRSA (AWS IAM Roles for Service Accounts)
+
+No static credentials needed. KEDA assumes an IAM role via OIDC federation.
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-sqs-auth
+  namespace: orders
+spec:
+  podIdentity:
+    provider: aws                   # aws | azure | gcp | aws-eks
+```
+
+Prerequisites:
+```bash
+# 1. Create IRSA role with SQS read permissions and trust policy scoped to KEDA SA
+# 2. Annotate KEDA operator SA with the role ARN
+kubectl annotate serviceaccount keda-operator \
+  -n keda \
+  eks.amazonaws.com/role-arn=arn:aws:iam::123456789:role/keda-operator
+```
+
+Minimum IAM policy for SQS scaler:
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sqs:GetQueueAttributes",
+        "sqs:GetQueueUrl"
+      ],
+      "Resource": "arn:aws:sqs:eu-central-1:123456789:orders"
+    }
+  ]
+}
+```
+
+### ClusterTriggerAuthentication
+
+Cluster-scoped version — reusable across all namespaces. Reference with `kind: ClusterTriggerAuthentication` in ScaledObject.
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ClusterTriggerAuthentication
+metadata:
+  name: cluster-sqs-auth            # No namespace
+spec:
+  podIdentity:
+    provider: aws
+```
+
+```yaml
+# In ScaledObject:
+triggers:
+  - type: aws-sqs-queue
+    authenticationRef:
+      name: cluster-sqs-auth
+      kind: ClusterTriggerAuthentication
+```
+
+---
+
+## Scalers
+
+### CPU and Memory (built-in, no TriggerAuthentication needed)
+
+```yaml
+triggers:
+  - type: cpu
+    metricType: Utilization         # Utilization | AverageValue
+    metadata:
+      value: "60"                   # 60% CPU utilization
+  - type: memory
+    metricType: Utilization
+    metadata:
+      value: "70"                   # 70% memory utilization
+```
+
+CPU and memory triggers require resource requests to be set on the target containers — HPA cannot compute utilization without them.
+
+### Prometheus
+
+```yaml
+triggers:
+  - type: prometheus
+    metadata:
+      serverAddress: http://prometheus.monitoring.svc.cluster.local:9090
+      metricName: http_requests_per_second
+      query: rate(http_requests_total[2m])
+      threshold: "100"
+      activationThreshold: "10"    # Min value to activate scaling (avoids flapping)
+      namespace: orders             # Prometheus namespace label filter (optional)
+```
+
+### AWS SQS
+
+```yaml
+triggers:
+  - type: aws-sqs-queue
+    metadata:
+      queueURL: https://sqs.eu-central-1.amazonaws.com/123456789/orders
+      queueLength: "10"            # Target messages per replica
+      awsRegion: eu-central-1
+      scaleOnInFlight: "true"      # Count in-flight messages too
+      activationQueueLength: "1"   # Min depth before activating
+    authenticationRef:
+      name: keda-sqs-auth
+```
+
+### Apache Kafka
+
+```yaml
+triggers:
+  - type: kafka
+    metadata:
+      bootstrapServers: kafka.kafka.svc.cluster.local:9092
+      consumerGroup: orders-consumer
+      topic: orders
+      lagThreshold: "20"           # Messages behind per replica
+      activationLagThreshold: "5"
+      offsetResetPolicy: latest    # latest | earliest
+    authenticationRef:
+      name: keda-kafka-auth
+```
+
+TriggerAuthentication for SASL/TLS:
+```yaml
+spec:
+  secretTargetRef:
+    - parameter: sasl
+      name: kafka-credentials
+      key: sasl                    # plaintext | scram_sha256 | scram_sha512
+    - parameter: username
+      name: kafka-credentials
+      key: username
+    - parameter: password
+      name: kafka-credentials
+      key: password
+    - parameter: tls
+      name: kafka-credentials
+      key: tls                     # enable | disable
+```
+
+### Redis (List)
+
+```yaml
+triggers:
+  - type: redis
+    metadata:
+      address: redis.cache.svc.cluster.local:6379
+      listName: order-queue
+      listLength: "20"
+      activationListLength: "5"
+    authenticationRef:
+      name: keda-redis-auth
+```
+
+### Cron (scheduled scaling)
+
+```yaml
+triggers:
+  - type: cron
+    metadata:
+      timezone: Europe/Berlin      # IANA timezone
+      start: "0 8 * * 1-5"        # Scale up: 08:00 Mon-Fri
+      end: "0 20 * * 1-5"         # Scale down: 20:00 Mon-Fri
+      desiredReplicas: "5"
+```
+
+Cron scaler always runs alongside other triggers. KEDA picks the maximum of all trigger desired replica counts.
+
+### Azure Service Bus
+
+```yaml
+triggers:
+  - type: azure-servicebus
+    metadata:
+      namespace: myservicebus
+      queueName: orders             # or topicName + subscriptionName for topics
+      messageCount: "10"
+      activationMessageCount: "1"
+    authenticationRef:
+      name: keda-asb-auth
+```
+
+### HTTP Add-on (separate chart)
+
+The HTTP Add-on requires installing `kedacore/keda-add-ons-http` separately. It adds an `HTTPScaledObject` kind that intercepts HTTP traffic and scales a Deployment from zero.
+
+```bash
+helm upgrade --install keda-add-ons-http kedacore/keda-add-ons-http \
+  --namespace keda \
+  --version 0.9.0
+```
+
+```yaml
+apiVersion: http.keda.sh/v1alpha1
+kind: HTTPScaledObject
+metadata:
+  name: orders-api
+  namespace: orders
+spec:
+  hosts:
+    - orders.example.com
+  scaleTargetRef:
+    name: orders-api
+    port: 8080
+  minReplicaCount: 0
+  maxReplicaCount: 10
+  scalingMetric:
+    requestRate:
+      granularity: 1s
+      targetValue: 100             # Requests/sec per replica
+      window: 1m
+```
+
+---
+
+## Scaling Lifecycle
+
+```
+No events → 0 replicas (if minReplicaCount: 0)
+          │
+          │ Event detected (queue depth > activationThreshold)
+          ▼
+1 replica (activation replica)
+          │
+          │ Continued events / metric above threshold
+          ▼
+N replicas (up to maxReplicaCount)
+          │
+          │ Events drain / metric below threshold
+          ▼
+cooldownPeriod expires → back to minReplicaCount
+```
+
+### Tuning pollingInterval and cooldownPeriod
+
+| Scenario | pollingInterval | cooldownPeriod |
+|---|---|---|
+| Low-latency queue processing | 5–15s | 30–60s |
+| Batch overnight jobs | 60–120s | 300–600s |
+| Web API with Prometheus metric | 30s | 300s |
+| Business-hours cron + queue | N/A (cron) + 15s | 120s |
+
+**Avoid too-low pollingInterval** — each poll is an API call to the external source. For SQS, AWS charges per API call. For Kafka, excessive polls add broker load.
+
+---
+
+## Security Patterns
+
+### Least-privilege TriggerAuthentication
+
+Never grant KEDA the ability to consume messages — it only needs to read queue depth metrics:
+
+| Scaler | Minimum permission |
+|---|---|
+| SQS | `sqs:GetQueueAttributes`, `sqs:GetQueueUrl` |
+| Kafka | Consumer group read (describe, offset fetch) — not produce |
+| Azure Service Bus | `Listen` on the specific queue/subscription |
+| Prometheus | No auth needed if Prometheus is cluster-internal |
+| Redis | `LLEN` command on the target list only |
+
+### Namespace-scoped vs cluster-scoped auth
+
+Use `TriggerAuthentication` (namespace-scoped) by default. Use `ClusterTriggerAuthentication` only when:
+- Multiple teams in multiple namespaces share the same external resource (e.g., a shared Kafka cluster)
+- A platform team manages authentication centrally
+
+Document which teams are permitted to reference a `ClusterTriggerAuthentication` — it bypasses namespace RBAC for credential access.
+
+### RBAC for ScaledObject management
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: keda-scaledobject-editor
+  namespace: orders
+rules:
+  - apiGroups: [keda.sh]
+    resources: [scaledobjects, scaledjobs, triggerauthentications]
+    verbs: [get, list, watch, create, update, patch, delete]
+```
+
+### Secrets for credentials
+
+Never inline credentials in ScaledObject. Always use TriggerAuthentication with a Kubernetes Secret or Pod Identity. Seal secrets with External Secrets Operator or Sealed Secrets.
+
+---
+
+## GitOps Integration
+
+### Flux example
+
+```yaml
+# infrastructure/keda/kustomization.yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: keda
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./infrastructure/keda
+  sourceRef:
+    kind: GitRepository
+    name: platform
+  prune: true
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: keda-operator
+      namespace: keda
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: keda-operator-metrics-apiserver
+      namespace: keda
+```
+
+### Ordering: KEDA before workloads
+
+```yaml
+# apps/orders/kustomization.yaml
+spec:
+  dependsOn:
+    - name: keda                    # KEDA CRDs must exist before ScaledObject
+```
+
+### Storing TriggerAuthentication in Git safely
+
+Store the TriggerAuthentication manifest without the Secret data. Pair it with an ExternalSecret that creates the Kubernetes Secret:
+
+```yaml
+# The TriggerAuthentication references a Secret by name — commit this
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: keda-sqs-auth
+spec:
+  secretTargetRef:
+    - parameter: awsAccessKeyID
+      name: keda-aws-credentials    # Created by ExternalSecret
+      key: AWS_ACCESS_KEY_ID
+```
+
+The Secret itself is never committed — it's rendered by External Secrets Operator at runtime.
+
+---
+
+## Troubleshooting
+
+### Diagnostic commands
+
+```bash
+# Check ScaledObject status
+kubectl get scaledobject -n <namespace>
+kubectl describe scaledobject <name> -n <namespace>
+
+# Check the HPA KEDA created
+kubectl get hpa -n <namespace>
+kubectl describe hpa keda-hpa-<scaledobject-name> -n <namespace>
+
+# Check KEDA operator logs
+kubectl logs -n keda -l app.kubernetes.io/name=keda-operator --tail=100
+
+# Check metrics server logs (auth issues show here)
+kubectl logs -n keda -l app.kubernetes.io/name=keda-operator-metrics-apiserver --tail=100
+
+# Fetch current metric value KEDA sees
+kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/<namespace>/<metric-name>"
+```
+
+### Common problems
+
+#### ScaledObject never activates (stays at 0 replicas)
+
+**Symptom:** `kubectl get scaledobject` shows `Active: false`, deployment stays at 0 replicas.
+
+**Diagnosis:**
+```bash
+kubectl describe scaledobject <name> -n <ns>
+# Look for: Conditions — Active, Ready, Fallback
+kubectl logs -n keda -l app.kubernetes.io/name=keda-operator --tail=100 | grep -i error
+```
+
+**Common causes:**
+- `activationThreshold` / `activationQueueLength` set too high — metric never crosses it
+- TriggerAuthentication missing or misconfigured — KEDA can't read the external source
+- External source unreachable from cluster — network policy blocking egress, or wrong endpoint
+
+#### Deployment doesn't scale down to 0
+
+**Symptom:** Deployment stays at 1 replica despite empty queue.
+
+**Check:**
+```bash
+kubectl describe scaledobject <name> -n <ns>
+# Look for: Idle Replica Count, Cooldown Period
+```
+
+**Common causes:**
+- `minReplicaCount: 1` — explicitly prevents scale-to-zero
+- `idleReplicaCount` set to 1 or above
+- `cooldownPeriod` not yet elapsed — wait longer before diagnosing
+- Multiple triggers: one trigger (e.g., Cron) keeps desired replicas > 0
+
+#### KEDA creates HPA but HPA shows `<unknown>` metrics
+
+**Symptom:** `kubectl get hpa -n <ns>` shows `TARGETS: <unknown>/10`.
+
+**Diagnosis:**
+```bash
+kubectl describe hpa keda-hpa-<name> -n <ns>
+# Look for: Warning FailedGetExternalMetric
+kubectl logs -n keda -l app.kubernetes.io/name=keda-operator-metrics-apiserver --tail=50
+```
+
+**Common causes:**
+- Metrics adapter pod not ready: `kubectl get pods -n keda`
+- TriggerAuthentication secret key missing or wrong
+- External source returns empty/null metric — check scaler-specific connection
+
+#### Kafka: consumer group not found / offset reset issues
+
+```bash
+# Check consumer group exists and has members
+kubectl exec -n kafka <kafka-pod> -- \
+  kafka-consumer-groups.sh --bootstrap-server localhost:9092 \
+  --describe --group orders-consumer
+```
+
+If the consumer group doesn't exist yet, Kafka scalers return 0 lag. The group is created when the first consumer connects. Use `offsetResetPolicy: earliest` to start consuming from the beginning if needed.
+
+#### SQS: KEDA has permissions but queue depth is always 0
+
+```bash
+# Test SQS GetQueueAttributes directly
+aws sqs get-queue-attributes \
+  --queue-url https://sqs.eu-central-1.amazonaws.com/123456789/orders \
+  --attribute-names ApproximateNumberOfMessages \
+  --region eu-central-1
+```
+
+If the AWS CLI returns the count correctly but KEDA reads 0, check `scaleOnInFlight` — by default KEDA uses `ApproximateNumberOfMessages`, not `ApproximateNumberOfMessagesNotVisible`. If your consumers leave messages in-flight, set `scaleOnInFlight: "true"`.
+
+#### Conflicting HPA error on ScaledObject admission
+
+```
+Error: ScaledObject targets a resource that already has an HPA
+```
+
+KEDA refuses to create a ScaledObject if an HPA already targets the same Deployment. Delete the existing HPA first:
+
+```bash
+kubectl delete hpa <existing-hpa> -n <namespace>
+```
+
+#### ScaledObject deleted but deployment stays at scaled-up count
+
+Set `advanced.restoreToOriginalReplicaCount: true` in the ScaledObject spec. Without this, KEDA leaves the last replica count in place on deletion.
+
+---
+
+## Observability
+
+### Prometheus metrics from KEDA
+
+KEDA exposes its own metrics on port 8080 (operator) and 9022 (metrics adapter):
+
+```bash
+kubectl port-forward -n keda svc/keda-operator 8080:8080
+curl localhost:8080/metrics | grep keda_
+```
+
+Key metrics:
+
+| Metric | Description |
+|---|---|
+| `keda_scaler_metrics_value` | Current metric value seen by KEDA |
+| `keda_scaler_active` | Whether the scaler is active (1) or idle (0) |
+| `keda_scaler_errors_total` | Errors fetching metrics from external source |
+| `keda_scaled_object_errors_total` | Errors on the ScaledObject reconcile loop |
+| `keda_resource_totals` | Count of ScaledObject/ScaledJob by namespace |
+
+### Grafana dashboard
+
+Import dashboard ID `17784` from Grafana.com — the official KEDA dashboard covers scaler health, active scalers, and error rates.
+
+---
+
+## Version Compatibility
+
+| KEDA version | Kubernetes | Helm chart |
+|---|---|---|
+| 2.14 | 1.27–1.30 | 2.14.x |
+| 2.13 | 1.26–1.29 | 2.13.x |
+| 2.12 | 1.25–1.28 | 2.12.x |
+
+Always check [keda.sh/docs](https://keda.sh/docs) for the current compatibility matrix before upgrading.
+
+### Upgrade checklist
+
+1. Check the KEDA release notes for removed scalers or changed metadata fields
+2. Run `helm upgrade --dry-run` first
+3. After upgrade, verify `kubectl get scaledobject -A` shows `Active: true` for all objects
+4. Check KEDA operator logs for any deprecation warnings: `kubectl logs -n keda -l app.kubernetes.io/name=keda-operator --tail=200 | grep -i warn`
+5. Rollback: `helm rollback keda -n keda` — ScaledObjects are preserved in etcd

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platform-skills
-description: Hands-on guidance for platform and DevOps engineers working with Kubernetes, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, and compliance. Use when designing or troubleshooting Kubernetes workloads and RBAC, writing Terraform modules, configuring Flux or Argo CD, setting up CI/CD pipelines, managing cloud identity and IAM, handling secrets, diagnosing DNS or VPC connectivity, operating a service mesh, applying product thinking to developer experience, or implementing SOC 2 compliance controls in Terraform — at any scale, for any team size.
+description: Hands-on guidance for platform and DevOps engineers working with Kubernetes, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, compliance, and KEDA event-driven autoscaling. Use when designing or troubleshooting Kubernetes workloads and RBAC, writing Terraform modules, configuring Flux or Argo CD, setting up CI/CD pipelines, managing cloud identity and IAM, handling secrets, diagnosing DNS or VPC connectivity, operating a service mesh, applying product thinking to developer experience, implementing SOC 2 compliance controls in Terraform, or scaling workloads with KEDA scalers (SQS, Kafka, Prometheus, Cron, HTTP) — at any scale, for any team size.
 ---
 
 # Platform Skills
@@ -33,6 +33,7 @@ Match the task to the right layer:
 20. `Kyverno`: Write and maintain Kubernetes-native admission policies using the CEL-based types — ValidatingPolicy, MutatingPolicy, GeneratingPolicy, ImageValidatingPolicy (all `policies.kyverno.io/v1`). Covers matchConstraints, matchConditions, CEL validations/mutations, generator.Apply(), Audit→Deny promotion, PolicyException, and kyverno-cli testing.
 21. `PR Review`: Comprehensive pre-merge risk review across six dimensions — cost impact, environment drift, ownership and governance gaps, SOC 2 compliance, deprecated API / version hygiene, and rollback feasibility scoring.
 22. `PR Comment Triage`: Triage bot or human PR comments, classify them as ACTIONABLE_FIX / INFORMATIONAL / NOT_APPLICABLE, make the minimal fix when valid, reply on the thread, and resolve it through `gh`.
+23. `KEDA`: Design, generate, debug, and review KEDA ScaledObject and ScaledJob resources. Covers all major scalers (Prometheus, SQS, Kafka, Redis, Cron, HTTP Add-on, Azure Service Bus), TriggerAuthentication with IRSA/Workload Identity, scaling lifecycle tuning, scale-to-zero patterns, and GitOps integration.
 
 If a task spans multiple areas, decide which layer owns the source of truth and keep the other layers consumers of that state.
 
@@ -89,6 +90,7 @@ When asked to generate code, start from the thinnest useful slice that proves th
 - For OPA / Conftest — Rego v1 syntax, rule types, package namespacing, input shapes, unit tests, validation pipeline (fmt/regal/verify), GitHub Actions integration, and troubleshooting — read [references/opa.md](references/opa.md).
 - For Kyverno CEL-based admission policies — ValidatingPolicy, MutatingPolicy, GeneratingPolicy, ImageValidatingPolicy, matchConstraints, matchConditions, Audit→Deny promotion, PolicyException, kyverno-cli testing, and migration from legacy ClusterPolicy — read [references/kyverno.md](references/kyverno.md).
 - For comprehensive PR review — cost impact, environment drift, ownership gaps, SOC 2 compliance, deprecated APIs, version hygiene, rollback feasibility, and bot comment triage — read [references/pr-review.md](references/pr-review.md).
+- For KEDA event-driven autoscaling — ScaledObject, ScaledJob, TriggerAuthentication, IRSA, scalers (Prometheus, SQS, Kafka, Redis, Cron, HTTP Add-on, Azure Service Bus), scaling lifecycle, security patterns, and troubleshooting — read [references/keda.md](references/keda.md).
 
 Load only the files needed for the current request.
 
@@ -115,3 +117,4 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:kyverno` — generate, test, audit, debug, or migrate Kyverno CEL-based admission policies
 - `/platform-skills:pr-review` — comprehensive PR review: cost, drift, ownership, compliance, upgrade, rollback
 - `/platform-skills:triage` — triage a PR comment (bot or human): classify as ACTIONABLE_FIX / INFORMATIONAL / NOT_APPLICABLE, produce the exact fix if needed, and write the thread reply
+- `/platform-skills:keda` — design, generate, debug, or review KEDA ScaledObject/ScaledJob autoscaling

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -62,6 +62,7 @@ REQUIRED_REFERENCES=(
   references/opa.md
   references/kyverno.md
   references/pr-review.md
+  references/keda.md
 )
 
 for ref in "${REQUIRED_REFERENCES[@]}"; do
@@ -96,6 +97,7 @@ EXAMPLE_DOMAINS=(
   examples/kyverno
   examples/pr-review
   examples/triage
+  examples/keda
 )
 
 for domain in "${EXAMPLE_DOMAINS[@]}"; do
@@ -184,6 +186,57 @@ if [ -d "$TRIAGE_EXAMPLES" ] && [ -f "$TRIAGE_EXAMPLES/README.md" ]; then
   pass "$TRIAGE_EXAMPLES has README.md"
 else
   fail "$TRIAGE_EXAMPLES missing README.md"
+fi
+
+echo ""
+echo "=== KEDA command integration ==="
+
+KEDA_CMD="commands/keda.md"
+KEDA_EXAMPLES="examples/keda"
+
+if [ -f "$KEDA_CMD" ]; then
+  pass "$KEDA_CMD exists"
+else
+  fail "$KEDA_CMD missing"
+fi
+
+for field in "^name: keda$" "^description:" "^argument-hint:"; do
+  if grep -qE "$field" "$KEDA_CMD"; then
+    pass "$KEDA_CMD has '$field'"
+  else
+    fail "$KEDA_CMD missing '$field'"
+  fi
+done
+
+if grep -q '"./commands/keda.md"' "$PLUGIN_JSON"; then
+  pass "commands/keda.md registered in plugin.json"
+else
+  fail "commands/keda.md not registered in plugin.json"
+fi
+
+for doc in SKILL.md skills/platform-skills/SKILL.md README.md; do
+  if grep -q "/platform-skills:keda" "$doc"; then
+    pass "$doc references /platform-skills:keda"
+  else
+    fail "$doc missing /platform-skills:keda"
+  fi
+done
+
+if [ -d "$KEDA_EXAMPLES" ] && [ -f "$KEDA_EXAMPLES/README.md" ]; then
+  pass "$KEDA_EXAMPLES has README.md"
+else
+  fail "$KEDA_EXAMPLES missing README.md"
+fi
+
+if [ -f "$KEDA_EXAMPLES/keda-validate.sh" ]; then
+  pass "$KEDA_EXAMPLES/keda-validate.sh exists"
+  if bash "$KEDA_EXAMPLES/keda-validate.sh" >/dev/null 2>&1; then
+    pass "$KEDA_EXAMPLES/keda-validate.sh passed"
+  else
+    fail "$KEDA_EXAMPLES/keda-validate.sh failed — run it directly for details"
+  fi
+else
+  fail "$KEDA_EXAMPLES/keda-validate.sh missing"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

- Adds Domain 23: **KEDA** — Kubernetes Event-Driven Autoscaling skill covering ScaledObject, ScaledJob, TriggerAuthentication, and all major scalers
- New slash command `/platform-skills:keda` with four modes: `generate`, `debug`, `review`, `scale`
- Four working examples: SQS+IRSA, Prometheus+Cron, Kafka SASL/TLS, ScaledJob batch processing
- Bumps version to `1.14.0` in `marketplace.json` and `CHANGELOG.md`

## Changes

| File | Change |
|---|---|
| `references/keda.md` | New comprehensive reference: architecture, all scalers, security patterns, GitOps, troubleshooting |
| `commands/keda.md` | New slash command with generate/debug/review/scale modes |
| `examples/keda/` | Four production-ready ScaledObject/ScaledJob examples |
| `SKILL.md` | Added Domain 23, reference pointer, and slash command registration |
| `README.md` | Added KEDA row to domains table, roadmap entry, and repo structure |
| `CHANGELOG.md` | Added `[1.14.0]` entry with full feature list |
| `.claude-plugin/marketplace.json` | Bumped to `1.14.0`, added KEDA keywords |

## Test plan

- [ ] `kubectl apply --dry-run=client -f examples/keda/scaledobject-sqs.yaml` — no validation errors
- [ ] `kubectl apply --dry-run=client -f examples/keda/scaledjob-sqs.yaml` — no validation errors
- [ ] Invoke `/platform-skills:keda generate` — generates a ScaledObject from description
- [ ] Invoke `/platform-skills:keda debug` — produces diagnostic checklist
- [ ] `bash tests/validate-skill.sh` — skill structure checks pass