### PR TITLE
chore: add community health files (CoC, PR template, issue templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Incorrect, outdated, or misleading content in a reference guide or example
+labels: bug
+assignees: ''
+---
+
+## What's wrong
+
+<!-- Describe the incorrect or misleading content. Be specific: file, section, line. -->
+
+**File / section:**
+
+**What it currently says:**
+
+**Why it's wrong:**
+
+## Correct behavior / expected content
+
+<!-- What should it say instead? Include evidence — docs link, test output, version notes. -->
+
+## Environment
+
+- Tool / service version:
+- Cloud provider / platform:
+- Claude Code version (if relevant):
+
+## Additional context
+
+<!-- Anything else that would help reproduce or understand the issue. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/nitinjain999/platform-skills/security/advisories/new
+    about: Report a security issue privately via GitHub Security Advisories

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a new skill command, mode, or tooling improvement
+labels: feature-request
+assignees: ''
+---
+
+## What would you like to see
+
+<!-- Describe the skill feature, slash command, or workflow improvement. -->
+
+## Use case
+
+<!-- What task are you trying to accomplish? How does the missing feature block you? -->
+
+## Proposed interface (optional)
+
+<!-- If it's a new slash command or mode, sketch how it would work.
+     Example: `/platform-skills:audit --scope iam` → lists IAM findings -->
+
+## Alternatives considered
+
+<!-- What workarounds are you using today? -->

--- a/.github/ISSUE_TEMPLATE/new_pattern.md
+++ b/.github/ISSUE_TEMPLATE/new_pattern.md
@@ -1,0 +1,30 @@
+---
+name: New pattern or domain
+about: Propose a new reference guide, example, or pattern for an existing domain
+labels: enhancement
+assignees: ''
+---
+
+## What problem does this solve
+
+<!-- What platform engineering problem is currently undocumented or poorly covered? -->
+
+## Proposed content
+
+<!-- Describe the pattern, guide, or example you'd like to see added.
+     Reference the target file: references/, examples/, or SKILL.md. -->
+
+**Target file:**
+
+**Pattern / domain:**
+
+**Outline (optional):**
+
+## Evidence this works in production
+
+<!-- Has this been validated in a real environment? Tool versions, cluster details, test output. -->
+
+## Are you willing to contribute it?
+
+- [ ] Yes, I'll open a PR
+- [ ] No, I'm requesting it from the maintainer

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- What does this PR do? One paragraph is enough. -->
+
+## Type of change
+
+- [ ] New domain or reference guide
+- [ ] New example(s)
+- [ ] Bug fix / correction to existing content
+- [ ] Improvement to existing pattern
+- [ ] Tooling / CI change
+- [ ] Other (describe below)
+
+## Checklist
+
+- [ ] Technically accurate and tested in a real environment
+- [ ] Follows the [writing principles](CLAUDE.md#writing-principles) (problem-first, concrete examples, blast radius documented)
+- [ ] Security-conscious — least privilege defaults, no wildcard IAM
+- [ ] Includes rollback plan for any risky operation
+- [ ] `CHANGELOG.md` updated
+- [ ] `README.md` badge counts updated (if adding domains, commands, or examples)
+- [ ] `bash tests/handbook-consistency.sh` passes locally
+
+## Validation steps
+
+<!-- How did you verify this works? Commands run, cluster version, tool versions. -->
+
+## Related issues
+
+<!-- Closes #... -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,3 +341,4 @@ Rules promoted from `.learnings/` — apply to every session in this project.
 - Dispatch all independent tool calls in a single message block — sequential calls only when output feeds the next.
 - Run `bash tests/handbook-consistency.sh` locally before every push to catch version/status/path check failures.
 - Use `repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies` for PR thread replies — omitting the PR number returns 404.
+- At the end of every session, append notable exchanges, decisions, and outcomes to `memory/YYYY-MM-DD.md` (today's date, created if missing). One file per day, append-only.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+## Our Pledge
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+**Positive behavior includes:**
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+**Unacceptable behavior includes:**
+- Trolling, insulting, or derogatory comments
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Sustained disruption of discussions
+- Other conduct reasonably considered inappropriate in a professional setting
+
+## Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, and other contributions that are not aligned to this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies in all project spaces — GitHub issues, pull requests, discussions, and any other forums managed by this project.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening a GitHub issue or contacting the maintainer directly via GitHub. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.


### PR DESCRIPTION
## Summary

Adds standard GitHub community health files to make contribution expectations clear and streamline issue/PR workflows.

**Files added:**
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1, adapted for this project
- `.github/PULL_REQUEST_TEMPLATE.md` — checklist-driven template covering type of change, review checklist (includes handbook-consistency check), validation steps, and related issues
- `.github/ISSUE_TEMPLATE/bug_report.md` — structured report for incorrect/outdated content
- `.github/ISSUE_TEMPLATE/new_pattern.md` — proposal template for new domains or reference guides
- `.github/ISSUE_TEMPLATE/feature_request.md` — template for new skill commands or modes
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, links to Security Advisories for vulnerabilities

## Checklist

- [x] No code changes — documentation and GitHub config only
- [x] `CHANGELOG.md` not required (no skill or content change)
- [x] `README.md` badge counts unchanged