### PR TITLE
fix(skill): add 'as a system' framing to improve Tessl Distinctiveness score

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 # Scope: project-level — applies to every Copilot Chat in this workspace
 # Upgrade: git pull in the platform-skills clone → copy updated file → commit
 
-Use when troubleshooting, implementing, reviewing, or auditing platform infrastructure. Apply these patterns when generating or reviewing code across Kubernetes, Flux CD, Argo CD, Terraform, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace/LLM observability, SOC 2 compliance, and PR review. Every answer includes blast radius, validation steps, and rollback plan.
+Use when troubleshooting, implementing, reviewing, or auditing platform infrastructure as a system — where Kubernetes, GitOps, CI/CD, and security concerns intersect. Apply these patterns when generating or reviewing code across Kubernetes, Flux CD, Argo CD, Terraform, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, KEDA, supply chain security (Cosign, SBOM, SLSA), Falco, Chaos Engineering, DORA metrics, Datadog/Dynatrace/LLM observability, SOC 2, and PR review. Every answer includes blast radius, validation steps, and rollback plan.
 
 ## Core Principles
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platform-skills
-description: "Use when troubleshooting, implementing, reviewing, or auditing platform infrastructure. Provides structured diagnosis with blast radius, validation steps, and rollback plan for: Kubernetes, Flux CD, Argo CD, Terraform, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace/LLM observability, SOC 2 compliance, and PR review."
+description: "Use when troubleshooting, implementing, reviewing, or auditing platform infrastructure as a system — where Kubernetes, GitOps, CI/CD, and security concerns intersect. Provides structured diagnosis with blast radius, validation steps, and rollback plan for: Kubernetes, Flux CD, Argo CD, Terraform, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, KEDA, supply chain security (Cosign, SBOM, SLSA), Falco, Chaos Engineering, DORA metrics, Datadog/Dynatrace/LLM observability, SOC 2, and PR review."
 ---
 
 # Platform Skills

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: platform-skills
-description: "Use when troubleshooting, implementing, reviewing, or auditing platform infrastructure. Provides structured diagnosis with blast radius, validation steps, and rollback plan for: Kubernetes, Flux CD, Argo CD, Terraform, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace/LLM observability, SOC 2 compliance, and PR review."
+description: "Use when troubleshooting, implementing, reviewing, or auditing platform infrastructure as a system — where Kubernetes, GitOps, CI/CD, and security concerns intersect. Provides structured diagnosis with blast radius, validation steps, and rollback plan for: Kubernetes, Flux CD, Argo CD, Terraform, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, KEDA, supply chain security (Cosign, SBOM, SLSA), Falco, Chaos Engineering, DORA metrics, Datadog/Dynatrace/LLM observability, SOC 2, and PR review."
 ---
 
 # Platform Skills


### PR DESCRIPTION
## Summary

Tessl Distinctiveness was docked because the broad scope appeared to overlap with focused single-technology skills. The fix signals that this skill covers how tools work *together as a platform system*, not as a substitute for individual domain skills.

Changed: `"Use when troubleshooting, implementing, reviewing, or auditing platform infrastructure."` → `"...platform infrastructure as a system — where Kubernetes, GitOps, CI/CD, and security concerns intersect."`

Updated in all three places: `SKILL.md`, `skills/platform-skills/SKILL.md`, `.github/copilot-instructions.md`.