### PR TITLE
fix(skill): add 'Use when' trigger to description for Tessl completeness 3/3

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platform-skills
-description: "Hands-on guidance for platform engineers: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering (Litmus, Chaos Mesh, GameDay), DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs. Every answer includes blast radius, validation steps, and rollback plan."
+description: "Use when working on platform engineering tasks: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering (Litmus, Chaos Mesh, GameDay), DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs. Every answer includes blast radius, validation steps, and rollback plan."
 ---
 
 # Platform Skills

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platform-skills
-description: "Use when working on platform engineering tasks: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering (Litmus, Chaos Mesh, GameDay), DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs. Every answer includes blast radius, validation steps, and rollback plan."
+description: "Use when troubleshooting, implementing, reviewing, or auditing platform infrastructure. Provides structured diagnosis with blast radius, validation steps, and rollback plan for: Kubernetes, Flux CD, Argo CD, Terraform, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace/LLM observability, SOC 2 compliance, and PR review."
 ---
 
 # Platform Skills

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platform-skills
-description: "Hands-on guidance for platform engineers: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering (Litmus, Chaos Mesh, GameDay), DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs. Every answer includes blast radius, validation steps, and rollback plan."
+description: "Use when working on platform engineering tasks: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering (Litmus, Chaos Mesh, GameDay), DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs. Every answer includes blast radius, validation steps, and rollback plan."
 ---
 
 # Platform Skills

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platform-skills
-description: "Use when working on platform engineering tasks: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering (Litmus, Chaos Mesh, GameDay), DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs. Every answer includes blast radius, validation steps, and rollback plan."
+description: "Use when troubleshooting, implementing, reviewing, or auditing platform infrastructure. Provides structured diagnosis with blast radius, validation steps, and rollback plan for: Kubernetes, Flux CD, Argo CD, Terraform, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace/LLM observability, SOC 2 compliance, and PR review."
 ---
 
 # Platform Skills


### PR DESCRIPTION
## Summary

Tessl Completeness score was 2/3 because the description lacked an explicit "Use when..." trigger clause. Changed the opening from "Hands-on guidance for platform engineers:" to "Use when working on platform engineering tasks:" — satisfies the rubric requirement for trigger guidance.

No other content changed. Both `SKILL.md` copies kept in sync.