### PR TITLE
chore: bump version to v1.17.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "description": "Practical guidance for platform engineers: Kubernetes, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP server development, observability (Prometheus/OpenTelemetry/Grafana), code documentation (OpenAPI/docstrings), SOC 2 compliance for Terraform, Datadog, Dynatrace, conventional commit message generation, OPA/Conftest Rego policies, Kyverno admission policies (ValidatingPolicy/MutatingPolicy/GeneratingPolicy/ImageValidatingPolicy, CEL expressions, Audit→Deny promotion), comprehensive PR review (cost impact, environment drift, ownership governance, compliance, deprecated API upgrade, rollback feasibility), PR comment triage, KEDA event-driven autoscaling (ScaledObject, ScaledJob, TriggerAuthentication, Prometheus/SQS/Kafka/Redis/Cron/HTTP/Azure scalers, scale-to-zero, IRSA), supply chain security (Cosign keyless signing, Syft SBOM, Trivy/Grype CVE gates, SLSA Level 2, Kyverno ImageValidatingPolicy enforcement), and Kubernetes runtime security (Falco eBPF, custom rules, Falcosidekick alert routing, Kyverno bridge). Covers troubleshooting, security-first patterns, DevEx, RFC/ADR, compliance controls, and working examples — at any scale.",
       "author": {
         "name": "Nitin Jain"
@@ -121,7 +121,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "da491846b0be793a7fc7b6716608ca6d693cb412"
+        "sha": "daba1ef692c7f4f1b5296f389bae2981721ed5ff"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-skills",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Practical guidance for platform engineers: Kubernetes, Kyverno admission policies, Helm, Terraform, GitOps, GitHub Actions, AWS, Azure, Linkerd, Linux, networking, MCP development, observability, code documentation, SOC 2 compliance, comprehensive PR review, PR comment triage, and KEDA event-driven autoscaling.",
   "author": {
     "name": "Nitin Jain",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.0] - 2026-05-20
+
+### Added
+
+- Closing `## Closing — Log learnings` section added to `commands/triage.md`, `commands/supply-chain.md`, and `commands/runtime-security.md` — each workflow now ends with an explicit step to log errors and learnings via `/platform-skills:self-improve log` immediately after completing work, preventing context loss across sessions
+- PostToolUse hook in `.claude/settings.json` (local, not committed) prompts incremental learning capture after every `git commit`
+
+### Changed
+
+- Promoted 10 learnings from v1.16.0 session to `CLAUDE.md` and reference guides (`references/supply-chain.md`, `references/runtime-security.md`, `references/kyverno.md`) as permanent agent rules
+
 ## [1.16.0] - 2026-05-20
 
 ### Added

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -60,7 +60,7 @@ claude plugin install platform-skills
 
 ```bash
 claude plugin list
-# platform-skills  v1.16.0  enabled
+# platform-skills  v1.17.0  enabled
 ```
 
 **Upgrade:**


### PR DESCRIPTION
## Summary

- Bumps version to `1.17.0` in `marketplace.json`, `plugin.json`, `INSTALLATION.md`
- Updates `marketplace.json source.sha` to current HEAD (`daba1ef`)
- Adds `[1.17.0]` CHANGELOG entry covering the closing log step additions and promoted learnings

## What's in 1.17.0

- `feat(self-improve)`: closing log step in triage, supply-chain, runtime-security commands (PR #37)
- `docs(memory)`: 10 learnings from v1.16.0 session promoted to CLAUDE.md and reference guides

## Test plan

- [ ] CI validates version strings match
- [ ] CI validates source.sha is reachable from tag
- [ ] Merge and tag `v1.17.0`