### PR TITLE
chore: update marketplace.json source.sha to v1.19.0 release commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -139,7 +139,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "497d92929edf5eff01083c6ebca2a9ec552c3505"
+        "sha": "cbcb09f227b57321286ba0c6126467afbfe4a809"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
Updates `source.sha` in `marketplace.json` to the v1.19.0 merge commit `cbcb09f` following the release of [Platform Skills v1.19.0](https://github.com/nitinjain999/platform-skills/releases/tag/v1.19.0).