### PR TITLE
docs(memory): promote v1.22.0 learnings — release checklist, SDK verification, sibling dynamic blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,3 +342,5 @@ Rules promoted from `.learnings/` — apply to every session in this project.
 - Run `bash tests/handbook-consistency.sh` locally before every push to catch version/status/path check failures.
 - Use `repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies` for PR thread replies — omitting the PR number returns 404.
 - At the end of every session, append notable exchanges, decisions, and outcomes to `memory/YYYY-MM-DD.md` (today's date, created if missing). One file per day, append-only.
+- Before every release commit, verify: (1) `SKILL.md` matches `skills/platform-skills/SKILL.md`, (2) `INSTALLATION.md` version matches plugin version, (3) all example READMEs have `Status:` label, (4) `marketplace.json` `source.sha` is the current main HEAD SHA.
+- Never write SDK method names, parameter names, or env vars for external tools (Datadog, LLMObs, etc.) without fetching actual SDK source or docs first.

--- a/references/terraform.md
+++ b/references/terraform.md
@@ -171,3 +171,48 @@ Minimum CI for Terraform changes:
 5. Controlled `apply` through protected environments
 
 If the task involves module quality, add tests or example validation. If the task involves platform rollout, focus on safe composition, state isolation, and promotion gates before writing module internals.
+
+## Sensitive-conditional dynamic blocks
+
+When a `dynamic` block's `for_each` condition depends on a sensitive nullable variable, none of the common single-block patterns work in Terraform 1.7:
+
+| Pattern | Failure |
+|---|---|
+| `for_each = condition ? [1] : []` | list literal rejected in some nested contexts |
+| `for_each = toset([var.secret])` | sensitive value cannot be a set element (used as key) |
+| `for_each = { k = var.secret }` | sensitive map value rejected |
+| `for_each = { k = true } if condition` | bool map rejected inside nested `dynamic` |
+
+**Reliable pattern: two sibling `dynamic` blocks**
+
+Use one block for each branch of the condition, with a literal non-sensitive map key:
+
+```hcl
+# Branch A — secret not set
+dynamic "origin" {
+  for_each = local.use_alb && var.cloudfront_origin_secret == null ? { alb = true } : {}
+  content {
+    domain_name = var.custom_origin_domain
+    origin_id   = local.alb_origin_id
+    custom_origin_config { http_port = 80; https_port = 443; origin_protocol_policy = "https-only"; origin_ssl_protocols = ["TLSv1.2"] }
+  }
+}
+
+# Branch B — secret present
+dynamic "origin" {
+  for_each = local.use_alb && var.cloudfront_origin_secret != null ? { alb = true } : {}
+  content {
+    domain_name = var.custom_origin_domain
+    origin_id   = local.alb_origin_id
+    custom_origin_config { http_port = 80; https_port = 443; origin_protocol_policy = "https-only"; origin_ssl_protocols = ["TLSv1.2"] }
+    custom_header {
+      name  = "X-CloudFront-Secret"
+      value = var.cloudfront_origin_secret
+    }
+  }
+}
+```
+
+The null-check (`== null` / `!= null`) moves the sensitive comparison out of the `for_each` value entirely, leaving only a plain bool map key `{ alb = true }`. Terraform accepts this in all nesting contexts.
+
+Apply this pattern any time a block is conditionally rendered based on whether a sensitive nullable variable is set.


### PR DESCRIPTION
## Summary

- **Release pre-flight checklist** (new CLAUDE.md Agent Rule): verify `SKILL.md` ↔ `skills/platform-skills/SKILL.md` sync, `INSTALLATION.md` version, example README `Status:` labels, and `marketplace.json` `source.sha` before every release commit. Consolidates ERR-20260520-006/007/012 and ERR-20260522-002/005.
- **SDK surface verification** (new CLAUDE.md Agent Rule): never write method names, parameter names, or env vars for external SDKs (Datadog, LLMObs, etc.) without fetching actual source or docs first. Consolidates ERR-20260520-014 through 019.
- **Sensitive-conditional dynamic blocks** (new `references/terraform.md` section): documents the two-sibling-dynamic-blocks pattern — the only Terraform 1.7 approach that works when `for_each` depends on a sensitive nullable variable. Consolidates ERR-20260522-001 and LRN-20260522-001.

## Test plan

- [ ] CI passes (no functional code changed — docs/rules only)
- [ ] `bash tests/handbook-consistency.sh` passes locally