### PR TITLE
docs(memory): promote ERR-009, ERR-010, CI-pattern to agent rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,3 +332,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for:
 ---
 
 Built with ❤️ by platform engineers, for platform engineers.
+
+## Agent Rules
+
+Rules promoted from `.learnings/` — apply to every session in this project.
+
+- Log errors and learnings at the point of discovery — never defer to end of session.
+- Dispatch all independent tool calls in a single message block — sequential calls only when output feeds the next.
+- Run `bash scripts/handbook-consistency.sh` locally before every push to catch version/status/path check failures.


### PR DESCRIPTION
## Summary

- Promotes three resolved `.learnings/` entries to permanent `## Agent Rules` in `CLAUDE.md`
- **ERR-009**: Log errors and learnings at point of discovery, not end of session
- **ERR-010**: Dispatch independent tool calls in a single parallel message block
- **CI pattern**: Run `handbook-consistency.sh` locally before every push
- Marks `FEAT-002` resolved — PostToolUse hook + closing log steps shipped in v1.17.0

## Test plan

- [ ] `CLAUDE.md` contains `## Agent Rules` section with 3 rules
- [ ] Rules are imperative voice, ≤ 80 characters each
- [ ] No other files changed