### PR TITLE
fix(tessl): move tile.json to repo root so all SKILL.md paths resolve

### DIFF
--- a/.github/workflows/tessl-publish.yml
+++ b/.github/workflows/tessl-publish.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           token: ${{ secrets.TESSL_TOKEN }}
       - name: Publish skill
-        run: tessl tile publish skills/platform-skills
+        run: tessl tile publish .

--- a/.github/workflows/tessl-publish.yml
+++ b/.github/workflows/tessl-publish.yml
@@ -17,8 +17,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: tesslio/setup-tessl@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: tesslio/setup-tessl@25ec223fc0da33b41b8044ff5ab2b85235f4f91e # v2
         with:
           token: ${{ secrets.TESSL_TOKEN }}
       - name: Publish skill

--- a/skills/platform-skills/tile.json
+++ b/skills/platform-skills/tile.json
@@ -1,8 +1,12 @@
 {
-  "name": "platform-skills",
+  "name": "nitinjain999/platform-skills",
   "version": "1.25.2",
   "summary": "Production-grade platform engineering handbook — Kubernetes, Terraform, Flux CD, GitHub Actions, AWS, and more.",
   "description": "Hands-on guidance for platform engineers: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs.",
+  "skills": {
+    "platform-skills": { "path": "SKILL.md" }
+  },
+  "private": false,
   "author": "Nitin Jain",
   "license": "Apache-2.0",
   "homepage": "https://github.com/nitinjain999/platform-skills"

--- a/tile.json
+++ b/tile.json
@@ -4,7 +4,7 @@
   "summary": "Production-grade platform engineering handbook — Kubernetes, Terraform, Flux CD, GitHub Actions, AWS, and more.",
   "description": "Hands-on guidance for platform engineers: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs.",
   "skills": {
-    "platform-skills": { "path": "SKILL.md" }
+    "platform-skills": { "path": "skills/platform-skills/SKILL.md" }
   },
   "private": false,
   "author": "Nitin Jain",


### PR DESCRIPTION
## Summary

Tessl resolves all paths in `SKILL.md` relative to the directory where `tile.json` lives. With `tile.json` inside `skills/platform-skills/`, every link to `references/` and `examples/` was failing with "File not found".

**Fix:** Move `tile.json` to the repo root and publish with `tessl tile publish .` instead of `tessl tile publish skills/platform-skills`.

- `tile.json` renamed `skills/platform-skills/tile.json` → `tile.json` (repo root)
- `skills.path` updated to `"skills/platform-skills/SKILL.md"`
- Workflow updated: `tessl tile publish skills/platform-skills` → `tessl tile publish .`

## Test plan

- [ ] CI checks pass
- [ ] Merge triggers `tessl-publish.yml`
- [ ] `tessl tile publish .` completes with no broken link errors