### PR TITLE
chore: update marketplace.json source.sha to v1.22.0 release commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -144,7 +144,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "6a4cb35404ec4ac5bbb4fd608408b5f7cb6b069c"
+        "sha": "85fe2a0070e47edaf441f3a1902f15d8219f2628"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
## Summary

- Updates `source.sha` in `.claude-plugin/marketplace.json` to point to the v1.22.0 merge commit (`85fe2a0`)
- Required before tagging `v1.22.0` — the release workflow validates that `source.sha` is a reachable ancestor of the tagged commit