### PR TITLE
chore: update marketplace.json source.sha to v1.25.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -160,7 +160,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "141a1ae316980e0e7735caaaabb765ef40c2b9b7"
+        "sha": "2cf5d71356f3b81caebd0fb5fc80d95a2c877a6a"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
Updates source.sha to `2cf5d71356f3b81caebd0fb5fc80d95a2c877a6a` — the v1.25.4 release merge commit.