### PR TITLE
fix(tessl): point skills.path to root SKILL.md so references/ resolves

### DIFF
--- a/tile.json
+++ b/tile.json
@@ -4,7 +4,7 @@
   "summary": "Production-grade platform engineering handbook — Kubernetes, Terraform, Flux CD, GitHub Actions, AWS, and more.",
   "description": "Hands-on guidance for platform engineers: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs.",
   "skills": {
-    "platform-skills": { "path": "skills/platform-skills/SKILL.md" }
+    "platform-skills": { "path": "SKILL.md" }
   },
   "private": false,
   "author": "Nitin Jain",


### PR DESCRIPTION
## Summary

Tessl resolves linked files relative to the `SKILL.md` it is given. With `"path": "skills/platform-skills/SKILL.md"`, it looked for `skills/platform-skills/references/` — which doesn't exist.

The root `SKILL.md` is identical to `skills/platform-skills/SKILL.md` and sits next to `references/` and `examples/`, so the correct path is simply `"SKILL.md"`.

## Test plan

- [ ] CI checks pass
- [ ] Merge and trigger `tessl-publish.yml` — no "File not found" errors