### PR TITLE
chore: update marketplace.json source.sha to v1.25.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -160,7 +160,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "fb4c3e42f1bc6a0b14182ccaa2b4ae64269557d1"
+        "sha": "141a1ae316980e0e7735caaaabb765ef40c2b9b7"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
Updates `source.sha` to `141a1ae316980e0e7735caaaabb765ef40c2b9b7` — the HEAD commit of the v1.25.3 release merge.