### PR TITLE
fix(tessl): add skills object to tile.json for publish validation

### DIFF
--- a/.github/workflows/tessl-publish.yml
+++ b/.github/workflows/tessl-publish.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}

--- a/.github/workflows/tessl-publish.yml
+++ b/.github/workflows/tessl-publish.yml
@@ -17,8 +17,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: tesslio/setup-tessl@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}
       - name: Publish skill

--- a/skills/platform-skills/tile.json
+++ b/skills/platform-skills/tile.json
@@ -3,6 +3,10 @@
   "version": "1.25.2",
   "summary": "Production-grade platform engineering handbook — Kubernetes, Terraform, Flux CD, GitHub Actions, AWS, and more.",
   "description": "Hands-on guidance for platform engineers: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs.",
+  "skills": {
+    "platform-skills": { "path": "SKILL.md" }
+  },
+  "private": false,
   "author": "Nitin Jain",
   "license": "Apache-2.0",
   "homepage": "https://github.com/nitinjain999/platform-skills"


### PR DESCRIPTION
## Summary

- `tile.json` was missing the required `skills` (or `docs`/`rules`) field, causing `tessl tile publish` to fail with: `At least one of docs, rules, or skills must be provided`
- Added `skills` object mapping `platform-skills` to `SKILL.md` (Tessl requires an object, not an array)
- Set `private: false` so the tile is listed publicly in the Tessl registry

## Test plan

- [ ] Merge triggers `.github/workflows/tessl-publish.yml`
- [ ] `tessl tile publish skills/platform-skills` completes without error
- [ ] Tile appears in Tessl registry under `platform-skills`