### PR TITLE
feat(self-improve): add closing log step to triage, supply-chain, runtime-security commands

### DIFF
--- a/commands/runtime-security.md
+++ b/commands/runtime-security.md
@@ -194,3 +194,14 @@ Steps:
 4. Remediation workflow: fix the workload → remove the label → re-admit
 
 Reference: `references/runtime-security.md` → Kyverno bridge, `references/kyverno.md` → ValidatingPolicy
+
+---
+
+## Closing — Log learnings
+
+After completing any runtime-security mode, log findings while context is fresh:
+
+- Incorrect Falco field, wrong driver, or broken rule condition discovered → log as `ERR` in `.learnings/ERRORS.md`
+- A rule pattern, operator, or configuration approach that worked → log as `LRN` in `.learnings/LEARNINGS.md`
+
+Use `/platform-skills:self-improve log` for each entry. Do not defer to end of session.

--- a/commands/supply-chain.md
+++ b/commands/supply-chain.md
@@ -211,3 +211,14 @@ Steps:
 4. Note: `generator_container_slsa3.yml` produces L2 provenance by default; L3 requires hermetic builds not available on standard GitHub-hosted runners
 
 Reference: `references/supply-chain.md` → SLSA levels, slsa-github-generator
+
+---
+
+## Closing — Log learnings
+
+After completing any supply-chain mode, log findings while context is fresh:
+
+- Incorrect action version, wrong flag, or broken reference discovered → log as `ERR` in `.learnings/ERRORS.md`
+- A pattern or approach that worked well → log as `LRN` in `.learnings/LEARNINGS.md`
+
+Use `/platform-skills:self-improve log` for each entry. Do not defer to end of session.

--- a/commands/triage.md
+++ b/commands/triage.md
@@ -171,3 +171,14 @@ When `--all` mode finishes, print a summary table:
 | #<id> | @<login> | INFORMATIONAL  | Replied, thread resolved |
 | #<id> | @<login> | NOT_APPLICABLE | Replied, thread resolved |
 ```
+
+---
+
+## Closing — Log learnings
+
+After completing triage (single comment or `--all`), log any errors or learnings that surfaced:
+
+- Each ACTIONABLE_FIX that required a non-obvious correction → log as `ERR` in `.learnings/ERRORS.md`
+- Any pattern or shortcut that worked well → log as `LRN` in `.learnings/LEARNINGS.md`
+
+Use `/platform-skills:self-improve log` for each entry worth keeping. Do not defer — log while the context is fresh.


### PR DESCRIPTION
## Summary

- Adds a `## Closing — Log learnings` section to `commands/triage.md`, `commands/supply-chain.md`, and `commands/runtime-security.md`
- Each section instructs the agent to log errors and learnings via `/platform-skills:self-improve log` immediately after completing work — not deferred to end of session
- Companion change (local only, not committed): added a `PostToolUse` hook on `git commit` in `.claude/settings.json` that prompts a log check after every commit

## Motivation

During v1.16.0 implementation, 7 errors and 4 learnings were never logged during the session. They were only recoverable because the session summary captured them before context was dropped. This PR makes incremental logging an explicit step in the three most active workflows.

## Test plan

- [ ] Run `/platform-skills:triage --all <PR>` and verify the closing log section appears in the skill output
- [ ] Run `/platform-skills:supply-chain audit` and verify same
- [ ] Run `/platform-skills:runtime-security install` and verify same