### PR TITLE
chore: update marketplace.json source.sha to v1.20.0 release commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -139,7 +139,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "cbcb09f227b57321286ba0c6126467afbfe4a809"
+        "sha": "8003d8b6b4b35d0e232dacb0e90d865f1c4aa944"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
## Summary

- Updates `source.sha` in `.claude-plugin/marketplace.json` to point to the v1.20.0 merge commit (`8003d8b6b4b35d0e232dacb0e90d865f1c4aa944`)

## Why

Marketplace consumers resolve the plugin from the SHA. Without this update, they would continue to resolve the pre-v1.20.0 tree, missing the LLM Observability content, pup CLI docs, and Datadog Labs skills added in this release.