### PR TITLE
fix: address post-v1.14.0 gaps — Copilot instructions, examples, doc coverage

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,10 @@
 # Platform Engineering Instructions for GitHub Copilot
-# Version: 1.12.0
+# Version: 1.14.0
 # Source: https://github.com/nitinjain999/platform-skills
 # Scope: project-level — applies to every Copilot Chat in this workspace
 # Upgrade: git pull in the platform-skills clone → copy updated file → commit
 
-You are assisting with platform engineering tasks. Apply these patterns when generating or reviewing code across Kubernetes, OpenShift, Argo CD, Flux CD, AWS, Azure, Terraform, GitHub Actions, Helm, Kyverno, OPA/Conftest, and PR review.
+You are assisting with platform engineering tasks. Apply these patterns when generating or reviewing code across Kubernetes, OpenShift, Argo CD, Flux CD, AWS, Azure, Terraform, GitHub Actions, Helm, Kyverno, OPA/Conftest, KEDA, and PR review.
 
 ## Core Principles
 
@@ -257,6 +257,47 @@ When reviewing any PR that touches infrastructure, check all six dimensions:
 6. **Prevention** — how to avoid in future
 7. **Rollback** — how to safely undo
 
+## KEDA (Kubernetes Event-Driven Autoscaling)
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: orders-processor
+  namespace: orders
+spec:
+  scaleTargetRef:
+    name: orders-processor
+  minReplicaCount: 1
+  maxReplicaCount: 20
+  cooldownPeriod: 300
+  triggers:
+    - type: aws-sqs-queue
+      metadata:
+        queueURL: https://sqs.eu-central-1.amazonaws.com/123456789/orders
+        queueLength: "5"
+        awsRegion: eu-central-1
+        activationQueueLength: "1"
+      authenticationRef:
+        name: keda-sqs-auth
+```
+
+Always:
+- Use `podIdentity.provider: aws` (IRSA) over static credentials — never put AWS keys in a Secret referenced by TriggerAuthentication when IRSA is available
+- Set `activationQueueLength` to avoid scaling from 0 on a single stray message
+- Set `minReplicaCount: 1` for latency-sensitive services (scale-to-zero means cold starts)
+- Pair Cron triggers with a real-time trigger (Prometheus / SQS) as a safety net for unexpected load
+- Never create your own HPA for a Deployment managed by KEDA — KEDA creates and owns it
+
+`cooldownPeriod` is KEDA's own wait after triggers go inactive before reducing desired replicas toward `minReplicaCount` — it is a KEDA field, not an HPA field. The HPA's scale-down delay is `advanced.horizontalPodAutoscalerConfig.behavior.scaleDown.stabilizationWindowSeconds`.
+
+Never generate:
+- Static credentials (`accessKey` / `secretKey`) in TriggerAuthentication when IRSA is available
+- A ScaledObject and a manual HPA targeting the same Deployment
+- `cpu` limits on ScaledJob containers — they cause throttling
+
+Reference: `references/keda.md`
+
 ## Reference Files
 
 - `references/kubernetes.md` — cluster baselines, RBAC, network policy
@@ -279,4 +320,5 @@ When reviewing any PR that touches infrastructure, check all six dimensions:
 - `references/opa.md` — Rego v1, rule types, testing, Conftest CLI
 - `references/kyverno.md` — CEL policies, Audit→Deny, PolicyException
 - `references/pr-review.md` — cost, drift, ownership, compliance, upgrade, rollback
+- `references/keda.md` — KEDA ScaledObject/ScaledJob, TriggerAuthentication, scalers, Cron, security, troubleshooting
 - `examples/` — working, production-ready code examples

--- a/EDITOR_INTEGRATIONS.md
+++ b/EDITOR_INTEGRATIONS.md
@@ -226,7 +226,7 @@ gh copilot suggest "$(cat your-deployment.yaml) — review this for production r
 
 ## Skill commands in Copilot Chat
 
-Platform skills ships 19 command workflows. In Claude Code they are slash commands (`/platform-skills:review`). In Copilot Chat you phrase them as natural language — the instructions file makes Copilot apply the same structured output.
+Platform skills ships 20 command workflows. In Claude Code they are slash commands (`/platform-skills:review`). In Copilot Chat you phrase them as natural language — the instructions file makes Copilot apply the same structured output.
 
 ### review — production-readiness check on any file
 
@@ -555,6 +555,152 @@ Draft an RFC for migrating from Argo CD to Flux CD. 15 teams affected, GitOps re
 
 ```
 Audit our developer experience using the SPACE framework. Engineers spend 45 minutes to get a new service to production on day 1.
+```
+
+---
+
+### linkerd — mTLS, proxy injection, traffic policy
+
+```
+linkerd viz edges shows plaintext between orders-service and payments-service. How do I diagnose why mTLS is not working?
+```
+
+```
+Generate a Linkerd Server and ServerAuthorization policy that restricts the payments-service to only accept traffic from the checkout namespace.
+```
+
+```
+My pods are not getting Linkerd proxy injected after I added the annotation. What are the most common causes and how do I check each?
+```
+
+```
+I need to configure Linkerd traffic splits for a canary deployment — 90% to v1, 10% to v2. Generate the TrafficSplit manifest.
+```
+
+---
+
+### linux — DNS, load balancer, VPC, process, disk, networking
+
+```
+A pod cannot resolve payments-service.checkout.svc.cluster.local. Walk me through the DNS resolution path and give exact dig commands to find the break.
+```
+
+```
+ALB returning 502 — target group shows healthy. What is the most likely cause and how do I confirm it?
+```
+
+```
+A node shows high iowait. Give me the commands to identify which process and disk are causing it and how to interpret the output.
+```
+
+```
+A VPC peering connection is established but traffic between the two VPCs is dropped. What is the diagnostic order and what are the most common causes?
+```
+
+---
+
+### datadog — Agent, APM, monitors, dashboards, SLOs
+
+```
+APM traces are missing for the payments-service. The agent shows healthy. What are the common causes and evidence commands?
+```
+
+```
+Generate a Datadog monitor for p99 latency on the checkout service. Alert at 500ms, recover at 300ms. Use burn-rate alerting for the SLO.
+```
+
+```
+Write a Datadog SLO definition for the orders API: 99.9% availability over 30 days, error budget burn-rate alerts.
+```
+
+```
+The Datadog Agent on EKS is not collecting Kubernetes state metrics. How do I diagnose and fix the kube-state-metrics integration?
+```
+
+---
+
+### dynatrace — OneAgent, instrumentation, SLOs, Davis AI
+
+```
+OneAgent is not injecting into pods in the checkout namespace. How do I diagnose the injection failure?
+```
+
+```
+Write a Dynatrace SLO definition for the orders service: 99.9% availability, 200ms response time target.
+```
+
+```
+Davis AI shows a problem with high failure rate on checkout-service. Walk me through the evidence collection and root cause steps.
+```
+
+```
+Generate the DynaKube CR to deploy Dynatrace OneAgent on EKS with CSI driver mode and cloud-native full-stack injection.
+```
+
+---
+
+### document — docstrings, OpenAPI, docs sites, guides
+
+```
+Add Google-style docstrings to all public functions in this Python module. Include parameters, return types, exceptions, and a usage example.
+[paste module]
+```
+
+```
+Generate an OpenAPI 3.1 spec for this FastAPI service. Extract shared schemas into components/schemas and add security schemes.
+[paste routes or codebase path]
+```
+
+```
+Set up a MkDocs documentation site for this Python library. Generate the mkdocs.yml, nav structure, and a Getting Started page.
+```
+
+```
+Write a developer getting-started guide for onboarding to this platform. Target: engineers new to the team, no prior Kubernetes experience.
+```
+
+---
+
+### mcp — scaffold, review, debug MCP servers
+
+```
+Scaffold a TypeScript MCP server that exposes two tools: one to list files in a directory and one to read a file. Use the official @modelcontextprotocol/sdk.
+```
+
+```
+Review this MCP server implementation for security issues — input validation, path traversal risks, and error handling.
+[paste server code]
+```
+
+```
+My MCP server tool is returning the wrong schema. How do I debug the tool registration and validate the schema against the MCP spec?
+```
+
+```
+Generate a Python MCP server using the fastmcp library that wraps the GitHub REST API. Include authentication via personal access token.
+```
+
+---
+
+### triage — classify, fix, reply to, and resolve PR comments
+
+```
+Triage PR comment #123456789 on PR 42. Classify as ACTIONABLE_FIX / INFORMATIONAL / NOT_APPLICABLE. If actionable, apply the minimal fix, commit, and resolve the thread.
+```
+
+```
+Triage all unresolved comments on PR 42 in one pass.
+/platform-skills:triage --all 42
+```
+
+```
+This reviewer comment says my IAM policy uses wildcards. Is it a valid finding? If yes, fix it with least-privilege scoping.
+[paste comment text and policy]
+```
+
+```
+Reply to this PR comment explaining why the current replica count is correct, then resolve the thread.
+[paste comment text]
 ```
 
 ---

--- a/examples/commit/README.md
+++ b/examples/commit/README.md
@@ -1,0 +1,98 @@
+# Commit Examples
+
+Status: Stable
+
+Working examples for the `/platform-skills:commit` command — generating, validating, and staging conventional commit messages.
+
+## How the Command Works
+
+```
+/platform-skills:commit analyze
+/platform-skills:commit generate
+/platform-skills:commit stage
+/platform-skills:commit validate "fix(auth): handle token expiry on refresh"
+```
+
+Claude:
+1. Reads staged or unstaged git diff
+2. Classifies the change type (`feat`, `fix`, `refactor`, `chore`, `ci`, `docs`, `test`, `perf`)
+3. Drafts a subject line: `<type>(<scope>): <imperative WHY, ≤72 chars>`
+4. Optionally stages related files and commits
+5. Validates an existing message against Conventional Commits 1.0.0 spec
+
+Never adds `Co-authored-by: Claude` or any AI attribution.
+
+---
+
+## Examples
+
+### good-commit-message.txt
+
+A correctly formatted conventional commit message with body and footer.
+
+**Before (vague message):**
+```
+Fix: updated auth service
+```
+
+**After (`/platform-skills:commit validate`):**
+```
+❌ Subject must use lowercase type — "Fix" is not valid
+❌ Missing scope — use fix(auth): or fix(service):
+❌ Description starts with past tense "updated" — use imperative: "handle"
+❌ Missing blank line between subject and body
+
+Suggested: fix(auth): handle token expiry on silent refresh
+```
+
+**Valid form:**
+```
+fix(auth): handle token expiry on silent refresh
+
+When the access token expires during a background refresh, the service
+was returning 401 instead of retrying with the refresh token. This caused
+session loss on long-lived tabs.
+
+Resolves: #142
+```
+
+---
+
+### diff-to-commit.diff
+
+A representative git diff showing multiple related changes to a single concern.
+
+```diff
+diff --git a/src/auth/refresh.ts b/src/auth/refresh.ts
+index a1b2c3d..e4f5a6b 100644
+--- a/src/auth/refresh.ts
++++ b/src/auth/refresh.ts
+@@ -12,6 +12,10 @@ export async function refreshToken(token: string): Promise<string> {
+   const response = await fetch('/api/auth/refresh', {
+     method: 'POST',
+     body: JSON.stringify({ token }),
+   });
++  if (response.status === 401) {
++    clearSession();
++    throw new TokenExpiredError('Refresh token expired — session cleared');
++  }
+   return response.json();
+ }
+```
+
+**Generated commit message:**
+```
+fix(auth): clear session and raise on expired refresh token
+
+Previously a 401 from /api/auth/refresh was silently swallowed, leaving
+the user with an invalid session. Now clears the session and raises
+TokenExpiredError so callers can redirect to login.
+```
+
+---
+
+## See Also
+
+- [commands/commit.md](../../commands/commit.md) — full command definition with all modes
+- [references/conventional-commits.md](../../references/conventional-commits.md) — Conventional Commits 1.0.0 spec and tooling
+- [examples/conventional-commits/](../conventional-commits/) — commitlint and commitizen configuration examples

--- a/examples/commit/good-commit-message.txt
+++ b/examples/commit/good-commit-message.txt
@@ -1,0 +1,7 @@
+fix(auth): handle token expiry on silent refresh
+
+When the access token expires during a background refresh, the service
+was returning 401 instead of retrying with the refresh token. This caused
+session loss on long-lived tabs where the user hadn't interacted for >1h.
+
+Resolves: #142

--- a/examples/linux-networking/README.md
+++ b/examples/linux-networking/README.md
@@ -1,0 +1,150 @@
+# Linux & Networking Examples
+
+Status: Stable
+
+Working examples for the `/platform-skills:linux` command — DNS troubleshooting, load balancer diagnostics, VPC connectivity, process and disk analysis, and Kubernetes networking.
+
+## How the Command Works
+
+```
+/platform-skills:linux dns
+/platform-skills:linux lb
+/platform-skills:linux vpc
+/platform-skills:linux process
+/platform-skills:linux disk
+/platform-skills:linux network
+/platform-skills:linux security-groups
+```
+
+---
+
+## Examples
+
+### dns-troubleshooting.sh
+
+Step-by-step DNS resolution diagnostics inside and outside Kubernetes.
+
+```bash
+#!/usr/bin/env bash
+# DNS resolution path for Kubernetes pod → service
+
+# 1. Check if CoreDNS pods are running
+kubectl get pods -n kube-system -l k8s-app=kube-dns
+
+# 2. Confirm the service exists
+kubectl get svc payments-service -n checkout
+
+# 3. Test resolution from inside a pod
+kubectl run -it --rm debug --image=busybox:1.36 --restart=Never -- sh
+# Inside pod:
+nslookup payments-service.checkout.svc.cluster.local
+# Expected: returns ClusterIP
+
+# 4. Check /etc/resolv.conf inside the pod
+cat /etc/resolv.conf
+# Expected: search checkout.svc.cluster.local svc.cluster.local cluster.local
+
+# 5. Check CoreDNS config
+kubectl get configmap coredns -n kube-system -o yaml
+
+# 6. Check CoreDNS logs for query errors
+kubectl logs -n kube-system -l k8s-app=kube-dns --tail=50
+
+# 7. Test external resolution (confirms CoreDNS forward is working)
+nslookup google.com
+```
+
+**Common failure causes:**
+
+| Symptom | Most likely cause | Evidence command |
+|---|---|---|
+| `nslookup` returns `NXDOMAIN` | Service name or namespace wrong in query | `kubectl get svc -A \| grep <name>` |
+| `nslookup` times out | CoreDNS pods not running or crashing | `kubectl get pods -n kube-system -l k8s-app=kube-dns` |
+| External DNS fails but internal works | CoreDNS forward config missing or wrong | `kubectl get configmap coredns -n kube-system -o yaml` |
+| Intermittent resolution failures | CoreDNS memory/CPU limit hit | `kubectl top pods -n kube-system -l k8s-app=kube-dns` |
+
+---
+
+### alb-502-diagnostic.sh
+
+Diagnosing 502 Bad Gateway from an AWS Application Load Balancer when target group shows healthy.
+
+```bash
+#!/usr/bin/env bash
+# ALB 502 diagnostic — target group healthy but 502 returned
+
+# 1. Confirm target health (look for "healthy" state)
+aws elbv2 describe-target-health \
+  --target-group-arn arn:aws:elasticloadbalancing:eu-central-1:123456789:targetgroup/orders/abc123
+
+# 2. Check ALB access logs for error detail (must have access logging enabled)
+# Filter for 502 responses in the last 5 minutes
+aws s3 sync s3://my-alb-logs/AWSLogs/123456789/elasticloadbalancing/eu-central-1/$(date +%Y/%m/%d)/ ./alb-logs/
+grep " 502 " ./alb-logs/*.log | tail -20
+
+# 3. Check security group: ALB must reach the pod/node on the target port
+aws ec2 describe-security-groups --group-ids sg-alb-id sg-node-id
+
+# 4. Check the app is actually listening on the expected port
+kubectl exec -it <pod-name> -n orders -- ss -tlnp | grep 8080
+
+# 5. Check pod logs for connection reset or timeout errors
+kubectl logs -n orders -l app=orders-api --tail=100 | grep -i "reset\|timeout\|refused"
+
+# 6. Check if the pod readiness probe is passing
+kubectl describe pod -n orders -l app=orders-api | grep -A5 "Readiness"
+```
+
+**502 root causes in order of frequency:**
+
+1. App not listening on the registered port (wrong `containerPort` or env var override)
+2. Security group blocks ALB → node traffic on the NodePort range
+3. App returns a response before headers are complete (HTTP/1.0 vs 1.1 mismatch)
+4. TLS termination mismatch (ALB expects HTTP, pod returns HTTPS)
+5. Readiness probe path wrong — pod marked healthy before app is ready
+
+---
+
+### vpc-connectivity.sh
+
+Diagnosing connectivity between two VPCs connected via VPC peering or Transit Gateway.
+
+```bash
+#!/usr/bin/env bash
+# VPC peering connectivity checklist
+
+# 1. Confirm peering connection is active
+aws ec2 describe-vpc-peering-connections \
+  --filters "Name=status-code,Values=active"
+
+# 2. Check route tables on BOTH sides — missing route is the most common cause
+# VPC A route table (should have route to VPC B CIDR)
+aws ec2 describe-route-tables --filters "Name=vpc-id,Values=vpc-aaa" \
+  --query 'RouteTables[*].Routes[?GatewayId!=`local`]'
+
+# VPC B route table (should have route to VPC A CIDR)
+aws ec2 describe-route-tables --filters "Name=vpc-id,Values=vpc-bbb" \
+  --query 'RouteTables[*].Routes[?GatewayId!=`local`]'
+
+# 3. Check security groups allow inbound traffic on the target port
+aws ec2 describe-security-groups --group-ids sg-target \
+  --query 'SecurityGroups[*].IpPermissions'
+
+# 4. Check NACLs — stateless, so both inbound AND outbound rules must allow traffic
+aws ec2 describe-network-acls \
+  --filters "Name=vpc-id,Values=vpc-bbb"
+
+# 5. Use VPC Reachability Analyzer to confirm path
+aws ec2 create-network-insights-path \
+  --source <source-eni-id> \
+  --destination <dest-eni-id> \
+  --protocol tcp \
+  --destination-port 8080
+```
+
+---
+
+## See Also
+
+- [commands/linux.md](../../commands/linux.md) — full command definition with all modes and diagnostics
+- [references/linux-networking.md](../../references/linux-networking.md) — DNS, load balancer, VPC/VNet, and process reference patterns

--- a/examples/linux-networking/dns-troubleshooting.sh
+++ b/examples/linux-networking/dns-troubleshooting.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# DNS resolution diagnostic script for Kubernetes pods
+# Usage: Run from a machine with kubectl access
+# Adjust NAMESPACE, SERVICE, and POD_SELECTOR for your environment.
+
+NAMESPACE="${1:-checkout}"
+SERVICE="${2:-payments-service}"
+
+echo "=== Step 1: CoreDNS pod health ==="
+kubectl get pods -n kube-system -l k8s-app=kube-dns
+
+echo ""
+echo "=== Step 2: Service exists in namespace ==="
+kubectl get svc "$SERVICE" -n "$NAMESPACE" || echo "MISSING: service $SERVICE not found in $NAMESPACE"
+
+echo ""
+echo "=== Step 3: CoreDNS configmap ==="
+kubectl get configmap coredns -n kube-system -o yaml
+
+echo ""
+echo "=== Step 4: CoreDNS recent logs (last 50 lines) ==="
+kubectl logs -n kube-system -l k8s-app=kube-dns --tail=50
+
+echo ""
+echo "=== Step 5: Test resolution from debug pod ==="
+echo "Run manually inside the cluster:"
+echo "  kubectl run -it --rm debug --image=busybox:1.36 --restart=Never -- nslookup ${SERVICE}.${NAMESPACE}.svc.cluster.local"
+
+echo ""
+echo "=== Step 6: CoreDNS resource usage ==="
+kubectl top pods -n kube-system -l k8s-app=kube-dns 2>/dev/null || echo "metrics-server not available"

--- a/examples/product/README.md
+++ b/examples/product/README.md
@@ -1,0 +1,165 @@
+# Product Examples
+
+Status: Stable
+
+Working examples for the `/platform-skills:product` command — DevEx audits, RFC/ADR drafts, incident updates, and post-mortems.
+
+## How the Command Works
+
+```
+/platform-skills:product devex
+/platform-skills:product rfc
+/platform-skills:product adr
+/platform-skills:product incident
+/platform-skills:product postmortem
+/platform-skills:product capacity
+```
+
+---
+
+## Examples
+
+### post-mortem-template.md
+
+A blameless post-mortem following the standard structure: timeline, impact, root cause, contributing factors, action items.
+
+**Scenario:** Database failover at 02:15 UTC caused 18 minutes of checkout downtime. Root cause: missing health check on standby replica.
+
+```markdown
+# Post-Mortem: Checkout Downtime — 2026-05-12
+
+**Severity:** P1  
+**Duration:** 18 minutes (02:15–02:33 UTC)  
+**Services affected:** checkout-api, payments-service  
+**On-call:** @alice
+
+## Impact
+
+- 100% of checkout requests failed for 18 minutes
+- Estimated 2,400 failed transactions
+- No data loss — all in-flight orders rolled back via idempotency keys
+
+## Timeline
+
+| Time (UTC) | Event |
+|---|---|
+| 02:15 | Primary RDS instance fails; automatic failover initiates |
+| 02:17 | Failover completes — standby promoted to primary |
+| 02:17 | checkout-api health checks fail — standby not accepting connections |
+| 02:18 | PagerDuty alert fires |
+| 02:22 | On-call acknowledges, starts investigation |
+| 02:28 | Root cause identified: pg_hba.conf not replicated to standby |
+| 02:33 | pg_hba.conf copied, connections restored, traffic recovers |
+
+## Root Cause
+
+The standby replica was promoted but its `pg_hba.conf` lacked the `checkout-api` service account entry. PostgreSQL rejected all connections from the application.
+
+## Contributing Factors
+
+- Standby configuration was not validated as part of the RDS module
+- No automated failover drill had been run in 8 months
+- Health check timeout was 30s — alert fired 3 minutes after failure
+
+## Action Items
+
+| Action | Owner | Due |
+|---|---|---|
+| Add pg_hba.conf validation to Terraform RDS module | @alice | 2026-05-19 |
+| Run quarterly failover drill and document in runbook | @bob | 2026-06-01 |
+| Reduce health check timeout from 30s to 10s | @alice | 2026-05-14 |
+| Add runbook link to PagerDuty alert | @carol | 2026-05-14 |
+
+## What Went Well
+
+- Idempotency keys prevented duplicate charges
+- On-call reached root cause within 6 minutes of acknowledgement
+- Rollback was safe — no manual data intervention needed
+```
+
+---
+
+### rfc-template.md
+
+An RFC for a significant platform change requiring cross-team review.
+
+**Scenario:** Migrating from Argo CD to Flux CD across 15 teams.
+
+```markdown
+# RFC: Migrate from Argo CD to Flux CD
+
+**Status:** Draft  
+**Author:** @platform-team  
+**Reviewers:** @alice, @bob, @dave  
+**Decision by:** 2026-06-15
+
+## Problem
+
+Argo CD and Flux CD are both active in production, managing overlapping namespaces. This creates dual-reconciler conflicts, unclear ownership, and duplicated platform effort.
+
+## Proposed Solution
+
+Standardise on Flux CD for all in-cluster GitOps. Migrate 15 teams over 8 weeks using a parallel-run approach.
+
+## Migration Plan
+
+| Week | Scope |
+|---|---|
+| 1–2 | Bootstrap Flux on all clusters alongside Argo CD |
+| 3–4 | Migrate platform add-ons (cert-manager, ingress, Linkerd) |
+| 5–6 | Migrate application teams in waves (4 teams/wave) |
+| 7 | Decommission Argo CD ApplicationSets |
+| 8 | Remove Argo CD Helm release and CRDs |
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Flux and Argo CD reconcile same resource simultaneously | Set Argo CD app to `ignoreDifferences` for migrated resources during cutover |
+| Team GitOps repos need restructuring | Provide migration script and 1:1 pairing sessions |
+| Flux outage during migration | Keep Argo CD as fallback until week 7 |
+
+## Alternatives Considered
+
+- Keep Argo CD only: Flux is already managing platform add-ons; migration overhead is lower than maintaining both.
+- Keep both permanently: dual-reconciler conflicts are unsustainable at scale.
+```
+
+---
+
+### adr-template.md
+
+An Architecture Decision Record for a narrower, already-decided choice.
+
+```markdown
+# ADR-012: Use External Secrets Operator for Secret Injection
+
+**Date:** 2026-04-10  
+**Status:** Accepted  
+**Deciders:** Platform team
+
+## Context
+
+Applications need access to secrets stored in AWS Secrets Manager. Options evaluated:
+1. Mount secrets as environment variables via Kubernetes Secrets committed to Git
+2. Use AWS Secrets Manager CSI driver
+3. Use External Secrets Operator (ESO)
+
+## Decision
+
+Use External Secrets Operator (ESO) with `ClusterSecretStore` backed by AWS Secrets Manager.
+
+## Consequences
+
+- **Good:** ESO rotates secrets automatically on a configurable schedule; no manual Kubernetes Secret updates.
+- **Good:** Secret values never appear in Git or Terraform state.
+- **Bad:** ESO adds an operator dependency; must be managed as a platform component.
+- **Neutral:** Application teams write `ExternalSecret` CRDs instead of referencing existing Secrets.
+```
+
+---
+
+## See Also
+
+- [commands/product.md](../../commands/product.md) — full command definition with all modes
+- [references/platform-operating-model.md](../../references/platform-operating-model.md) — platform product thinking and operating model

--- a/examples/product/post-mortem-template.md
+++ b/examples/product/post-mortem-template.md
@@ -1,0 +1,73 @@
+# Post-Mortem: [Service] [Incident Type] — [Date]
+
+Status: Stable
+
+**Severity:** P1 / P2 / P3
+**Duration:** N minutes (HH:MM–HH:MM UTC)
+**Services affected:** service-a, service-b
+**On-call:** @engineer
+
+---
+
+## Impact
+
+- Quantify user-facing impact (% requests failed, affected users, failed transactions)
+- Note any data integrity impact
+- Note any financial impact estimate
+
+---
+
+## Timeline
+
+| Time (UTC) | Event |
+|---|---|
+| HH:MM | [First symptom observed] |
+| HH:MM | [Alert fired] |
+| HH:MM | [On-call acknowledged] |
+| HH:MM | [Root cause identified] |
+| HH:MM | [Mitigation applied] |
+| HH:MM | [Full recovery confirmed] |
+
+---
+
+## Root Cause
+
+One sentence describing the technical root cause. Follow with supporting evidence (log lines, metrics, traces).
+
+---
+
+## Contributing Factors
+
+- Factor 1 (e.g., missing health check on standby)
+- Factor 2 (e.g., no quarterly failover drill)
+- Factor 3 (e.g., alert timeout too long)
+
+---
+
+## Action Items
+
+| Action | Owner | Due |
+|---|---|---|
+| [Specific, measurable action] | @owner | YYYY-MM-DD |
+| [Specific, measurable action] | @owner | YYYY-MM-DD |
+
+---
+
+## What Went Well
+
+- [Thing that worked as expected]
+- [Effective process or tooling]
+
+---
+
+## Detection
+
+How was this incident detected? (alert, user report, on-call observation)
+How long after the start of impact was it detected? What would reduce this?
+
+---
+
+## See Also
+
+- [commands/product.md](../../commands/product.md) — full post-mortem and RFC command definition
+- [references/platform-operating-model.md](../../references/platform-operating-model.md) — incident communication patterns

--- a/references/platform-operating-model.md
+++ b/references/platform-operating-model.md
@@ -89,3 +89,63 @@ Apply these defaults:
 - Policy: Run Terraform and Kubernetes policy checks in CI before merge.
 - Observability: Platform repos should define baseline metrics, logs, alerts, and ownership metadata.
 - Governance: Use CODEOWNERS and protected branches to separate approval paths for foundations versus app delivery.
+
+## Secrets ownership
+
+Secrets span every layer. Keep ownership clean:
+
+| Layer | Owns | Does NOT Own |
+|---|---|---|
+| Terraform | Secrets backends (Vault, AWS Secrets Manager), KMS keys, IAM policies for secret access | Secret values, application-level credentials |
+| External Secrets Operator / Secrets Store CSI | Rendering secrets into Kubernetes from the secrets backend at runtime | Managing the backing store or rotating credentials |
+| Kubernetes | `Secret` objects created by ESO/CSI — ephemeral, never committed to Git | Long-lived secrets in Git |
+| Application | Reading secrets via env vars or mounted files — never logging or serialising them | Anything in the platform layer |
+
+Decision rules:
+- Secret values never appear in Git, Terraform state, or CI logs.
+- Use ESO `ExternalSecret` or Secrets Store CSI `SecretProviderClass` — not `kubectl create secret` in pipelines.
+- Rotate via the secrets backend, not by patching Kubernetes Secrets directly.
+- See `references/secrets.md` for ESO patterns and Vault integration examples.
+
+## Observability ownership
+
+Define which layer owns each signal so gaps don't fall between teams:
+
+| Signal | Owner | Tool examples |
+|---|---|---|
+| Cluster infrastructure metrics (node CPU, memory, disk) | Platform team | kube-state-metrics, node-exporter, CloudWatch, Azure Monitor |
+| Workload RED metrics (rate, error, duration) | Application team | Prometheus client libs, OpenTelemetry SDK |
+| Distributed traces | Application team | OpenTelemetry, Datadog APM, Dynatrace |
+| Structured logs | Application team | JSON to stdout; platform routes to log aggregator |
+| Alerting rules and SLOs | Joint ownership — platform defines baseline, app teams own service-level alerts | Prometheus alertmanager, Datadog monitors, Dynatrace Davis |
+| Dashboards | Application team per service; platform team for shared infrastructure boards | Grafana, Datadog, Dynatrace |
+
+Platform team responsibility:
+- Provision and operate the observability stack (Prometheus, Grafana, Loki, or Datadog/Dynatrace agents).
+- Publish a baseline `PrometheusRule` and `ServiceMonitor` template for new services.
+- Own the alertmanager / notification routing configuration.
+
+See `references/observability.md` for instrumentation patterns.
+
+## Cost allocation and tagging
+
+Enforce tagging at the Terraform layer before resources are created:
+
+```hcl
+# Required on every aws_* resource
+locals {
+  required_tags = {
+    "env"        = var.environment          # dev | staging | production
+    "team"       = var.team                 # platform | checkout | payments
+    "service"    = var.service_name         # human-readable service identifier
+    "managed-by" = "terraform"
+    "repo"       = var.repo_url
+  }
+}
+```
+
+Decision rules:
+- Enforce with a Checkov or tfsec custom rule in CI — fail the plan if required tags are missing.
+- Map tags to cost allocation keys in AWS Cost Explorer or Azure Cost Management.
+- Use a Kyverno `MutatingPolicy` to enforce matching labels (`app.kubernetes.io/team`, `app.kubernetes.io/part-of`) on Kubernetes workloads so cost can be attributed at the namespace or workload level.
+- Review cost impact as part of every infrastructure PR — see `references/pr-review.md` → cost mode.

--- a/tests/handbook-consistency.sh
+++ b/tests/handbook-consistency.sh
@@ -93,4 +93,20 @@ for pattern in "${STALE_LINK_PATTERNS[@]}"; do
   fi
 done
 
+echo "Checking command count consistency..."
+EXPECTED_COUNT=20
+COUNT_DOCS=(
+  "GETTING_STARTED.md"
+  "QUICKSTART.md"
+  "CHANGELOG.md"
+)
+for doc in "${COUNT_DOCS[@]}"; do
+  if grep -q "$EXPECTED_COUNT command" "$doc" || grep -q "all $EXPECTED_COUNT" "$doc" || grep -q "$EXPECTED_COUNT workflow" "$doc"; then
+    echo "✅ $doc references $EXPECTED_COUNT commands"
+  else
+    echo "❌ $doc does not reference $EXPECTED_COUNT commands — stale count?"
+    exit 1
+  fi
+done
+
 echo "✅ Handbook consistency checks passed"


### PR DESCRIPTION
## Summary

- **High: `copilot-instructions.md` stale at 1.12.0, KEDA missing** — bumped to 1.14.0; added full KEDA section (ScaledObject example, IRSA rules, `cooldownPeriod` vs `stabilizationWindowSeconds` distinction, never-generate list); added `references/keda.md` to the Reference Files list; added KEDA to the domain scope line.

- **High: Wiki command counts say 19** — updated `Home.md` and `Commands.md` to 20 (pushed directly to wiki repo).

- **Medium: `EDITOR_INTEGRATIONS.md` missing 6 command sections** — count updated 19→20; added sections for `linkerd`, `linux`, `datadog`, `dynatrace`, `document`, `mcp`, and `triage`, each with 4 representative Copilot Chat prompts.

- **Medium: 4 commands had no `examples/` directory** — created `examples/commit/`, `examples/product/`, `examples/linux-networking/` with README and concrete example files (the `examples/documentation/` directory already existed).

- **Medium: `platform-operating-model.md` missing cross-cutting sections** — added Secrets ownership (layer decision table), Observability ownership (signal-to-owner table), and Cost allocation and tagging (Terraform tag pattern + enforcement guidance).

- **Low: `handbook-consistency.sh` no count guard** — added command count check that validates GETTING_STARTED.md, QUICKSTART.md, and CHANGELOG.md all reference the expected count (20), failing CI if they drift.

## Test plan

- [ ] `bash tests/handbook-consistency.sh` — passes including new count guard
- [ ] `bash tests/validate-skill.sh` — all checks pass
- [ ] `bash tests/validate-helmcheck.sh` — all checks pass
- [ ] Verify `.github/copilot-instructions.md` says `Version: 1.14.0` and has a KEDA section
- [ ] Verify `EDITOR_INTEGRATIONS.md` has sections for all 20 commands
- [ ] Verify `examples/commit/`, `examples/product/`, `examples/linux-networking/` each have a README and at least one example file