### PR TITLE
fix(tessl): correct tile.json name format and add skills object

### DIFF
--- a/.github/workflows/tessl-publish.yml
+++ b/.github/workflows/tessl-publish.yml
@@ -17,8 +17,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: tesslio/setup-tessl@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}
       - name: Publish skill

--- a/skills/platform-skills/tile.json
+++ b/skills/platform-skills/tile.json
@@ -1,8 +1,12 @@
 {
-  "name": "platform-skills",
+  "name": "nitinjain999/platform-skills",
   "version": "1.25.2",
   "summary": "Production-grade platform engineering handbook — Kubernetes, Terraform, Flux CD, GitHub Actions, AWS, and more.",
   "description": "Hands-on guidance for platform engineers: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs.",
+  "skills": {
+    "platform-skills": { "path": "SKILL.md" }
+  },
+  "private": false,
   "author": "Nitin Jain",
   "license": "Apache-2.0",
   "homepage": "https://github.com/nitinjain999/platform-skills"


### PR DESCRIPTION
## Summary

- `name` must be `workspace/tile` format — changed `"platform-skills"` → `"nitinjain999/platform-skills"`
- Added `skills` object (required by Tessl — at least one of docs/rules/skills must be present)
- Set `private: false` for public registry listing
- Pinned action SHAs to latest versions (CI immutable-ref check requirement)

## Test plan

- [ ] CI checks pass
- [ ] Merge triggers `tessl-publish.yml`
- [ ] `tessl tile publish` completes without validation errors
- [ ] Tile visible in Tessl registry as `nitinjain999/platform-skills`