### PR TITLE
feat: supply chain security + runtime security skills — v1.16.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.15.0",
-      "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP server development, observability (Prometheus/OpenTelemetry/Grafana), code documentation (OpenAPI/docstrings), SOC 2 compliance for Terraform, Datadog, Dynatrace, conventional commit message generation, OPA/Conftest Rego policies, Kyverno admission policies (ValidatingPolicy/MutatingPolicy/GeneratingPolicy/ImageValidatingPolicy, CEL expressions, Audit→Deny promotion), comprehensive PR review (cost impact, environment drift, ownership governance, compliance, deprecated API upgrade, rollback feasibility), PR comment triage, and KEDA event-driven autoscaling (ScaledObject, ScaledJob, TriggerAuthentication, Prometheus/SQS/Kafka/Redis/Cron/HTTP/Azure scalers, scale-to-zero, IRSA). Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
+      "version": "1.16.0",
+      "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP server development, observability (Prometheus/OpenTelemetry/Grafana), code documentation (OpenAPI/docstrings), SOC 2 compliance for Terraform, Datadog, Dynatrace, conventional commit message generation, OPA/Conftest Rego policies, Kyverno admission policies (ValidatingPolicy/MutatingPolicy/GeneratingPolicy/ImageValidatingPolicy, CEL expressions, Audit→Deny promotion), comprehensive PR review (cost impact, environment drift, ownership governance, compliance, deprecated API upgrade, rollback feasibility), PR comment triage, KEDA event-driven autoscaling (ScaledObject, ScaledJob, TriggerAuthentication, Prometheus/SQS/Kafka/Redis/Cron/HTTP/Azure scalers, scale-to-zero, IRSA), supply chain security (Cosign keyless signing, Syft SBOM, Trivy/Grype CVE gates, SLSA Level 2, Kyverno ImageValidatingPolicy enforcement), and Kubernetes runtime security (Falco eBPF, custom rules, Falcosidekick alert routing, Kyverno bridge). Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
       "author": {
         "name": "Nitin Jain"
       },
@@ -107,7 +107,16 @@
         "sqs-scaler",
         "kafka-scaler",
         "prometheus-scaler",
-        "cron-scaler"
+        "cron-scaler",
+        "supply-chain-security",
+        "cosign",
+        "sbom",
+        "trivy",
+        "slsa",
+        "falco",
+        "runtime-security",
+        "ebpf",
+        "threat-detection"
       ],
       "source": {
         "source": "url",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-skills",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Practical guidance for platform engineers: Kubernetes, Kyverno admission policies, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP development, observability, code documentation, SOC 2 compliance, comprehensive PR review, PR comment triage, and KEDA event-driven autoscaling.",
   "author": {
     "name": "Nitin Jain",
@@ -50,7 +50,22 @@
     "scaledobject",
     "scaledjob",
     "autoscaling",
-    "scale-to-zero"
+    "scale-to-zero",
+    "supply-chain-security",
+    "image-signing",
+    "cosign",
+    "sigstore",
+    "sbom",
+    "syft",
+    "trivy",
+    "grype",
+    "slsa",
+    "runtime-security",
+    "falco",
+    "falcosidekick",
+    "ebpf",
+    "syscall-monitoring",
+    "threat-detection"
   ],
   "skills": [
     "./skills/platform-skills"
@@ -76,6 +91,8 @@
     "./commands/pr-review.md",
     "./commands/triage.md",
     "./commands/keda.md",
-    "./commands/self-improve.md"
+    "./commands/self-improve.md",
+    "./commands/supply-chain.md",
+    "./commands/runtime-security.md"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ _site/
 .learnings/
 memory/working-buffer.md
 .learnings/.pending-errors.log
+docs/superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-05-20
+
+### Added
+
+#### Supply Chain Security — Domain 25
+
+New Domain 25: `Supply Chain Security` — secure the build pipeline and image lifecycle.
+
+- `references/supply-chain.md` — comprehensive reference covering:
+  - Cosign keyless signing (Sigstore/Rekor, OIDC-based, no key management)
+  - SBOM generation and OCI attestation with Syft
+  - CVE scanning with Trivy and Grype, severity gate strategy
+  - SLSA Level 2 vs Level 3 provenance requirements
+  - Kyverno `ImageValidatingPolicy` for admission enforcement
+  - Gap classification table and recommended rollout order
+- `commands/supply-chain.md` — slash command `/platform-skills:supply-chain` with six modes: `audit`, `sign`, `sbom`, `scan`, `enforce`, `slsa`
+- `examples/supply-chain/` — five working GitHub Actions workflows and one Kyverno policy:
+  - `sign-and-push.yaml` — build → Cosign keyless sign → push
+  - `sbom-attest.yaml` — Syft SBOM generation and Cosign attestation
+  - `trivy-gate.yaml` — Trivy scan with CRITICAL+HIGH severity gate and GitHub Security tab upload
+  - `kyverno-verify-image.yaml` — `ImageValidatingPolicy` blocking unsigned images (Audit mode)
+  - `slsa-provenance.yaml` — SLSA Level 2 provenance via `slsa-github-generator`
+  - `supply-chain-validate.sh` — domain validator
+
+#### Runtime Security — Domain 26
+
+New Domain 26: `Runtime Security` — detect in-container threats with Falco.
+
+- `references/runtime-security.md` — comprehensive reference covering:
+  - Falco architecture: eBPF probe, rules engine, alert output
+  - Driver comparison: `modern_ebpf` vs `ebpf` vs `kmod` (kmod never on managed K8s)
+  - EKS and GKE installation with eBPF (Bottlerocket, COS, Fargate caveats)
+  - Built-in ruleset overview and noise reduction approach
+  - Custom rule syntax: condition fields, lists, macros
+  - Falcosidekick alert routing: Slack, webhook, SNS, PagerDuty
+  - Falco → Kyverno bridge pattern for blocking flagged workload re-admission
+  - Resource sizing and CPU limit guidance (do not set CPU limits)
+- `commands/runtime-security.md` — slash command `/platform-skills:runtime-security` with five modes: `install`, `rules`, `alerts`, `debug`, `harden`
+- `examples/runtime-security/` — four working Helm values and one Kyverno policy:
+  - `falco-values.yaml` — Falco Helm values with eBPF driver and resource limits
+  - `falco-custom-rules.yaml` — shell-in-container, privilege escalation, unexpected outbound
+  - `falcosidekick-values.yaml` — Slack + webhook routing with deduplication
+  - `falco-kyverno-bridge.yaml` — `ValidatingPolicy` blocking Falco-flagged workload re-admission
+  - `runtime-security-validate.sh` — domain validator
+
 ## [1.15.0] - 2026-05-20
 
 ### Added

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1789,6 +1789,83 @@ Reference: `commands/self-improve.md`, `references/agent-self-improve.md`, and `
 
 ---
 
+## `/platform-skills:supply-chain`
+
+Secure the software supply chain from build pipeline to running container.
+
+**Modes**
+
+| Mode | What it does |
+|---|---|
+| `audit` | Review an existing pipeline for supply chain security gaps |
+| `sign` | Walk through Cosign keyless signing setup (Sigstore/Rekor, no key management) |
+| `sbom` | Generate and attest an SBOM with Syft |
+| `scan` | Trivy or Grype CVE scan with configurable severity gate |
+| `enforce` | Generate Kyverno `ImageValidatingPolicy` to block unsigned images at admission |
+| `slsa` | SLSA Level 2 provenance via `slsa-github-generator` GitHub Actions reusable workflow |
+
+**Usage**
+
+```
+/platform-skills:supply-chain audit
+/platform-skills:supply-chain sign
+/platform-skills:supply-chain sbom
+/platform-skills:supply-chain scan
+/platform-skills:supply-chain enforce
+/platform-skills:supply-chain slsa
+[paste workflow YAML or describe your registry/CI setup]
+```
+
+**Key rules enforced**
+
+- Never store signing keys in CI — use keyless (OIDC + Rekor) only
+- Always sign the digest (`@sha256:…`), never the tag
+- Pin all action versions to SHA, not tag
+- Gate on CRITICAL+HIGH by default; document exceptions
+- Deploy Kyverno `ImageValidatingPolicy` in Audit mode first, then Deny
+
+Reference: `references/supply-chain.md` and `examples/supply-chain/`
+
+---
+
+## `/platform-skills:runtime-security`
+
+Detect and respond to in-container threats at the syscall level using Falco.
+
+**Modes**
+
+| Mode | What it does |
+|---|---|
+| `install` | Deploy Falco on EKS/GKE with eBPF driver via Helm |
+| `rules` | Write and unit-test custom Falco rules |
+| `alerts` | Configure Falcosidekick to route alerts to Slack, PagerDuty, or webhook |
+| `debug` | Diagnose why a Falco rule is not firing |
+| `harden` | Map Falco alert metadata to Kyverno admission enforcement |
+
+**Usage**
+
+```
+/platform-skills:runtime-security install
+/platform-skills:runtime-security rules
+[describe the threat you want to detect]
+/platform-skills:runtime-security alerts
+/platform-skills:runtime-security debug
+[paste kubectl logs output from Falco pod]
+/platform-skills:runtime-security harden
+```
+
+**Key rules enforced**
+
+- Always use eBPF driver on managed Kubernetes — never kernel module
+- Never run Falco as a sidecar — must be a DaemonSet
+- Do not set CPU limits on Falco DaemonSet — event processing is bursty
+- Set `minimumpriority: warning` for Slack routing; suppress DEBUG/INFO noise
+- Test every custom rule with `falco-event-generator` before production
+
+Reference: `references/runtime-security.md` and `examples/runtime-security/`
+
+---
+
 ## Tips for best results
 
 **Paste context** — paste the manifest, error output, plan output, or code block directly after the command. The more concrete the input, the more actionable the output.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -159,6 +159,8 @@ See [COMMANDS.md](COMMANDS.md) for every command with modes and example prompts:
 | `triage` | Use `/platform-skills:triage` to classify, fix, reply to, and resolve PR comments |
 | `keda` | Use `/platform-skills:keda` to generate, debug, review, or design a KEDA scaling strategy |
 | `self-improve` | Bootstrap `.learnings/` workspace, log errors and learnings, resume after interruption, promote to project memory |
+| `supply-chain` | Sign images, generate SBOMs, run CVE gates, enforce image signatures, generate SLSA provenance |
+| `runtime-security` | Deploy Falco with eBPF, write custom rules, route alerts, debug rule firing, bridge to Kyverno |
 
 ### How the agent and skill system work
 

--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -109,6 +109,8 @@ Slash commands are predefined workflows. Use them instead of writing a long prom
 | `/platform-skills:triage` | Triage a PR comment, fix valid findings, reply, and resolve the thread |
 | `/platform-skills:keda` | KEDA ScaledObject/ScaledJob — generate, debug, review, or design a scaling strategy |
 | `/platform-skills:self-improve` | Bootstrap `.learnings/` workspace, log errors/learnings, resume after interruption, review patterns, promote to project memory |
+| `/platform-skills:supply-chain` | Sign images, generate SBOMs, run CVE gates, enforce image signatures, generate SLSA provenance |
+| `/platform-skills:runtime-security` | Deploy Falco with eBPF, write custom rules, route alerts, debug rule firing, bridge to Kyverno |
 
 Invoke a command by typing it at the start of your message:
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -60,7 +60,7 @@ claude plugin install platform-skills
 
 ```bash
 claude plugin list
-# platform-skills  v1.15.0  enabled
+# platform-skills  v1.16.0  enabled
 ```
 
 **Upgrade:**

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platform-skills
-description: Hands-on guidance for platform and DevOps engineers working with Kubernetes, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, compliance, KEDA event-driven autoscaling, and self-improving agent patterns. Use when designing or troubleshooting Kubernetes workloads and RBAC, writing Terraform modules, configuring Flux or Argo CD, setting up CI/CD pipelines, managing cloud identity and IAM, handling secrets, diagnosing DNS or VPC connectivity, operating a service mesh, applying product thinking to developer experience, implementing SOC 2 compliance controls in Terraform, scaling workloads with KEDA scalers (SQS, Kafka, Prometheus, Cron, HTTP), or bootstrapping .learnings/ directories, WAL protocol, VFM scoring, and proactive agent behavior — at any scale, for any team size.
+description: Hands-on guidance for platform and DevOps engineers working with Kubernetes, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, compliance, KEDA event-driven autoscaling, and self-improving agent patterns. Use when designing or troubleshooting Kubernetes workloads and RBAC, writing Terraform modules, configuring Flux or Argo CD, setting up CI/CD pipelines, managing cloud identity and IAM, handling secrets, diagnosing DNS or VPC connectivity, operating a service mesh, applying product thinking to developer experience, implementing SOC 2 compliance controls in Terraform, scaling workloads with KEDA scalers (SQS, Kafka, Prometheus, Cron, HTTP), or bootstrapping .learnings/ directories, WAL protocol, VFM scoring, and proactive agent behavior — at any scale, for any team size, supply chain security (Cosign, Syft, Trivy, SLSA, image signing enforcement), and Kubernetes runtime security (Falco eBPF, custom rules, Falcosidekick alert routing)
 ---
 
 # Platform Skills
@@ -35,6 +35,8 @@ Match the task to the right layer:
 22. `PR Comment Triage`: Triage bot or human PR comments, classify them as ACTIONABLE_FIX / INFORMATIONAL / NOT_APPLICABLE, make the minimal fix when valid, reply on the thread, and resolve it through `gh`.
 23. `KEDA`: Design, generate, debug, and review KEDA ScaledObject and ScaledJob resources. Covers all major scalers (Prometheus, SQS, Kafka, Redis, Cron, HTTP Add-on, Azure Service Bus), TriggerAuthentication with IRSA/Workload Identity, scaling lifecycle tuning, scale-to-zero patterns, and GitOps integration.
 24. `Agent Self-Improvement`: Bootstrap and operate self-improving, proactive agent workspaces. Covers `.learnings/` directory setup, LRN/ERR/FEAT entry lifecycle, recurring pattern detection, promotion to project memory, WAL protocol, working buffer, VFM scoring, ADL decision logic, Six Operating Pillars, heartbeat, and reverse prompting.
+25. `Supply Chain Security`: Secure the build pipeline and image lifecycle with Cosign keyless signing (Sigstore/Rekor), Syft SBOM generation and attestation, Trivy/Grype CVE scanning with severity gates, SLSA Level 2 provenance, and Kyverno ImageValidatingPolicy admission enforcement. All open-source, no license cost.
+26. `Runtime Security`: Detect in-container threats at the syscall level with Falco (eBPF driver, CNCF, no license cost). Covers eBPF driver deployment on EKS/GKE, custom rule authoring, Falcosidekick alert routing to Slack/PagerDuty/webhook, rule debugging, and bridging runtime signals to Kyverno admission enforcement.
 
 If a task spans multiple areas, decide which layer owns the source of truth and keep the other layers consumers of that state.
 
@@ -121,3 +123,5 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:triage` — triage a PR comment (bot or human): classify as ACTIONABLE_FIX / INFORMATIONAL / NOT_APPLICABLE, produce the exact fix if needed, and write the thread reply
 - `/platform-skills:keda` — design, generate, debug, or review KEDA ScaledObject/ScaledJob autoscaling
 - `/platform-skills:self-improve` — bootstrap `.learnings/` directory, log learnings/errors/feature requests, review recurring patterns, and promote entries to project memory
+- `/platform-skills:supply-chain` — sign images, generate and attest SBOMs, run CVE severity gates, enforce image signatures in Kubernetes, and generate SLSA Level 2 provenance
+- `/platform-skills:runtime-security` — deploy Falco with eBPF, write custom rules, route alerts, debug why a rule is not firing, and bridge Falco signals to Kyverno admission enforcement

--- a/SKILL.md
+++ b/SKILL.md
@@ -95,6 +95,8 @@ When asked to generate code, start from the thinnest useful slice that proves th
 - For comprehensive PR review — cost impact, environment drift, ownership gaps, SOC 2 compliance, deprecated APIs, version hygiene, rollback feasibility, and bot comment triage — read [references/pr-review.md](references/pr-review.md).
 - For KEDA event-driven autoscaling — ScaledObject, ScaledJob, TriggerAuthentication, IRSA, scalers (Prometheus, SQS, Kafka, Redis, Cron, HTTP Add-on, Azure Service Bus), scaling lifecycle, security patterns, and troubleshooting — read [references/keda.md](references/keda.md).
 - For agent self-improvement patterns — `.learnings/` directory, WAL protocol, VFM scoring, ADL Protocol, working buffer, and proactive agent behavior — read [references/agent-self-improve.md](references/agent-self-improve.md).
+- For supply chain security — Cosign keyless signing, Syft SBOM generation and attestation, Trivy/Grype CVE scanning, SLSA Level 2 provenance, and Kyverno ImageValidatingPolicy enforcement — read [references/supply-chain.md](references/supply-chain.md).
+- For Kubernetes runtime security — Falco eBPF deployment on EKS/GKE, custom rule authoring, Falcosidekick alert routing, and bridging Falco signals to Kyverno admission enforcement — read [references/runtime-security.md](references/runtime-security.md).
 
 Load only the files needed for the current request.
 

--- a/commands/runtime-security.md
+++ b/commands/runtime-security.md
@@ -98,7 +98,7 @@ Configure Falcosidekick to route Falco alerts to Slack, webhooks, or other outpu
 Steps:
 1. Install Falcosidekick alongside Falco:
    ```bash
-   helm install falco falcosecurity/falco \
+   helm upgrade --install falco falcosecurity/falco \
      --namespace falco \
      --create-namespace \
      --set falcosidekick.enabled=true \
@@ -138,11 +138,13 @@ Checklist (work through in order):
    ```
 2. **Is the rule loaded?**
    ```bash
-   kubectl exec -n falco daemonset/falco -- falco --list-rules | grep "<rule name>"
+   kubectl logs -n falco -l app.kubernetes.io/name=falco | grep -i "Loading rules"
+   kubectl exec -n falco daemonset/falco -- cat /etc/falco/rules.d/custom-rules.yaml 2>/dev/null \
+     || kubectl exec -n falco daemonset/falco -- ls /etc/falco/
    ```
 3. **Is the condition correct?** Test the event type:
    ```bash
-   kubectl exec -n falco daemonset/falco -- falco --validate /etc/falco/custom-rules.yaml
+   kubectl exec -n falco daemonset/falco -- falco --validate /etc/falco/rules.d/custom-rules.yaml
    ```
 4. **Is the event being generated?** Use event-generator for syscall rules:
    ```bash
@@ -151,7 +153,8 @@ Checklist (work through in order):
 5. **Is the priority too low?** If `falcosidekick.config.slack.minimumpriority: error`, rules with `priority: WARNING` are silently dropped. Adjust priority or threshold.
 6. **Is there a macro override?** Check if a built-in macro like `never_true` is shadowing your condition:
    ```bash
-   kubectl exec -n falco daemonset/falco -- falco --list-macros | grep "<macro name>"
+   kubectl exec -n falco daemonset/falco -- cat /etc/falco/falco_rules.yaml | grep -A3 "macro: <macro name>"
+   kubectl exec -n falco daemonset/falco -- ls /etc/falco/rules.d/
    ```
 
 Reference: `references/runtime-security.md` → Troubleshooting

--- a/commands/runtime-security.md
+++ b/commands/runtime-security.md
@@ -1,0 +1,193 @@
+---
+name: runtime-security
+description: Detect and respond to in-container threats at the syscall level using Falco (eBPF-based, CNCF, open-source, no license cost). Covers Falco installation on EKS/GKE with eBPF driver, custom rule authoring, alert routing via Falcosidekick, rule debugging, and bridging Falco runtime signals to Kyverno admission enforcement. Use when asked to "detect privilege escalation in containers", "set up runtime threat detection", "write a Falco rule", "route Falco alerts to Slack", or "debug why my Falco rule is not firing".
+argument-hint: "[install|rules|alerts|debug|harden] [description or symptom]"
+---
+
+Detect and respond to threats inside running containers using Falco.
+
+## Mode: install
+
+Deploy Falco on Kubernetes (EKS or GKE) using the eBPF driver via Helm.
+
+Prerequisites:
+- Helm 3.x
+- `kubectl` access to the target cluster
+- Node OS: Amazon Linux 2/2023 (EKS) or Container-Optimized OS (GKE) — both support eBPF
+
+Steps:
+1. Add the Falco Helm repository:
+   ```bash
+   helm repo add falcosecurity https://falcosecurity.github.io/charts
+   helm repo update
+   ```
+2. Install Falco with eBPF driver (never kernel module on managed K8s):
+   ```bash
+   helm install falco falcosecurity/falco \
+     --namespace falco \
+     --create-namespace \
+     -f examples/runtime-security/falco-values.yaml
+   ```
+3. Verify DaemonSet is running on all nodes:
+   ```bash
+   kubectl rollout status daemonset/falco -n falco
+   kubectl get pods -n falco -o wide
+   ```
+4. Confirm Falco is receiving events:
+   ```bash
+   kubectl logs -n falco -l app.kubernetes.io/name=falco --tail=20
+   ```
+   Expected: lines like `Notice A shell was spawned...` (from the default ruleset test events)
+
+EKS-specific note: if using Bottlerocket nodes, set `driver.kind: modern_ebpf` in Helm values — Bottlerocket does not ship kernel headers for the classic eBPF probe.
+
+GKE-specific note: COS nodes require `driver.kind: modern_ebpf`. GKE Autopilot does not support Falco (no DaemonSet scheduling).
+
+Reference: `references/runtime-security.md` → eBPF driver, Node OS compatibility
+
+## Mode: rules
+
+Write and test custom Falco rules.
+
+Steps:
+1. Explain the rule structure:
+   ```yaml
+   - rule: Shell spawned in container
+     desc: A shell was spawned inside a container — potential interactive intrusion
+     condition: >
+       spawned_process
+       and container
+       and shell_procs
+       and not container.image.repository in (allowed_shell_images)
+     output: >
+       Shell spawned in container
+       (user=%user.name user_id=%user.uid
+        container=%container.name image=%container.image.repository
+        shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline)
+     priority: WARNING
+     tags: [container, shell, mitre_execution]
+   ```
+2. Key condition fields:
+   - `spawned_process` — a new process was exec'd
+   - `container` — event is inside a container (not on the host)
+   - `proc.name` — process name
+   - `container.image.repository` — image name without tag
+   - `fd.net` — network file descriptor (for connection events)
+3. Test with falco-event-generator:
+   ```bash
+   kubectl run event-generator \
+     --image=falcosecurity/event-generator \
+     --restart=Never \
+     --rm -it -- run syscall
+   ```
+   Then check logs: `kubectl logs -n falco -l app.kubernetes.io/name=falco | grep WARNING`
+4. Load custom rules via Helm values:
+   ```yaml
+   customRules:
+     custom-rules.yaml: |-
+       - rule: Shell spawned in container
+         ...
+   ```
+
+Reference: `references/runtime-security.md` → Rule syntax, Condition fields, Lists and macros
+
+## Mode: alerts
+
+Configure Falcosidekick to route Falco alerts to Slack, webhooks, or other outputs.
+
+Steps:
+1. Install Falcosidekick alongside Falco:
+   ```bash
+   helm install falco falcosecurity/falco \
+     --namespace falco \
+     --create-namespace \
+     --set falcosidekick.enabled=true \
+     --set falcosidekick.webui.enabled=true \
+     -f examples/runtime-security/falcosidekick-values.yaml
+   ```
+2. Configure Slack output in Falcosidekick values:
+   ```yaml
+   falcosidekick:
+     config:
+       slack:
+         webhookurl: "https://hooks.slack.com/services/<token>"
+         minimumpriority: warning
+         messageformat: >
+           Alert: *{{ .Rule }}* (Priority: {{ .Priority }})
+           Container: `{{ index .OutputFields "container.name" }}`
+           Image: `{{ index .OutputFields "container.image.repository" }}`
+   ```
+3. Verify alerts are routing:
+   ```bash
+   kubectl port-forward -n falco svc/falco-falcosidekick-ui 2802:2802
+   # Open http://localhost:2802 — events appear in the UI
+   ```
+4. Deduplication: set `slack.minimumpriority: warning` to suppress DEBUG/INFO noise
+
+Reference: `references/runtime-security.md` → Falcosidekick, Output types
+
+## Mode: debug
+
+Diagnose why a Falco rule is not firing.
+
+Checklist (work through in order):
+1. **Is Falco running?**
+   ```bash
+   kubectl get pods -n falco -o wide
+   kubectl logs -n falco -l app.kubernetes.io/name=falco | tail -20
+   ```
+2. **Is the rule loaded?**
+   ```bash
+   kubectl exec -n falco daemonset/falco -- falco --list-rules | grep "<rule name>"
+   ```
+3. **Is the condition correct?** Test the event type:
+   ```bash
+   kubectl exec -n falco daemonset/falco -- falco --validate /etc/falco/custom-rules.yaml
+   ```
+4. **Is the event being generated?** Use event-generator for syscall rules:
+   ```bash
+   kubectl run test --image=falcosecurity/event-generator --rm -it -- run syscall
+   ```
+5. **Is the priority too low?** If `falcosidekick.config.slack.minimumpriority: error`, rules with `priority: WARNING` are silently dropped. Adjust priority or threshold.
+6. **Is there a macro override?** Check if a built-in macro like `never_true` is shadowing your condition:
+   ```bash
+   kubectl exec -n falco daemonset/falco -- falco --list-macros | grep "<macro name>"
+   ```
+
+Reference: `references/runtime-security.md` → Troubleshooting
+
+## Mode: harden
+
+Map Falco runtime alerts to Kyverno admission policies to prevent redeployment of flagged workloads.
+
+Steps:
+1. Explain the bridge pattern: Falco detects a runtime violation → alert metadata is added as a label/annotation to the offending Pod or Deployment → Kyverno admission policy blocks future admission of workloads with that label
+2. Label the offending workload (from an alert webhook handler or manual response):
+   ```bash
+   kubectl label deployment <name> -n <namespace> \
+     security.platform/falco-alert=critical
+   ```
+3. Apply the Kyverno policy to block re-admission:
+   ```yaml
+   apiVersion: policies.kyverno.io/v1
+   kind: ValidatingPolicy
+   metadata:
+     name: block-falco-flagged-workloads
+   spec:
+     validationActions: [Deny]
+     matchConstraints:
+       resourceRules:
+       - apiGroups: ["apps"]
+         apiVersions: ["v1"]
+         operations: ["CREATE", "UPDATE"]
+         resources: ["deployments"]
+     validations:
+     - expression: >
+         !has(object.metadata.labels) ||
+         !('security.platform/falco-alert' in object.metadata.labels) ||
+         object.metadata.labels['security.platform/falco-alert'] != 'critical'
+       message: "Deployment is flagged by a Falco critical alert and cannot be re-admitted. Remove the flag after remediation."
+   ```
+4. Remediation workflow: fix the workload → remove the label → re-admit
+
+Reference: `references/runtime-security.md` → Kyverno bridge, `references/kyverno.md` → ValidatingPolicy

--- a/commands/supply-chain.md
+++ b/commands/supply-chain.md
@@ -1,0 +1,210 @@
+---
+name: supply-chain
+description: Secure the software supply chain from source to running container. Covers Cosign keyless image signing (Sigstore/Rekor), SBOM generation and attestation (Syft), vulnerability scanning with severity gates (Trivy/Grype), SLSA Level 2 provenance, and Kyverno/OPA admission enforcement. All open-source, no license cost. Use when asked to "sign my image", "generate an SBOM", "scan for CVEs", "attest build provenance", "enforce image signatures in Kubernetes", or "implement SLSA".
+argument-hint: "[audit|sign|sbom|scan|enforce|slsa] [description or file path]"
+---
+
+Secure the software supply chain — from the build pipeline to running containers.
+
+## Mode: audit
+
+Review an existing CI/CD pipeline and cluster admission configuration for supply chain security gaps.
+
+Steps:
+1. Ask for or read: the GitHub Actions workflow file(s), any existing image scanning steps, and any Kyverno/OPA admission policies
+2. Classify gaps by severity:
+   - **Critical**: images pushed without signing, no CVE gate, unsigned images admitted to cluster
+   - **High**: SBOM not generated or not attested, severity gate only on CRITICAL (misses HIGH)
+   - **Medium**: action versions pinned to tag not SHA, no SLSA provenance
+3. Output a prioritised gap list:
+   ```
+   [CRITICAL] No image signing — any image can be admitted to the cluster
+   [CRITICAL] No CVE severity gate — vulnerable images pass CI
+   [HIGH]     No SBOM attestation — cannot audit what is running
+   [MEDIUM]   Action versions pinned to tag, not SHA
+   ```
+4. Recommend the fix order: sign → scan-gate → SBOM → enforce → SLSA
+
+Reference: `references/supply-chain.md` → Gap classification, Fix order
+
+## Mode: sign
+
+Set up keyless image signing with Cosign using Sigstore/Rekor (no key management required).
+
+Steps:
+1. Confirm the image registry (ECR, GHCR, Docker Hub) and CI platform (GitHub Actions assumed)
+2. Generate the signing workflow step:
+   ```yaml
+   - name: Install Cosign
+     uses: sigstore/cosign-installer@v3.8.1   # pin to SHA in production
+
+   - name: Sign image
+     env:
+       COSIGN_EXPERIMENTAL: "1"   # enables keyless / OIDC flow
+     run: |
+       cosign sign --yes \
+         ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+   ```
+3. Explain the keyless flow: GitHub Actions OIDC token → Fulcio CA → Rekor transparency log
+4. Show verification command:
+   ```bash
+   cosign verify \
+     --certificate-identity-regexp="https://github.com/<org>/<repo>/.github/workflows/.*" \
+     --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+     ghcr.io/<org>/<image>@<digest>
+   ```
+5. Flag: always sign the digest (`@sha256:…`), never the tag — tags are mutable
+
+Key rules:
+- Never store signing keys in CI secrets — use keyless only
+- Always sign the digest, not the tag
+- Pin `cosign-installer` to a SHA: `sigstore/cosign-installer@11086d9`
+
+Reference: `references/supply-chain.md` → Keyless signing, Rekor transparency log
+
+## Mode: sbom
+
+Generate a Software Bill of Materials with Syft and attest it as an OCI artifact alongside the image.
+
+Steps:
+1. Add the SBOM generation step after build, before push:
+   ```yaml
+   - name: Generate SBOM
+     uses: anchore/sbom-action@v0.20.0
+     with:
+       image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+       format: spdx-json
+       output-file: sbom.spdx.json
+
+   - name: Attest SBOM
+     run: |
+       cosign attest --yes \
+         --predicate sbom.spdx.json \
+         --type spdxjson \
+         ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+   ```
+2. Show how to retrieve the SBOM attestation:
+   ```bash
+   cosign download attestation \
+     --predicate-type https://spdx.dev/Document \
+     ghcr.io/<org>/<image>@<digest> | jq '.payload | @base64d | fromjson'
+   ```
+3. Note: use `spdx-json` format for broadest tooling compatibility; `cyclonedx-json` is an alternative
+
+Reference: `references/supply-chain.md` → SBOM formats, Syft, Attestation
+
+## Mode: scan
+
+Add a CVE vulnerability scan with a configurable severity gate that fails the build.
+
+Steps:
+1. Add Trivy scan step:
+   ```yaml
+   - name: Scan image for vulnerabilities
+     uses: aquasecurity/trivy-action@0.30.0
+     with:
+       image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+       format: table
+       exit-code: '1'
+       ignore-unfixed: true
+       vuln-type: os,library
+       severity: CRITICAL,HIGH
+   ```
+2. Explain `ignore-unfixed: true` — skip CVEs with no fix available (reduces noise without reducing security)
+3. For Grype (alternative), show:
+   ```yaml
+   - name: Scan with Grype
+     uses: anchore/scan-action@v6
+     with:
+       image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+       fail-build: true
+       severity-cutoff: high
+   ```
+4. Recommend Trivy for new setups (CNCF, single binary, SBOM support); Grype for teams already using Syft
+
+Reference: `references/supply-chain.md` → Trivy vs Grype, Severity gates
+
+## Mode: enforce
+
+Generate a Kyverno `ImageValidatingPolicy` that blocks unsigned or unverified images at admission time.
+
+Steps:
+1. Ask: keyless (Sigstore) or key-based signing?
+2. For keyless, generate:
+   ```yaml
+   apiVersion: policies.kyverno.io/v1
+   kind: ImageValidatingPolicy
+   metadata:
+     name: require-signed-images
+   spec:
+     matchConstraints:
+       resourceRules:
+       - apiGroups: ["apps"]
+         apiVersions: ["v1"]
+         operations: ["CREATE", "UPDATE"]
+         resources: ["deployments", "statefulsets", "daemonsets"]
+     matchImageReferences:
+     - glob: "ghcr.io/<org>/*"
+     validations:
+     - expression: >
+         images.containers.map(image, verifyImageSignatures(image, [{"keyless": {
+           "url": "https://fulcio.sigstore.dev",
+           "rekor": {"url": "https://rekor.sigstore.dev"},
+           "identities": [{"issuer": "https://token.actions.githubusercontent.com",
+             "subjectRegExp": "https://github.com/<org>/.*"}]
+         }}])).all(e, e > 0)
+       message: "Image must be signed via Sigstore keyless signing from GitHub Actions"
+   ```
+3. Show audit-first deployment:
+   ```yaml
+   spec:
+     failurePolicy: Audit   # start here, move to Enforce after validation
+   ```
+4. Cross-reference: `/platform-skills:kyverno` for full ImageValidatingPolicy guidance
+
+Reference: `references/supply-chain.md` → Kyverno enforcement, `references/kyverno.md` → ImageValidatingPolicy
+
+## Mode: slsa
+
+Generate a GitHub Actions workflow for SLSA Level 2 provenance using `slsa-github-generator`.
+
+Steps:
+1. Explain what SLSA L2 gives: signed provenance linking the artifact to the specific build inputs (source commit, workflow, runner)
+2. Generate the workflow using the official reusable workflow:
+   ```yaml
+   jobs:
+     build:
+       outputs:
+         digest: ${{ steps.build.outputs.digest }}
+       steps:
+         - name: Build and push image
+           id: build
+           uses: docker/build-push-action@v6
+           with:
+             push: true
+             tags: ghcr.io/<org>/<image>:${{ github.sha }}
+
+     provenance:
+       needs: build
+       permissions:
+         actions: read
+         id-token: write
+         packages: write
+       uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+       with:
+         image: ghcr.io/<org>/<image>
+         digest: ${{ needs.build.outputs.digest }}
+         registry-username: ${{ github.actor }}
+       secrets:
+         registry-password: ${{ secrets.GITHUB_TOKEN }}
+   ```
+3. Show provenance verification:
+   ```bash
+   slsa-verifier verify-image \
+     ghcr.io/<org>/<image>@<digest> \
+     --source-uri github.com/<org>/<repo> \
+     --source-branch main
+   ```
+4. Note: `generator_container_slsa3.yml` produces L2 provenance by default; L3 requires hermetic builds not available on standard GitHub-hosted runners
+
+Reference: `references/supply-chain.md` → SLSA levels, slsa-github-generator

--- a/commands/supply-chain.md
+++ b/commands/supply-chain.md
@@ -36,11 +36,9 @@ Steps:
 2. Generate the signing workflow step:
    ```yaml
    - name: Install Cosign
-     uses: sigstore/cosign-installer@v3.8.1   # pin to SHA in production
+     uses: sigstore/cosign-installer@11086d9f32b178aa24e93c2b86eba3ef4b16b68a  # v3.8.1
 
    - name: Sign image
-     env:
-       COSIGN_EXPERIMENTAL: "1"   # enables keyless / OIDC flow
      run: |
        cosign sign --yes \
          ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
@@ -58,7 +56,7 @@ Steps:
 Key rules:
 - Never store signing keys in CI secrets — use keyless only
 - Always sign the digest, not the tag
-- Pin `cosign-installer` to a SHA: `sigstore/cosign-installer@11086d9`
+- Pin `cosign-installer` to a full SHA, e.g.: `sigstore/cosign-installer@11086d9f32b178aa24e93c2b86eba3ef4b16b68a`
 
 Reference: `references/supply-chain.md` → Keyless signing, Rekor transparency log
 
@@ -67,10 +65,10 @@ Reference: `references/supply-chain.md` → Keyless signing, Rekor transparency 
 Generate a Software Bill of Materials with Syft and attest it as an OCI artifact alongside the image.
 
 Steps:
-1. Add the SBOM generation step after build, before push:
+1. Add the SBOM generation step after build and push (digest is only available after registry push):
    ```yaml
    - name: Generate SBOM
-     uses: anchore/sbom-action@v0.20.0
+     uses: anchore/sbom-action@61119d458adab75f756bc0b9e4bde25725f86a7a  # v0.20.0
      with:
        image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
        format: spdx-json
@@ -101,7 +99,7 @@ Steps:
 1. Add Trivy scan step:
    ```yaml
    - name: Scan image for vulnerabilities
-     uses: aquasecurity/trivy-action@0.30.0
+     uses: aquasecurity/trivy-action@18f2135c0b15d26b3a4c2efded75e06b6f0e4884  # v0.30.0
      with:
        image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
        format: table
@@ -137,6 +135,7 @@ Steps:
    metadata:
      name: require-signed-images
    spec:
+     validationActions: [Audit]   # switch to [Deny] after all images are signing
      matchConstraints:
        resourceRules:
        - apiGroups: ["apps"]
@@ -158,7 +157,7 @@ Steps:
 3. Show audit-first deployment:
    ```yaml
    spec:
-     failurePolicy: Audit   # start here, move to Enforce after validation
+     validationActions: [Audit]   # start here, switch to [Deny] after validation
    ```
 4. Cross-reference: `/platform-skills:kyverno` for full ImageValidatingPolicy guidance
 
@@ -174,8 +173,12 @@ Steps:
    ```yaml
    jobs:
      build:
+       runs-on: ubuntu-latest
        outputs:
          digest: ${{ steps.build.outputs.digest }}
+       permissions:
+         contents: read
+         packages: write
        steps:
          - name: Build and push image
            id: build

--- a/commands/supply-chain.md
+++ b/commands/supply-chain.md
@@ -112,7 +112,7 @@ Steps:
 3. For Grype (alternative), show:
    ```yaml
    - name: Scan with Grype
-     uses: anchore/scan-action@v6
+     uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
      with:
        image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
        fail-build: true
@@ -138,10 +138,10 @@ Steps:
      validationActions: [Audit]   # switch to [Deny] after all images are signing
      matchConstraints:
        resourceRules:
-       - apiGroups: ["apps"]
+       - apiGroups: [""]
          apiVersions: ["v1"]
          operations: ["CREATE", "UPDATE"]
-         resources: ["deployments", "statefulsets", "daemonsets"]
+         resources: ["pods"]
      matchImageReferences:
      - glob: "ghcr.io/<org>/*"
      validations:
@@ -182,7 +182,7 @@ Steps:
        steps:
          - name: Build and push image
            id: build
-           uses: docker/build-push-action@v6
+           uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355  # v6.10.0
            with:
              push: true
              tags: ghcr.io/<org>/<image>:${{ github.sha }}
@@ -193,7 +193,7 @@ Steps:
          actions: read
          id-token: write
          packages: write
-       uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+       uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@5a775b367a56d5bd118a224a811bba288150a563  # v2.0.0
        with:
          image: ghcr.io/<org>/<image>
          digest: ${{ needs.build.outputs.digest }}

--- a/docs/superpowers/specs/2026-05-20-supply-chain-runtime-security-design.md
+++ b/docs/superpowers/specs/2026-05-20-supply-chain-runtime-security-design.md
@@ -1,0 +1,205 @@
+# Design: Supply Chain Security + Runtime Security Skills
+
+**Date:** 2026-05-20
+**Status:** Approved for implementation
+**Author:** Nitin Jain
+
+---
+
+## Summary
+
+Add two new first-class skills to the platform-skills plugin:
+
+1. **`/platform-skills:supply-chain`** — Secure the software supply chain from source to running container: image signing (Cosign/Sigstore), SBOM generation and attestation (Syft), vulnerability scanning (Trivy/Grype), SLSA Level 2/3 provenance, and Kyverno/OPA enforcement gates that block unsigned or unverified images at admission time.
+
+2. **`/platform-skills:runtime-security`** — Detect and respond to threats inside running containers using Falco (eBPF-based, CNCF, open-source/free). Covers Falco installation on EKS/GKE, custom rule authoring, alert routing via Falcosidekick, and bridging runtime alerts to Kyverno enforcement.
+
+Both skills are 100% open-source / no-license-cost tooling.
+
+---
+
+## Why Two Skills Instead of One
+
+Supply chain and runtime security are operated by different teams at different points in the lifecycle:
+
+- **Supply chain** is a CI/CD concern — build pipeline, image registry, admission control. Owned by the platform/CI team.
+- **Runtime security** is a cluster operations concern — DaemonSet deployment, rule authoring, alert routing, incident response. Owned by the platform/security operations team.
+
+Combining them into one command would make each half harder to discover and navigate.
+
+---
+
+## Skill 1: `/platform-skills:supply-chain`
+
+### Activation triggers
+
+- Files: Dockerfile, GitHub Actions workflows, `.github/workflows/*.yaml`
+- Tool names: `cosign`, `syft`, `trivy`, `grype`, `slsa-verifier`
+- Keywords: "sign image", "SBOM", "scan for CVEs", "attest provenance", "keyless signing", "supply chain", "Sigstore", "Rekor", "SLSA"
+- Kyverno `ImageValidatingPolicy` with `verifyImages` blocks
+
+### Modes
+
+| Mode | What it does |
+|---|---|
+| `audit` | Review an existing pipeline for supply chain gaps; output a prioritised gap list |
+| `sign` | Walk through Cosign keyless signing setup using Sigstore/Rekor (no key management) |
+| `sbom` | Generate and attest an SBOM with Syft; attach to image as OCI attestation |
+| `scan` | Trivy or Grype CVE scan with configurable severity gate (CRITICAL/HIGH exit-code policy) |
+| `enforce` | Generate Kyverno `ImageValidatingPolicy` or OPA policy to block unsigned/unattested images at admission |
+| `slsa` | SLSA Level 2 provenance via `slsa-github-generator` GitHub Actions reusable workflow |
+
+### Tool stack (all open-source, no license cost)
+
+| Tool | Purpose | CNCF? |
+|---|---|---|
+| Cosign (Sigstore) | Keyless image signing and verification | Yes |
+| Syft | SBOM generation (SPDX, CycloneDX) | No (Anchore OSS) |
+| Trivy | CVE scanning, SBOM, misconfig detection | Yes |
+| Grype | CVE scanning against Syft SBOM | No (Anchore OSS) |
+| Rekor | Transparency log for signatures | Yes (Sigstore) |
+| slsa-github-generator | SLSA Level 2/3 provenance | Yes (OpenSSF) |
+| Kyverno ImageValidatingPolicy | Admission enforcement | Yes |
+
+### Content structure
+
+```
+references/supply-chain.md
+  ├── Keyless signing with Cosign (OIDC, Rekor transparency log)
+  ├── SBOM generation and attestation with Syft
+  ├── Vulnerability scanning: Trivy vs Grype trade-offs
+  ├── Severity gate configuration and break-the-build strategy
+  ├── SLSA Level 2 vs Level 3: what each requires
+  ├── Kyverno ImageValidatingPolicy: verifyImages, keyless, attestations
+  ├── OPA policy: enforce signed images via Rego
+  ├── Cross-references: github-actions.md, kyverno.md
+  └── Troubleshooting: signature not found, SBOM attestation missing
+
+examples/supply-chain/
+  ├── sign-and-push.yaml          # GHA: build → cosign sign → push
+  ├── sbom-attest.yaml            # GHA: syft SBOM → cosign attest
+  ├── trivy-gate.yaml             # GHA: trivy scan with CRITICAL exit gate
+  ├── kyverno-verify-image.yaml   # ImageValidatingPolicy: keyless verification
+  └── slsa-provenance.yaml        # GHA: slsa-github-generator L2 provenance
+```
+
+### Key rules to enforce
+
+- Never store signing keys in CI environment variables — use keyless (OIDC + Rekor)
+- Always pin `cosign`, `syft`, `trivy` action versions to a SHA, not a tag
+- Gate on CRITICAL + HIGH by default; document any exceptions in the policy
+- Attest SBOM as an OCI artifact alongside the image, not as a file artefact
+- Kyverno `ImageValidatingPolicy` must apply before workload admission, not as a background scan
+
+---
+
+## Skill 2: `/platform-skills:runtime-security`
+
+### Activation triggers
+
+- Files: `falco-values.yaml`, `falco-rules.yaml`, Falcosidekick config
+- Keywords: "runtime security", "Falco", "syscall monitoring", "container threat detection", "privilege escalation detection", "eBPF security"
+- Symptoms: "pod running unexpected binary", "shell spawned in container", "unexpected outbound connection"
+
+### Modes
+
+| Mode | What it does |
+|---|---|
+| `install` | Deploy Falco via Helm on EKS/GKE with eBPF driver (no kernel module required) |
+| `rules` | Write and unit-test custom Falco rules; explain built-in ruleset |
+| `alerts` | Configure Falcosidekick to route alerts → Slack, webhook, PagerDuty |
+| `debug` | Diagnose why a Falco rule is not firing; explain event filter syntax |
+| `harden` | Map Falco alert metadata to Kyverno enforcement or OPA policy gates |
+
+### Tool stack (all open-source, no license cost)
+
+| Tool | Purpose | CNCF? |
+|---|---|---|
+| Falco | eBPF-based syscall/kernel event monitoring | Yes |
+| Falcosidekick | Alert fanout: Slack, webhook, SNS, PagerDuty | Yes (Falco ecosystem) |
+| Falcosidekick UI | Alert dashboard | Yes (Falco ecosystem) |
+| Helm falcosecurity/falco | Official Helm chart | Yes |
+
+### Content structure
+
+```
+references/runtime-security.md
+  ├── Falco architecture: eBPF driver vs kernel module (prefer eBPF on managed K8s)
+  ├── Installing Falco on EKS with eBPF (no kernel module, Fargate caveats)
+  ├── Installing Falco on GKE (COS node image, eBPF requirement)
+  ├── Built-in ruleset overview: which rules to enable in production
+  ├── Writing custom rules: condition syntax, output fields, priority levels
+  ├── Testing rules with falco --dry-run and event-generator
+  ├── Falcosidekick: routing config, output types, alert deduplication
+  ├── Bridging Falco → Kyverno: using alert metadata in admission policy
+  ├── Resource sizing: CPU/memory for Falco DaemonSet
+  └── Troubleshooting: rule not firing, high CPU, missed events
+
+examples/runtime-security/
+  ├── falco-values.yaml              # Helm values: eBPF driver, resource limits, tolerations
+  ├── falco-custom-rules.yaml        # Rules: shell in container, privilege escalation, unexpected outbound
+  ├── falcosidekick-values.yaml      # Helm values: Slack + webhook routing, deduplication
+  └── falco-kyverno-bridge.yaml      # Kyverno policy: deny workloads that triggered Falco critical alerts
+```
+
+### Key rules to enforce
+
+- Always use eBPF driver on managed Kubernetes (EKS, GKE, AKS) — kernel module requires privileged access and breaks on node OS upgrades
+- Never run Falco as a sidecar — it must be a DaemonSet to see all node-level syscalls
+- Set `priority: WARNING` or higher for production alert routing; DEBUG/INFO are noise
+- Always set resource `limits.memory` on the Falco DaemonSet — kernel event processing can spike
+- Test every custom rule with `falco-event-generator` before deploying to production
+
+---
+
+## SKILL.md additions
+
+Two new numbered entries in the "Pick the right tool" section:
+
+```
+25. `Supply Chain Security`: Secure the build pipeline and image lifecycle with Cosign keyless signing,
+    Syft SBOM generation, Trivy/Grype scanning, SLSA Level 2 provenance, and Kyverno admission enforcement.
+    All open-source, no license cost.
+
+26. `Runtime Security`: Detect in-container threats at the syscall level with Falco (eBPF, CNCF).
+    Covers rule authoring, Falcosidekick alert routing, and bridging runtime signals to admission enforcement.
+```
+
+Two new activation keyword clusters added to the skill frontmatter `description`.
+
+Two new command entries added to `COMMANDS.md` following the same structure as `/platform-skills:keda`.
+
+---
+
+## Cross-references
+
+| This skill | Links to |
+|---|---|
+| `supply-chain` enforce mode | `references/kyverno.md` → ImageValidatingPolicy |
+| `supply-chain` scan mode | `references/github-actions.md` → CI gate patterns |
+| `runtime-security` harden mode | `references/kyverno.md`, `references/opa.md` |
+| `runtime-security` install mode | `references/kubernetes.md` → DaemonSet baseline |
+
+---
+
+## Validation steps (post-implementation)
+
+1. `bash tests/validate-skill.sh` — passes all existing checks
+2. New supply-chain examples pass `yamllint` and `kubeconform`
+3. New runtime-security Helm values pass `helm lint falcosecurity/falco -f examples/runtime-security/falco-values.yaml`
+4. COMMANDS.md entry count increases by 2
+5. SKILL.md numbered list increases from 24 to 26
+
+---
+
+## Rollback plan
+
+Both skills are purely additive — new files in `references/`, `examples/`, and appended entries in `SKILL.md` and `COMMANDS.md`. Rollback = revert the branch. No existing files are modified beyond appending.
+
+---
+
+## Out of scope
+
+- Paid tools (Aqua, Snyk, Twistlock, Sysdig) — excluded by license constraint
+- Falco on AWS Fargate — Fargate does not expose the node kernel; noted as a caveat in the reference, not a supported path
+- SLSA Level 3 (hermetic builds) — covered in the reference as future state; the example targets Level 2 which is achievable with GitHub Actions today

--- a/examples/runtime-security/README.md
+++ b/examples/runtime-security/README.md
@@ -1,0 +1,38 @@
+# Runtime Security Examples
+
+Working examples for the `/platform-skills:runtime-security` skill.
+
+## Files
+
+| File | Description |
+|---|---|
+| `falco-values.yaml` | Helm values: Falco with eBPF driver, resource limits, node tolerations |
+| `falco-custom-rules.yaml` | Custom rules: shell in container, privilege escalation, unexpected outbound |
+| `falcosidekick-values.yaml` | Helm values: Falcosidekick with Slack and webhook routing |
+| `falco-kyverno-bridge.yaml` | Kyverno ValidatingPolicy: block re-admission of Falco-flagged workloads |
+
+## Usage
+
+```bash
+# Install Falco
+helm upgrade --install falco falcosecurity/falco \
+  --namespace falco \
+  --create-namespace \
+  -f examples/runtime-security/falco-values.yaml
+
+# Install with Falcosidekick
+helm upgrade --install falco falcosecurity/falco \
+  --namespace falco \
+  --create-namespace \
+  --set falcosidekick.enabled=true \
+  -f examples/runtime-security/falcosidekick-values.yaml
+
+# Apply Kyverno bridge policy
+kubectl apply -f examples/runtime-security/falco-kyverno-bridge.yaml
+```
+
+## Validation
+
+```bash
+bash examples/runtime-security/runtime-security-validate.sh
+```

--- a/examples/runtime-security/README.md
+++ b/examples/runtime-security/README.md
@@ -1,5 +1,7 @@
 # Runtime Security Examples
 
+Status: Stable
+
 Working examples for the `/platform-skills:runtime-security` skill.
 
 ## Files

--- a/examples/runtime-security/falco-custom-rules.yaml
+++ b/examples/runtime-security/falco-custom-rules.yaml
@@ -44,7 +44,7 @@
   condition: >
     outbound
     and container
-    and not fd.sport in (80, 443, 8080, 8443, 5432, 6379, 9200)
+    and not fd.rport in (80, 443, 8080, 8443, 5432, 6379, 9200)
     and not container.image.repository in (allowed_network_images)
   output: >
     Unexpected outbound connection from container

--- a/examples/runtime-security/falco-custom-rules.yaml
+++ b/examples/runtime-security/falco-custom-rules.yaml
@@ -1,0 +1,64 @@
+# Custom Falco rules for common threat patterns.
+# Load these via the Helm chart customRules value or by mounting as a ConfigMap.
+
+# Macro: identify shell binaries
+- macro: shell_procs
+  condition: proc.name in (bash, sh, zsh, dash, fish, ksh)
+
+# Rule 1: Interactive shell in any container
+- rule: Shell spawned in container
+  desc: An interactive shell was spawned inside a running container — potential intrusion
+  condition: >
+    spawned_process
+    and container
+    and shell_procs
+    and not container.image.repository in (allowed_shell_images)
+  output: >
+    Shell spawned in container
+    (user=%user.name uid=%user.uid
+     container=%container.name image=%container.image.repository
+     shell=%proc.name parent=%proc.pname cmdline=%proc.cmdline
+     pod=%k8s.pod.name ns=%k8s.ns.name)
+  priority: WARNING
+  tags: [container, shell, mitre_execution]
+
+# Rule 2: Privilege escalation attempt
+- rule: Privilege escalation via setuid binary
+  desc: A container process called a setuid binary — potential privilege escalation
+  condition: >
+    spawned_process
+    and container
+    and proc.is_suid_exe = true
+    and not proc.name in (ping)
+  output: >
+    Privilege escalation via setuid binary
+    (user=%user.name container=%container.name
+     binary=%proc.name parent=%proc.pname
+     pod=%k8s.pod.name ns=%k8s.ns.name)
+  priority: ERROR
+  tags: [container, privilege_escalation, mitre_privilege_escalation]
+
+# Rule 3: Unexpected outbound connection on non-standard port
+- rule: Unexpected outbound connection
+  desc: Container made an outbound TCP connection on a port not in the known-good list
+  condition: >
+    outbound
+    and container
+    and not fd.sport in (80, 443, 8080, 8443, 5432, 6379, 9200)
+    and not container.image.repository in (allowed_network_images)
+  output: >
+    Unexpected outbound connection from container
+    (user=%user.name container=%container.name
+     image=%container.image.repository
+     connection=%fd.name
+     pod=%k8s.pod.name ns=%k8s.ns.name)
+  priority: NOTICE
+  tags: [container, network, mitre_exfiltration]
+
+# Allow-list for shells (containers that legitimately run shells)
+- list: allowed_shell_images
+  items: []   # add image repos here: ["ghcr.io/org/debug-tools"]
+
+# Allow-list for containers with non-standard network access
+- list: allowed_network_images
+  items: []   # add image repos here: ["ghcr.io/org/egress-proxy"]

--- a/examples/runtime-security/falco-kyverno-bridge.yaml
+++ b/examples/runtime-security/falco-kyverno-bridge.yaml
@@ -1,0 +1,33 @@
+# Kyverno ValidatingPolicy: block re-admission of Deployments flagged by a Falco critical alert.
+# Workflow:
+#   1. Falco fires a critical rule in a container
+#   2. Alert handler labels the Deployment: security.platform/falco-alert=critical
+#   3. This policy blocks CREATE/UPDATE on that Deployment until the label is removed
+#   4. Ops team remediates, removes the label, then redeploys
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: block-falco-flagged-workloads
+  annotations:
+    policies.kyverno.io/title: Block Falco-Flagged Workloads
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/description: >
+      Prevents re-admission of Deployments that have been flagged by a Falco critical alert.
+      Remove the security.platform/falco-alert label after remediation to re-enable deployment.
+spec:
+  validationActions: [Deny]
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["apps"]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["deployments"]
+  validations:
+  - expression: >
+      !has(object.metadata.labels) ||
+      !('security.platform/falco-alert' in object.metadata.labels) ||
+      object.metadata.labels['security.platform/falco-alert'] != 'critical'
+    message: >
+      This Deployment has been flagged by a Falco critical security alert
+      (security.platform/falco-alert=critical). Remediate the security issue and
+      remove the label before redeploying.

--- a/examples/runtime-security/falco-values.yaml
+++ b/examples/runtime-security/falco-values.yaml
@@ -5,6 +5,8 @@ driver:
   kind: modern_ebpf
 
 falco:
+  # Deprecated: grpc/grpc_output are deprecated in Falco chart; Falcosidekick uses http output instead.
+  # Keep enabled only if you have direct gRPC consumers. For Falcosidekick, these are not needed.
   grpc:
     enabled: true
   grpc_output:

--- a/examples/runtime-security/falco-values.yaml
+++ b/examples/runtime-security/falco-values.yaml
@@ -1,0 +1,32 @@
+# Falco Helm values for EKS/GKE with modern eBPF driver.
+# modern_ebpf requires Linux 5.8+ kernel (AL2023, COS, Ubuntu 22.04+).
+# Never use kmod (kernel module) on managed Kubernetes.
+driver:
+  kind: modern_ebpf
+
+falco:
+  grpc:
+    enabled: true
+  grpc_output:
+    enabled: true
+  json_output: true        # structured output; required for Falcosidekick parsing
+  log_stderr: true
+  log_syslog: false
+  priority: warning        # suppress DEBUG and INFO from default ruleset
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 512Mi          # cpu limit intentionally omitted — kernel event processing is bursty
+
+tolerations:
+  - effect: NoSchedule
+    operator: Exists       # Falco must run on ALL nodes, including tainted system nodes
+  - effect: NoExecute
+    operator: Exists
+
+# Load custom rules from the falco-custom-rules.yaml file in this directory
+customRules:
+  {}   # replace with: custom-rules.yaml: |- <content> when adding custom rules

--- a/examples/runtime-security/falcosidekick-values.yaml
+++ b/examples/runtime-security/falcosidekick-values.yaml
@@ -6,6 +6,8 @@ falcosidekick:
 
   webui:
     enabled: true           # dashboard at port 2802
+    # IMPORTANT: set credentials before exposing — default is admin:admin
+    # user: ""              # set via: --set falcosidekick.webui.user=<login:password>
 
   config:
     debug: false

--- a/examples/runtime-security/falcosidekick-values.yaml
+++ b/examples/runtime-security/falcosidekick-values.yaml
@@ -1,0 +1,35 @@
+# Falcosidekick Helm values: Slack + webhook alert routing.
+# Pass to Falco Helm chart via --set falcosidekick.enabled=true -f falcosidekick-values.yaml
+# or merge into falco-values.yaml.
+falcosidekick:
+  enabled: true
+
+  webui:
+    enabled: true           # dashboard at port 2802
+
+  config:
+    debug: false
+
+    # Slack output — substitute webhook URL
+    slack:
+      webhookurl: ""        # set via --set falcosidekick.config.slack.webhookurl=<url>
+      channel: "#platform-security-alerts"
+      minimumpriority: warning
+      messageformat: >
+        :rotating_light: *{{ .Rule }}* ({{ .Priority }})
+        *Container:* `{{ index .OutputFields "container.name" }}`
+        *Image:* `{{ index .OutputFields "container.image.repository" }}`
+        *Pod:* `{{ index .OutputFields "k8s.pod.name" }}` in `{{ index .OutputFields "k8s.ns.name" }}`
+        *Cmdline:* `{{ index .OutputFields "proc.cmdline" }}`
+
+    # Webhook output — for custom alert handlers or SIEM integration
+    webhook:
+      address: ""           # set via --set falcosidekick.config.webhook.address=<url>
+      minimumpriority: error
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 256Mi         # cpu limit intentionally omitted

--- a/examples/runtime-security/runtime-security-validate.sh
+++ b/examples/runtime-security/runtime-security-validate.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Validates runtime-security example files: YAML syntax check.
+# Run from repository root: bash examples/runtime-security/runtime-security-validate.sh
+
+set -euo pipefail
+
+ERRORS=0
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; ERRORS=$((ERRORS + 1)); }
+
+EXAMPLE_DIR="examples/runtime-security"
+
+echo ""
+echo "=== Runtime Security Examples: YAML syntax ==="
+
+for f in "$EXAMPLE_DIR"/*.yaml; do
+  if yq eval 'true' "$f" > /dev/null 2>&1; then
+    pass "$f is valid YAML"
+  else
+    fail "$f has invalid YAML"
+  fi
+done
+
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+  echo "FAIL: $ERRORS error(s)"
+  exit 1
+fi
+echo "PASS: all runtime-security example checks passed"

--- a/examples/supply-chain/README.md
+++ b/examples/supply-chain/README.md
@@ -1,0 +1,23 @@
+# Supply Chain Security Examples
+
+Working examples for the `/platform-skills:supply-chain` skill.
+
+## Files
+
+| File | Description |
+|---|---|
+| `sign-and-push.yaml` | GitHub Actions: build, sign with Cosign keyless, and push |
+| `sbom-attest.yaml` | GitHub Actions: generate SBOM with Syft and attest |
+| `trivy-gate.yaml` | GitHub Actions: Trivy CVE scan with CRITICAL+HIGH severity gate |
+| `kyverno-verify-image.yaml` | Kyverno ImageValidatingPolicy: block unsigned images |
+| `slsa-provenance.yaml` | GitHub Actions: SLSA Level 2 provenance via slsa-github-generator |
+
+## Usage
+
+Copy the relevant file into your `.github/workflows/` or `policies/` directory and substitute `<org>` and `<image>` placeholders.
+
+## Validation
+
+```bash
+bash examples/supply-chain/supply-chain-validate.sh
+```

--- a/examples/supply-chain/README.md
+++ b/examples/supply-chain/README.md
@@ -1,5 +1,7 @@
 # Supply Chain Security Examples
 
+Status: Stable
+
 Working examples for the `/platform-skills:supply-chain` skill.
 
 ## Files

--- a/examples/supply-chain/kyverno-verify-image.yaml
+++ b/examples/supply-chain/kyverno-verify-image.yaml
@@ -1,0 +1,41 @@
+# Kyverno ImageValidatingPolicy: block images not signed via Sigstore keyless from GitHub Actions.
+# This is a cluster-scoped resource — it applies across all namespaces.
+# Start with validationActions: [Audit], move to [Deny] after all images in scope are signing.
+#
+# To restrict to specific namespaces, use matchConditions:
+#   - expression: "request.namespace in ['production', 'staging']"
+apiVersion: policies.kyverno.io/v1
+kind: ImageValidatingPolicy
+metadata:
+  name: require-signed-images
+  annotations:
+    policies.kyverno.io/title: Require Signed Images
+    policies.kyverno.io/severity: critical
+    policies.kyverno.io/description: >
+      All container images must be signed via Sigstore keyless signing from GitHub Actions.
+      Unsigned images are reported as violations (Audit mode) or blocked (Deny mode).
+spec:
+  validationActions: [Audit]   # change to [Deny] after validating all images are signed
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["pods"]
+  matchImageReferences:
+  - glob: "ghcr.io/<org>/*"
+  attestors:
+  - name: cosign
+    cosign:
+      keyless:
+        identities:
+        - issuer: "https://token.actions.githubusercontent.com"
+          subjectRegExp: "https://github.com/<org>/.*/.github/workflows/.*@refs/heads/main"
+        ctlog:
+          url: https://rekor.sigstore.dev
+  validations:
+  - expression: >-
+      images.containers.map(image,
+        verifyImageSignatures(image, [attestors.cosign])
+      ).all(e, e > 0)
+    message: "Image must be signed via Sigstore keyless signing from GitHub Actions (main branch)."

--- a/examples/supply-chain/sbom-attest.yaml
+++ b/examples/supply-chain/sbom-attest.yaml
@@ -1,6 +1,6 @@
-# GitHub Actions workflow: generate SBOM with Syft and attest it to the image digest.
-# Run after sign-and-push or add these steps to the same job.
-# The digest is required — run this after the image is pushed to the registry.
+# GitHub Actions workflow: generate SBOM with Syft and attest it to the image.
+# Triggered by workflow_run from build-sign-push; references the image by tag.
+# To attest by digest (preferred), plumb the pushed digest as a workflow_run output.
 name: sbom-attest
 
 on:
@@ -28,7 +28,7 @@ jobs:
       - name: Generate SBOM with Syft
         uses: anchore/sbom-action@61119d458adab75f756bc0b9e4bde25725f86a7a  # v0.20.0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ github.event.workflow_run.head_sha }}
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@:${{ github.event.workflow_run.head_sha }}
           format: spdx-json
           output-file: sbom.spdx.json
 
@@ -37,4 +37,4 @@ jobs:
           cosign attest --yes \
             --predicate sbom.spdx.json \
             --type spdxjson \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ github.event.workflow_run.head_sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@:${{ github.event.workflow_run.head_sha }}

--- a/examples/supply-chain/sbom-attest.yaml
+++ b/examples/supply-chain/sbom-attest.yaml
@@ -1,0 +1,40 @@
+# GitHub Actions workflow: generate SBOM with Syft and attest it to the image digest.
+# Run after sign-and-push or add these steps to the same job.
+# The digest is required — run this after the image is pushed to the registry.
+name: sbom-attest
+
+on:
+  workflow_run:
+    workflows: [build-sign-push]
+    types: [completed]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: <org>/<image>
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write   # required for Cosign attest OIDC token exchange with Fulcio
+
+    steps:
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@11086d9f32b178aa24e93c2b86eba3ef4b16b68a  # v3.8.1
+
+      - name: Generate SBOM with Syft
+        uses: anchore/sbom-action@61119d458adab75f756bc0b9e4bde25725f86a7a  # v0.20.0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ github.event.workflow_run.head_sha }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Attest SBOM to image digest
+        run: |
+          cosign attest --yes \
+            --predicate sbom.spdx.json \
+            --type spdxjson \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ github.event.workflow_run.head_sha }}

--- a/examples/supply-chain/sign-and-push.yaml
+++ b/examples/supply-chain/sign-and-push.yaml
@@ -1,0 +1,48 @@
+# GitHub Actions workflow: build container image, sign with Cosign keyless, push to GHCR.
+# Substitute <org> and <image> with your values.
+# Cosign v2 keyless signing uses OIDC — no private key to store or rotate.
+name: build-sign-push
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: <org>/<image>
+
+jobs:
+  build-sign-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write   # required for Cosign keyless OIDC token exchange with Fulcio
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355  # v6.10.0
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@11086d9f32b178aa24e93c2b86eba3ef4b16b68a  # v3.8.1
+
+      - name: Sign image digest with Cosign keyless
+        # Always sign the digest (@sha256:...), never the tag — tags are mutable
+        run: |
+          cosign sign --yes \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}

--- a/examples/supply-chain/slsa-provenance.yaml
+++ b/examples/supply-chain/slsa-provenance.yaml
@@ -1,0 +1,58 @@
+# GitHub Actions workflow: generate SLSA Level 2 provenance using slsa-github-generator.
+# The provenance job runs after build using the official SLSA reusable workflow.
+# L2 is achievable on standard GitHub-hosted runners.
+# L3 requires hermetic builds — not available on ubuntu-latest.
+name: slsa-provenance
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: <org>/<image>
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Log in to GHCR
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355  # v6.10.0
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+  provenance:
+    needs: build
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    # generator_container_slsa3.yml produces SLSA L2 on standard GitHub-hosted runners.
+    # L3 requires hermetic builds and is not supported on ubuntu-latest.
+    # Pin to a full SHA for production: gh api repos/slsa-framework/slsa-github-generator/git/ref/tags/v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: ghcr.io/<org>/<image>
+      digest: ${{ needs.build.outputs.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/supply-chain/slsa-provenance.yaml
+++ b/examples/supply-chain/slsa-provenance.yaml
@@ -49,7 +49,7 @@ jobs:
     # generator_container_slsa3.yml produces SLSA L2 on standard GitHub-hosted runners.
     # L3 requires hermetic builds and is not supported on ubuntu-latest.
     # Pin to a full SHA for production: gh api repos/slsa-framework/slsa-github-generator/git/ref/tags/v2.0.0
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@5a775b367a56d5bd118a224a811bba288150a563  # v2.0.0
     with:
       image: ghcr.io/<org>/<image>
       digest: ${{ needs.build.outputs.digest }}

--- a/examples/supply-chain/supply-chain-validate.sh
+++ b/examples/supply-chain/supply-chain-validate.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Validates supply-chain example files: YAML syntax check.
+# Run from repository root: bash examples/supply-chain/supply-chain-validate.sh
+
+set -euo pipefail
+
+ERRORS=0
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; ERRORS=$((ERRORS + 1)); }
+
+EXAMPLE_DIR="examples/supply-chain"
+
+echo ""
+echo "=== Supply Chain Examples: YAML syntax ==="
+
+for f in "$EXAMPLE_DIR"/*.yaml; do
+  if yq eval 'true' "$f" > /dev/null 2>&1; then
+    pass "$f is valid YAML"
+  else
+    fail "$f has invalid YAML"
+  fi
+done
+
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+  echo "FAIL: $ERRORS error(s)"
+  exit 1
+fi
+echo "PASS: all supply-chain example checks passed"

--- a/examples/supply-chain/trivy-gate.yaml
+++ b/examples/supply-chain/trivy-gate.yaml
@@ -1,4 +1,5 @@
 # GitHub Actions workflow: scan image with Trivy; fail build on CRITICAL or HIGH CVEs.
+# This workflow expects the image to already exist in the registry (e.g. pushed by a preceding job or workflow).
 # ignore-unfixed: true suppresses CVEs with no available fix (reduces noise, does not reduce security).
 name: trivy-scan
 
@@ -34,6 +35,6 @@ jobs:
 
       - name: Upload Trivy SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@f411752efdf656cb71aa17b755b22c890960da1d  # v3.35.5
         with:
           sarif_file: trivy-results.sarif

--- a/examples/supply-chain/trivy-gate.yaml
+++ b/examples/supply-chain/trivy-gate.yaml
@@ -1,0 +1,39 @@
+# GitHub Actions workflow: scan image with Trivy; fail build on CRITICAL or HIGH CVEs.
+# ignore-unfixed: true suppresses CVEs with no available fix (reduces noise, does not reduce security).
+name: trivy-scan
+
+on:
+  pull_request:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: <org>/<image>
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # required to upload SARIF results to GitHub Security tab
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@18f2135c0b15d26b3a4c2efded75e06b6f0e4884  # v0.30.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+
+      - name: Upload Trivy SARIF to GitHub Security tab
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif

--- a/references/runtime-security.md
+++ b/references/runtime-security.md
@@ -1,0 +1,288 @@
+# Runtime Security Reference
+
+Covers Falco — eBPF-based syscall monitoring for Kubernetes workloads. Falco is a CNCF project, open-source, and free to run. Complements supply chain security (pre-deployment controls) with in-cluster threat detection (post-deployment controls).
+
+---
+
+## Architecture
+
+Falco runs as a DaemonSet on every node. It uses eBPF to hook into the Linux kernel and observe syscalls made by all containers on that node — without modifying the containers or the images.
+
+```
+Kernel syscalls (open, exec, connect, …)
+  → Falco eBPF probe (per node)
+  → Falco engine (rules evaluation)
+  → Alert output
+      ├── stdout (default)
+      ├── Falcosidekick (fan-out: Slack, PagerDuty, SNS, webhook)
+      └── gRPC output (for programmatic consumers)
+```
+
+### Driver options
+
+| Driver | Requires | Use when |
+|---|---|---|
+| `modern_ebpf` | Linux 5.8+ kernel (BTF enabled) | EKS (AL2023), GKE (COS), recommended default |
+| `ebpf` (classic) | Kernel headers on node | Older nodes without BTF support |
+| `kmod` (kernel module) | Build toolchain + privileged | **Never use on managed K8s** — breaks on node OS upgrades |
+
+**Always use eBPF on managed Kubernetes.** The kernel module requires privileged access and breaks whenever the node OS is upgraded (e.g., EKS AMI rotation, GKE node auto-upgrade).
+
+---
+
+## Installing Falco on EKS
+
+```yaml
+# falco-values.yaml — EKS with modern_ebpf driver
+driver:
+  kind: modern_ebpf   # no kernel headers required; needs Linux 5.8+ with BTF
+
+falco:
+  grpc:
+    enabled: true     # enables gRPC output for programmatic consumers
+  grpc_output:
+    enabled: true
+  json_output: true   # structured output; required for Falcosidekick parsing
+  priority: warning   # suppress DEBUG and INFO from default ruleset
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 512Mi     # cpu limit intentionally omitted — kernel event processing is bursty
+
+tolerations:
+  - effect: NoSchedule
+    operator: Exists  # Falco must run on ALL nodes including tainted ones
+  - effect: NoExecute
+    operator: Exists
+```
+
+**Bottlerocket nodes:** set `driver.kind: modern_ebpf` — Bottlerocket does not ship kernel headers.
+
+**Fargate:** Falco cannot run on Fargate. Fargate does not expose the node kernel to DaemonSets.
+
+---
+
+## Installing Falco on GKE
+
+GKE Container-Optimized OS (COS) requires `modern_ebpf` (BTF enabled by default). Standard Ubuntu nodes can use either driver.
+
+```yaml
+driver:
+  kind: modern_ebpf
+
+tolerations:
+  - effect: NoSchedule
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+```
+
+**GKE Autopilot:** DaemonSets are not schedulable on Autopilot — Falco is not supported.
+
+---
+
+## Built-in Ruleset
+
+The default Falco ruleset (`/etc/falco/falco_rules.yaml`) ships ~200 rules. Key ones to enable in production:
+
+| Rule | Priority | What it detects |
+|---|---|---|
+| `Terminal shell in container` | NOTICE | Interactive shell spawned inside a running container |
+| `Privilege Escalation via Sudo` | WARNING | `sudo` or `su` executed in a container |
+| `Write below etc` | ERROR | Write to `/etc` inside a container |
+| `Contact K8S API Server From Container` | NOTICE | Container calling the K8s API directly |
+| `Unexpected outbound connection destination` | NOTICE | Outbound connection to unexpected IP/port |
+| `Launch Privileged Container` | WARNING | Container started with `--privileged` |
+
+Tune noise by adding process names or image repositories to built-in allow-list macros rather than disabling rules entirely.
+
+---
+
+## Writing Custom Rules
+
+### Rule structure
+
+```yaml
+- rule: Unexpected binary executed in web container
+  desc: A binary not in the known-good set was exec'd in the web-tier container
+  condition: >
+    spawned_process
+    and container
+    and container.image.repository = "ghcr.io/<org>/web"
+    and not proc.name in (node, npm, sh, bash)
+  output: >
+    Unexpected binary in web container
+    (user=%user.name image=%container.image.repository
+     binary=%proc.name parent=%proc.pname cmdline=%proc.cmdline
+     pod=%k8s.pod.name ns=%k8s.ns.name)
+  priority: WARNING
+  tags: [container, execution, custom]
+```
+
+### Key condition fields
+
+| Field | Type | Example |
+|---|---|---|
+| `spawned_process` | macro | new process was exec'd |
+| `container` | macro | event is inside a container |
+| `proc.name` | string | `node`, `bash` |
+| `proc.cmdline` | string | full command including args |
+| `container.image.repository` | string | `ghcr.io/org/image` |
+| `user.name` | string | unix username |
+| `fd.net` | macro | event involves a network fd |
+| `evt.type` | string | `execve`, `open`, `connect` |
+
+### Lists and macros
+
+```yaml
+- list: allowed_web_binaries
+  items: [node, npm, sh]
+
+- macro: web_container
+  condition: container.image.repository = "ghcr.io/<org>/web"
+
+- rule: Unexpected binary in web container
+  condition: spawned_process and web_container and not proc.name in (allowed_web_binaries)
+  output: >
+    Unexpected binary in web container
+    (user=%user.name binary=%proc.name cmdline=%proc.cmdline pod=%k8s.pod.name)
+  priority: WARNING
+  tags: [container, execution, custom]
+```
+
+### Loading custom rules via Helm
+
+```yaml
+customRules:
+  custom-rules.yaml: |-
+    - list: allowed_web_binaries
+      items: [node, npm, sh]
+    - rule: Unexpected binary in web container
+      condition: spawned_process and container and not proc.name in (allowed_web_binaries)
+      output: "Binary %proc.name in container %container.name"
+      priority: WARNING
+```
+
+### Testing rules
+
+```bash
+# Deploy the official event-generator to trigger known-bad syscall patterns
+kubectl run event-generator \
+  --image=falcosecurity/event-generator \
+  --restart=Never \
+  --rm -it -- run syscall
+
+# Watch Falco logs on the same node
+kubectl logs -n falco -l app.kubernetes.io/name=falco | grep WARNING
+```
+
+---
+
+## Falcosidekick: Alert Routing
+
+Falcosidekick fans out Falco alerts to 50+ outputs. Enable alongside Falco:
+
+```bash
+helm upgrade --install falco falcosecurity/falco \
+  --namespace falco \
+  --create-namespace \
+  --set falcosidekick.enabled=true \
+  --set falcosidekick.webui.enabled=true \
+  -f falco-values.yaml
+```
+
+### Slack configuration
+
+```yaml
+falcosidekick:
+  config:
+    slack:
+      webhookurl: "https://hooks.slack.com/services/<token>"
+      minimumpriority: warning   # suppress DEBUG and INFO
+      messageformat: >
+        :rotating_light: *{{ .Rule }}* ({{ .Priority }})
+        Container: `{{ index .OutputFields "container.name" }}`
+        Image: `{{ index .OutputFields "container.image.repository" }}`
+        Cmdline: `{{ index .OutputFields "proc.cmdline" }}`
+        Pod: `{{ index .OutputFields "k8s.pod.name" }}` in `{{ index .OutputFields "k8s.ns.name" }}`
+```
+
+### Output types (selection)
+
+| Output | Config key | Use case |
+|---|---|---|
+| Slack | `slack.webhookurl` | Team alert channel |
+| Webhook | `webhook.address` | Custom handler or SIEM |
+| AWS SNS | `aws.sns.topicarn` | AWS-native alert pipeline |
+| PagerDuty | `pagerduty.routingkey` | On-call escalation |
+
+---
+
+## Bridging Falco → Kyverno
+
+Falco detects threats at runtime. Kyverno can prevent re-admission of flagged workloads.
+
+### Pattern
+
+1. Falco alert fires (e.g., shell in container)
+2. Alert webhook handler labels the Deployment: `security.platform/falco-alert: critical`
+3. Kyverno `ValidatingPolicy` blocks `CREATE`/`UPDATE` on Deployments with that label
+4. Ops team reviews, remediates, removes the label
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: ValidatingPolicy
+metadata:
+  name: block-falco-flagged-workloads
+spec:
+  validationActions: [Deny]
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["apps"]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["deployments"]
+  validations:
+  - expression: >
+      !has(object.metadata.labels) ||
+      !('security.platform/falco-alert' in object.metadata.labels) ||
+      object.metadata.labels['security.platform/falco-alert'] != 'critical'
+    message: >
+      This Deployment is flagged by a Falco critical alert. Remediate and remove
+      the security.platform/falco-alert label before redeploying.
+```
+
+See `examples/runtime-security/falco-kyverno-bridge.yaml` for the full policy with annotations.
+
+---
+
+## Resource Sizing
+
+| Component | CPU request | Memory request | Memory limit |
+|---|---|---|---|
+| Falco DaemonSet | 100m | 256Mi | 512Mi |
+| Falcosidekick Deployment | 100m | 128Mi | 256Mi |
+| Falcosidekick UI Deployment | 50m | 64Mi | 128Mi |
+
+**Do not set CPU limits on Falco.** Kernel event processing is bursty; a CPU limit causes throttling and missed events.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Rule not firing | Wrong condition field or event type | Test with `falco-event-generator`; check Falco startup logs for rule load errors |
+| Rule loaded but no alert | Event not reaching rule condition | Run event-generator; check `falco.priority` threshold |
+| High CPU on Falco pod | Too many low-priority events | Add conditions to narrow scope; raise `falco.priority` to `warning` |
+| Missed events | CPU throttling | Remove `limits.cpu` from Falco DaemonSet |
+| Falcosidekick not receiving | Falco gRPC not enabled | Set `falco.grpc.enabled: true` and `falco.grpc_output.enabled: true` |
+| DaemonSet not on tainted node | Missing toleration | Add `tolerations: [{effect: NoSchedule, operator: Exists}]` |
+| No events on GKE | Wrong driver for COS | Set `driver.kind: modern_ebpf` |
+| `failed to load module` | Using kmod driver on managed K8s | Switch to `driver.kind: modern_ebpf` |
+| Custom rules not loaded | Wrong mount path | Rules load from `/etc/falco/rules.d/`, not `/etc/falco/` |

--- a/references/supply-chain.md
+++ b/references/supply-chain.md
@@ -198,7 +198,7 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@5a775b367a56d5bd118a224a811bba288150a563  # v2.0.0
     # Pin to a specific release SHA for production. Get SHA via:
     # gh api repos/slsa-framework/slsa-github-generator/git/ref/tags/v2.0.0
     with:

--- a/references/supply-chain.md
+++ b/references/supply-chain.md
@@ -1,0 +1,276 @@
+# Supply Chain Security Reference
+
+Covers the full supply chain security stack: keyless image signing with Cosign, SBOM generation and attestation with Syft, CVE scanning with Trivy/Grype, SLSA Level 2 provenance, and Kyverno admission enforcement. All tools are open-source with no license cost.
+
+---
+
+## Tool Stack
+
+| Tool | Purpose | Project |
+|---|---|---|
+| Cosign (Sigstore) | Keyless image signing and verification | CNCF (Sigstore) |
+| Fulcio | Certificate authority for keyless signing | CNCF (Sigstore) |
+| Rekor | Transparency log for signatures and attestations | CNCF (Sigstore) |
+| Syft | SBOM generation (SPDX, CycloneDX) | Anchore OSS |
+| Trivy | CVE scanning, SBOM, misconfiguration detection | CNCF (Aqua) |
+| Grype | CVE scanning against Syft SBOM | Anchore OSS |
+| slsa-github-generator | SLSA Level 2/3 provenance via GitHub Actions | OpenSSF |
+| Kyverno ImageValidatingPolicy | Admission enforcement for signed images | CNCF |
+
+---
+
+## Keyless Signing with Cosign
+
+Keyless signing uses GitHub Actions OIDC tokens — no private key to store, rotate, or leak.
+
+### Flow
+
+```
+GitHub Actions OIDC token
+  → Fulcio CA (issues short-lived signing certificate)
+  → Cosign signs image digest with that certificate
+  → Signature + certificate uploaded to Rekor transparency log
+```
+
+### Sign in CI
+
+```yaml
+- name: Install Cosign
+  uses: sigstore/cosign-installer@11086d9f32b178aa24e93c2b86eba3ef4b16b68a  # v3.8.1
+
+- name: Sign image
+  run: |
+    cosign sign --yes \
+      ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+```
+
+**Always sign the digest, not the tag.** Tags are mutable; a digest is immutable.
+
+### Verify locally
+
+```bash
+cosign verify \
+  --certificate-identity-regexp="https://github.com/<org>/<repo>/.github/workflows/.*" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
+  ghcr.io/<org>/<image>@<digest>
+```
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `no matching signatures` | Image was pushed without signing step | Run the sign step after push, not before |
+| `certificate has expired` | Short-lived cert checked too late | Re-sign; keyless certs are valid for ~10 min |
+| `COSIGN_EXPERIMENTAL set in CI` | Leftover cosign v1 config | Remove it; keyless is the default in cosign v2 |
+
+---
+
+## SBOM Generation and Attestation with Syft
+
+An SBOM (Software Bill of Materials) lists every package inside the image. Attesting it as an OCI artifact links the SBOM to the specific image digest in Rekor.
+
+### Generate and attest
+
+```yaml
+- name: Generate SBOM
+  uses: anchore/sbom-action@61119d458adab75f756bc0b9e4bde25725f86a7a  # v0.20.0
+  with:
+    image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+    format: spdx-json
+    output-file: sbom.spdx.json
+
+- name: Attest SBOM
+  run: |
+    cosign attest --yes \
+      --predicate sbom.spdx.json \
+      --type spdxjson \
+      ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+```
+
+### SBOM formats
+
+| Format | Use case |
+|---|---|
+| `spdx-json` | Broadest tooling support; recommended default |
+| `cyclonedx-json` | Better for dependency tracking; preferred by some scanners |
+
+### Retrieve SBOM attestation
+
+```bash
+cosign download attestation \
+  --predicate-type https://spdx.dev/Document \
+  ghcr.io/<org>/<image>@<digest> \
+  | jq '.payload | @base64d | fromjson'
+```
+
+---
+
+## Vulnerability Scanning: Trivy vs Grype
+
+Both tools scan container images for CVEs. Use Trivy for new setups; use Grype if already using Syft in the pipeline.
+
+### Trivy (recommended)
+
+```yaml
+- name: Scan image
+  uses: aquasecurity/trivy-action@18f2135c0b15d26b3a4c2efded75e06b6f0e4884  # v0.30.0
+  with:
+    image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+    format: table
+    exit-code: '1'
+    ignore-unfixed: true
+    vuln-type: os,library
+    severity: CRITICAL,HIGH
+```
+
+`ignore-unfixed: true` suppresses CVEs with no available fix — they cannot be actioned, and suppressing them reduces noise without weakening the gate.
+
+### Grype (Anchore)
+
+```yaml
+- name: Scan with Grype
+  uses: anchore/scan-action@v6
+  with:
+    image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+    fail-build: true
+    severity-cutoff: high
+```
+
+### Severity gate strategy
+
+| Gate | What it catches | Recommended for |
+|---|---|---|
+| `CRITICAL` only | Actively exploited, widely known | Minimum viable gate |
+| `CRITICAL,HIGH` | High-impact CVEs with known exploit paths | **Recommended default** |
+| `CRITICAL,HIGH,MEDIUM` | Broad coverage | Regulated environments |
+
+---
+
+## SLSA Level 2 Provenance
+
+SLSA (Supply-chain Levels for Software Artifacts) Level 2 provides a signed attestation linking the artifact to the exact build inputs: source commit, workflow, and runner.
+
+### What each level requires
+
+| Level | Requirement |
+|---|---|
+| L1 | Provenance generated (unsigned) |
+| **L2** | Provenance signed by CI; hosted build platform |
+| L3 | Hardened builds; hermetic; no secret injection |
+
+**L2 is achievable on standard GitHub-hosted runners. L3 requires hermetic builds (not available on standard runners).**
+
+### Workflow (slsa-github-generator)
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355  # v6.10.0
+        with:
+          push: true
+          tags: ghcr.io/<org>/<image>:${{ github.sha }}
+
+  provenance:
+    needs: build
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ghcr.io/<org>/<image>
+      digest: ${{ needs.build.outputs.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Verify provenance
+
+```bash
+slsa-verifier verify-image \
+  ghcr.io/<org>/<image>@<digest> \
+  --source-uri github.com/<org>/<repo> \
+  --source-branch main
+```
+
+---
+
+## Kyverno Admission Enforcement
+
+Block unsigned or unverified images at the Kubernetes admission layer using `ImageValidatingPolicy`.
+
+### Keyless policy (Sigstore)
+
+```yaml
+apiVersion: policies.kyverno.io/v1
+kind: ImageValidatingPolicy
+metadata:
+  name: require-signed-images
+  namespace: production
+spec:
+  validationActions: [Audit]   # switch to [Deny] after all images are signing
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["pods"]
+  matchImageReferences:
+  - glob: "ghcr.io/<org>/*"
+  validations:
+  - expression: >
+      images.containers.map(image, verifyImageSignatures(image, [{"keyless": {
+        "url": "https://fulcio.sigstore.dev",
+        "rekor": {"url": "https://rekor.sigstore.dev"},
+        "identities": [{"issuer": "https://token.actions.githubusercontent.com",
+          "subjectRegExp": "https://github.com/<org>/.*/.github/workflows/.*@refs/heads/main"}]
+      }}])).all(e, e > 0)
+    message: "Image must be signed via Sigstore keyless signing from GitHub Actions (main branch)"
+```
+
+**Note:** Targeting `pods` in the core API group ensures all workloads are covered, including those created by Jobs, CronJobs, and bare pod specs. Kyverno's autogen can extend coverage to higher-level controllers but is not enabled by default for ImageValidatingPolicy.
+
+### Deployment strategy
+
+1. Start with `validationActions: [Audit]` — monitor violations without blocking
+2. Review audit events: `kubectl get policyreport -A`
+3. Move to `validationActions: [Deny]` once all images in scope are signing
+
+### Cross-reference
+
+For full `ImageValidatingPolicy` syntax, CEL expressions, and kyverno-cli testing: see `references/kyverno.md`.
+
+---
+
+## Gap Classification (for audit mode)
+
+| Gap | Severity | Impact |
+|---|---|---|
+| No image signing | Critical | Any image admitted; no provenance chain |
+| No CVE severity gate | Critical | Vulnerable images ship to production |
+| No SBOM | High | Cannot audit what packages are running |
+| Severity gate CRITICAL only | High | HIGH-severity CVEs pass undetected |
+| Action versions pinned to tag | Medium | Supply chain attack via tag mutation |
+| No SLSA provenance | Medium | No cryptographic link between build and artifact |
+| SBOM not attested | Medium | SBOM exists but not linked to image |
+
+---
+
+## Recommended rollout order
+
+1. **Sign** — establish provenance chain first
+2. **Scan gate** — block CVEs from shipping
+3. **SBOM** — generate and attest
+4. **Enforce** — Kyverno `ImageValidatingPolicy` in Audit mode
+5. **SLSA** — add Level 2 provenance attestation
+6. **Enforce → Deny** — harden admission after all images are signing

--- a/references/supply-chain.md
+++ b/references/supply-chain.md
@@ -35,6 +35,11 @@ GitHub Actions OIDC token
 ### Sign in CI
 
 ```yaml
+# Job-level permissions required for keyless signing
+permissions:
+  id-token: write   # required for Cosign OIDC token exchange with Fulcio
+  packages: write   # required to push to GHCR
+
 - name: Install Cosign
   uses: sigstore/cosign-installer@11086d9f32b178aa24e93c2b86eba3ef4b16b68a  # v3.8.1
 
@@ -72,6 +77,11 @@ An SBOM (Software Bill of Materials) lists every package inside the image. Attes
 ### Generate and attest
 
 ```yaml
+# Job-level permissions required for cosign attest
+permissions:
+  id-token: write   # required for Cosign OIDC token exchange with Fulcio
+  packages: write   # required to push attestation to GHCR
+
 - name: Generate SBOM
   uses: anchore/sbom-action@61119d458adab75f756bc0b9e4bde25725f86a7a  # v0.20.0
   with:
@@ -129,7 +139,7 @@ Both tools scan container images for CVEs. Use Trivy for new setups; use Grype i
 
 ```yaml
 - name: Scan with Grype
-  uses: anchore/scan-action@v6
+  uses: anchore/scan-action@16910d14a7731ecfd3ac9785e39a479f53cca83c  # v3.9.0
   with:
     image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
     fail-build: true
@@ -172,6 +182,9 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
       - name: Build and push
         id: build
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355  # v6.10.0
@@ -185,7 +198,9 @@ jobs:
       actions: read
       id-token: write
       packages: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    # Pin to a specific release SHA for production. Get SHA via:
+    # gh api repos/slsa-framework/slsa-github-generator/git/ref/tags/v2.0.0
     with:
       image: ghcr.io/<org>/<image>
       digest: ${{ needs.build.outputs.digest }}
@@ -216,9 +231,13 @@ apiVersion: policies.kyverno.io/v1
 kind: ImageValidatingPolicy
 metadata:
   name: require-signed-images
-  namespace: production
+  annotations:
+    policies.kyverno.io/title: Require Signed Images
+    policies.kyverno.io/description: >
+      Block admission of images not signed via Sigstore keyless signing from GitHub Actions.
+      Apply to selected namespaces using matchConditions.
 spec:
-  validationActions: [Audit]   # switch to [Deny] after all images are signing
+  validationActions: [Audit]   # switch to [Deny] after all images are signed
   matchConstraints:
     resourceRules:
     - apiGroups: [""]
@@ -227,24 +246,30 @@ spec:
       resources: ["pods"]
   matchImageReferences:
   - glob: "ghcr.io/<org>/*"
+  attestors:
+  - name: cosign
+    cosign:
+      keyless:
+        identities:
+        - issuer: "https://token.actions.githubusercontent.com"
+          subjectRegExp: "https://github.com/<org>/.*/.github/workflows/.*@refs/heads/main"
+        ctlog:
+          url: https://rekor.sigstore.dev
   validations:
-  - expression: >
-      images.containers.map(image, verifyImageSignatures(image, [{"keyless": {
-        "url": "https://fulcio.sigstore.dev",
-        "rekor": {"url": "https://rekor.sigstore.dev"},
-        "identities": [{"issuer": "https://token.actions.githubusercontent.com",
-          "subjectRegExp": "https://github.com/<org>/.*/.github/workflows/.*@refs/heads/main"}]
-      }}])).all(e, e > 0)
-    message: "Image must be signed via Sigstore keyless signing from GitHub Actions (main branch)"
+  - expression: >-
+      images.containers.map(image,
+        verifyImageSignatures(image, [attestors.cosign])
+      ).all(e, e > 0)
+    message: "Image must be signed via Sigstore keyless signing from GitHub Actions (main branch)."
 ```
 
-**Note:** Targeting `pods` in the core API group ensures all workloads are covered, including those created by Jobs, CronJobs, and bare pod specs. Kyverno's autogen can extend coverage to higher-level controllers but is not enabled by default for ImageValidatingPolicy.
+**Note:** `ImageValidatingPolicy` is cluster-scoped — there is no `namespace` field in metadata. Targeting `pods` in the core API group ensures all workloads are covered, including those created by Jobs, CronJobs, and bare pod specs. Kyverno's autogen can extend coverage to higher-level controllers but is not enabled by default for ImageValidatingPolicy.
 
 ### Deployment strategy
 
 1. Start with `validationActions: [Audit]` — monitor violations without blocking
 2. Review audit events: `kubectl get policyreport -A`
-3. Move to `validationActions: [Deny]` once all images in scope are signing
+3. Move to `validationActions: [Deny]` once all images in scope are signed
 
 ### Cross-reference
 
@@ -273,4 +298,4 @@ For full `ImageValidatingPolicy` syntax, CEL expressions, and kyverno-cli testin
 3. **SBOM** — generate and attest
 4. **Enforce** — Kyverno `ImageValidatingPolicy` in Audit mode
 5. **SLSA** — add Level 2 provenance attestation
-6. **Enforce → Deny** — harden admission after all images are signing
+6. **Enforce → Deny** — harden admission after all images are signed

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platform-skills
-description: Hands-on guidance for platform and DevOps engineers working with Kubernetes, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, compliance, KEDA event-driven autoscaling, and self-improving agent patterns. Use when designing or troubleshooting Kubernetes workloads and RBAC, writing Terraform modules, configuring Flux or Argo CD, setting up CI/CD pipelines, managing cloud identity and IAM, handling secrets, diagnosing DNS or VPC connectivity, operating a service mesh, applying product thinking to developer experience, implementing SOC 2 compliance controls in Terraform, scaling workloads with KEDA scalers (SQS, Kafka, Prometheus, Cron, HTTP), or bootstrapping .learnings/ directories, WAL protocol, VFM scoring, and proactive agent behavior — at any scale, for any team size.
+description: Hands-on guidance for platform and DevOps engineers working with Kubernetes, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, compliance, KEDA event-driven autoscaling, and self-improving agent patterns. Use when designing or troubleshooting Kubernetes workloads and RBAC, writing Terraform modules, configuring Flux or Argo CD, setting up CI/CD pipelines, managing cloud identity and IAM, handling secrets, diagnosing DNS or VPC connectivity, operating a service mesh, applying product thinking to developer experience, implementing SOC 2 compliance controls in Terraform, scaling workloads with KEDA scalers (SQS, Kafka, Prometheus, Cron, HTTP), or bootstrapping .learnings/ directories, WAL protocol, VFM scoring, and proactive agent behavior — at any scale, for any team size, supply chain security (Cosign, Syft, Trivy, SLSA, image signing enforcement), and Kubernetes runtime security (Falco eBPF, custom rules, Falcosidekick alert routing)
 ---
 
 # Platform Skills
@@ -35,6 +35,8 @@ Match the task to the right layer:
 22. `PR Comment Triage`: Triage bot or human PR comments, classify them as ACTIONABLE_FIX / INFORMATIONAL / NOT_APPLICABLE, make the minimal fix when valid, reply on the thread, and resolve it through `gh`.
 23. `KEDA`: Design, generate, debug, and review KEDA ScaledObject and ScaledJob resources. Covers all major scalers (Prometheus, SQS, Kafka, Redis, Cron, HTTP Add-on, Azure Service Bus), TriggerAuthentication with IRSA/Workload Identity, scaling lifecycle tuning, scale-to-zero patterns, and GitOps integration.
 24. `Agent Self-Improvement`: Bootstrap and operate self-improving, proactive agent workspaces. Covers `.learnings/` directory setup, LRN/ERR/FEAT entry lifecycle, recurring pattern detection, promotion to project memory, WAL protocol, working buffer, VFM scoring, ADL decision logic, Six Operating Pillars, heartbeat, and reverse prompting.
+25. `Supply Chain Security`: Secure the build pipeline and image lifecycle with Cosign keyless signing (Sigstore/Rekor), Syft SBOM generation and attestation, Trivy/Grype CVE scanning with severity gates, SLSA Level 2 provenance, and Kyverno ImageValidatingPolicy admission enforcement. All open-source, no license cost.
+26. `Runtime Security`: Detect in-container threats at the syscall level with Falco (eBPF driver, CNCF, no license cost). Covers eBPF driver deployment on EKS/GKE, custom rule authoring, Falcosidekick alert routing to Slack/PagerDuty/webhook, rule debugging, and bridging runtime signals to Kyverno admission enforcement.
 
 If a task spans multiple areas, decide which layer owns the source of truth and keep the other layers consumers of that state.
 
@@ -121,3 +123,5 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:triage` — triage a PR comment (bot or human): classify as ACTIONABLE_FIX / INFORMATIONAL / NOT_APPLICABLE, produce the exact fix if needed, and write the thread reply
 - `/platform-skills:keda` — design, generate, debug, or review KEDA ScaledObject/ScaledJob autoscaling
 - `/platform-skills:self-improve` — bootstrap `.learnings/` directory, log learnings/errors/feature requests, review recurring patterns, and promote entries to project memory
+- `/platform-skills:supply-chain` — sign images, generate and attest SBOMs, run CVE severity gates, enforce image signatures in Kubernetes, and generate SLSA Level 2 provenance
+- `/platform-skills:runtime-security` — deploy Falco with eBPF, write custom rules, route alerts, debug why a rule is not firing, and bridge Falco signals to Kyverno admission enforcement

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -95,6 +95,8 @@ When asked to generate code, start from the thinnest useful slice that proves th
 - For comprehensive PR review — cost impact, environment drift, ownership gaps, SOC 2 compliance, deprecated APIs, version hygiene, rollback feasibility, and bot comment triage — read [references/pr-review.md](references/pr-review.md).
 - For KEDA event-driven autoscaling — ScaledObject, ScaledJob, TriggerAuthentication, IRSA, scalers (Prometheus, SQS, Kafka, Redis, Cron, HTTP Add-on, Azure Service Bus), scaling lifecycle, security patterns, and troubleshooting — read [references/keda.md](references/keda.md).
 - For agent self-improvement patterns — `.learnings/` directory, WAL protocol, VFM scoring, ADL Protocol, working buffer, and proactive agent behavior — read [references/agent-self-improve.md](references/agent-self-improve.md).
+- For supply chain security — Cosign keyless signing, Syft SBOM generation and attestation, Trivy/Grype CVE scanning, SLSA Level 2 provenance, and Kyverno ImageValidatingPolicy enforcement — read [references/supply-chain.md](references/supply-chain.md).
+- For Kubernetes runtime security — Falco eBPF deployment on EKS/GKE, custom rule authoring, Falcosidekick alert routing, and bridging Falco signals to Kyverno admission enforcement — read [references/runtime-security.md](references/runtime-security.md).
 
 Load only the files needed for the current request.
 

--- a/tests/validate-skill.sh
+++ b/tests/validate-skill.sh
@@ -64,6 +64,8 @@ REQUIRED_REFERENCES=(
   references/pr-review.md
   references/keda.md
   references/agent-self-improve.md
+  references/supply-chain.md
+  references/runtime-security.md
 )
 
 for ref in "${REQUIRED_REFERENCES[@]}"; do
@@ -100,6 +102,8 @@ EXAMPLE_DOMAINS=(
   examples/triage
   examples/keda
   examples/agent-self-improve
+  examples/supply-chain
+  examples/runtime-security
 )
 
 for domain in "${EXAMPLE_DOMAINS[@]}"; do
@@ -235,6 +239,8 @@ VALIDATE_SCRIPTS=(
   "examples/terraform/terraform-validate.sh"
   "examples/github-actions/gha-validate.sh"
   "examples/compliance/compliance-validate.sh"
+  "examples/supply-chain/supply-chain-validate.sh"
+  "examples/runtime-security/runtime-security-validate.sh"
 )
 
 for script in "${VALIDATE_SCRIPTS[@]}"; do


### PR DESCRIPTION
## Summary

- Adds Domain 25: \`/platform-skills:supply-chain\` — Cosign keyless signing (Sigstore/Rekor), Syft SBOM generation and OCI attestation, Trivy/Grype CVE gates with severity thresholds, SLSA Level 2 provenance, and Kyverno \`ImageValidatingPolicy\` admission enforcement
- Adds Domain 26: \`/platform-skills:runtime-security\` — Falco eBPF deployment on EKS/GKE, custom Falco rule authoring, Falcosidekick alert routing to Slack/webhook/PagerDuty, rule debugging, and Falco→Kyverno bridge pattern
- All tooling is open-source with no license cost (Cosign, Syft, Trivy, Grype, Falco, Falcosidekick, Kyverno)
- 17 commits — command files, reference guides, 11 working examples, validate scripts, and all registry updates

## Files changed

**New files (Domain 25 — Supply Chain):**
- \`commands/supply-chain.md\` — 6-mode slash command (audit/sign/sbom/scan/enforce/slsa)
- \`references/supply-chain.md\` — keyless signing, SBOM, CVE gates, SLSA L2, Kyverno enforcement
- \`examples/supply-chain/\` — 5 GitHub Actions workflows + 1 Kyverno policy + validate script

**New files (Domain 26 — Runtime Security):**
- \`commands/runtime-security.md\` — 5-mode slash command (install/rules/alerts/debug/harden)
- \`references/runtime-security.md\` — Falco architecture, EKS/GKE install, rules, Falcosidekick, Kyverno bridge
- \`examples/runtime-security/\` — 4 Helm values files + 1 Kyverno policy + validate script

**Updated registry files:**
- \`SKILL.md\` / \`skills/platform-skills/SKILL.md\` — entries 25+26, reference pointers, command list
- \`COMMANDS.md\` — two full command blocks with modes, usage, and key rules
- \`GETTING_STARTED.md\` / \`HOW_IT_WORKS.md\` — table rows for both new commands
- \`.claude-plugin/plugin.json\` / \`marketplace.json\` — version 1.16.0, new commands, keywords
- \`tests/validate-skill.sh\` — new domains registered in REQUIRED_REFERENCES, EXAMPLE_DOMAINS, VALIDATE_SCRIPTS
- \`CHANGELOG.md\` — \`[1.16.0]\` section

## Test plan

- [x] \`bash tests/validate-skill.sh\` — PASS (0 failures)
- [x] \`bash examples/supply-chain/supply-chain-validate.sh\` — PASS (5 YAML files)
- [x] \`bash examples/runtime-security/runtime-security-validate.sh\` — PASS (4 YAML files)