### PR TITLE
feat(evals): add Tessl evaluation scenarios — v1.26.0

### DIFF
--- a/evals/flux-helmrelease/capability.txt
+++ b/evals/flux-helmrelease/capability.txt
@@ -1,0 +1,1 @@
+Flux CD troubleshooting: classify a HelmRelease failure by layer (source/artifact/reconciliation/chart rendering/runtime), collect evidence, identify root cause, and provide a fix with rollback.

--- a/evals/flux-helmrelease/criteria.json
+++ b/evals/flux-helmrelease/criteria.json
@@ -1,0 +1,34 @@
+{
+  "criteria": [
+    {
+      "name": "correct_layer",
+      "description": "Classifies the failure as the `chart rendering` or `reconciliation` layer — NOT source or runtime. The chart rendered successfully but ClusterRole ownership conflict prevents install.",
+      "required": true
+    },
+    {
+      "name": "evidence_commands",
+      "description": "Lists at least 2 of these evidence commands: `flux logs --kind=HelmRelease --name=cert-manager`, `kubectl get clusterrole cert-manager-cainjector -o yaml`, `helm list -n cert-manager`, `kubectl get events -n cert-manager`.",
+      "required": true
+    },
+    {
+      "name": "root_cause",
+      "description": "Correctly identifies the root cause: a pre-existing ClusterRole from a prior manual or helm install is not owned by this Flux-managed HelmRelease, causing the ownership conflict.",
+      "required": true
+    },
+    {
+      "name": "fix",
+      "description": "Fix includes either: (a) `helm uninstall cert-manager -n cert-manager` followed by `flux reconcile helmrelease cert-manager -n cert-manager`, or (b) annotating/labeling the conflicting resource with the correct Helm release metadata to adopt it.",
+      "required": true
+    },
+    {
+      "name": "blast_radius",
+      "description": "Notes that `helm uninstall` will delete all cert-manager managed resources (certificates, CRDs) and cause a brief lapse in certificate issuance. Recommends draining or suspending dependent workloads first.",
+      "required": true
+    },
+    {
+      "name": "validation",
+      "description": "Validation includes: `flux get helmrelease cert-manager -n cert-manager` shows Ready=True, and `kubectl get pods -n cert-manager` shows all pods running.",
+      "required": true
+    }
+  ]
+}

--- a/evals/flux-helmrelease/task.md
+++ b/evals/flux-helmrelease/task.md
@@ -1,0 +1,29 @@
+# Task: Diagnose a stuck HelmRelease
+
+A platform engineer reports that a HelmRelease has been in a `Reconciling` state for 20 minutes and the application pods have not been updated.
+
+The following output was collected:
+
+```
+$ flux get helmrelease cert-manager -n cert-manager
+NAME         REVISION  SUSPENDED  READY  MESSAGE
+cert-manager           False      False  Helm install failed: rendered manifests contain a resource that already exists...
+```
+
+```
+$ kubectl describe helmrelease cert-manager -n cert-manager | grep -A 10 "Status:"
+Status:
+  Conditions:
+    Last Transition Time:  2026-05-24T10:00:00Z
+    Message:               Helm install failed: rendered manifests contain a resource that already exists. Unable to continue with install: ClusterRole "cert-manager-cainjector" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata
+    Reason:                InstallFailed
+    Status:                False
+    Type:                  Ready
+```
+
+1. Classify which Flux layer this failure belongs to: source | artifact | reconciliation | chart rendering | runtime.
+2. List the evidence you would collect next (exact commands).
+3. State the root cause.
+4. Provide the fix with exact commands.
+5. State the blast radius and rollback plan.
+6. Provide the validation steps to confirm the fix worked.

--- a/evals/instructions.json
+++ b/evals/instructions.json
@@ -1,0 +1,3 @@
+{
+  "instructions": "You are a senior platform engineer. When given a task, apply the platform-skills guidance: classify the problem, collect evidence, identify the root cause, propose a fix with blast radius and rollback plan, and provide validation steps. Be concrete and production-safe."
+}

--- a/evals/opa-policy/capability.txt
+++ b/evals/opa-policy/capability.txt
@@ -1,0 +1,1 @@
+OPA/Rego policy authoring: write a deny rule with metadata, explain the policy intent, provide a conftest test, and document the pipeline integration.

--- a/evals/opa-policy/criteria.json
+++ b/evals/opa-policy/criteria.json
@@ -1,0 +1,34 @@
+{
+  "criteria": [
+    {
+      "name": "rego_v1_import",
+      "description": "Policy uses `import rego.v1` — not the legacy implicit future.keywords import.",
+      "required": true
+    },
+    {
+      "name": "metadata_annotation",
+      "description": "Policy has a METADATA block with at least `title` and `entrypoint: true`.",
+      "required": true
+    },
+    {
+      "name": "deny_rule_correct",
+      "description": "The deny rule correctly catches both `\"Action\": \"*\"` (string) and `\"Action\": [\"*\"]` (array) forms. Uses `contains msg if` syntax (not the deprecated `msg { ... }` form).",
+      "required": true
+    },
+    {
+      "name": "deny_message_names_resource",
+      "description": "The deny message includes the resource name (e.g. `sprintf(\"IAM policy '%s' must not use wildcard Action\", [name])`).",
+      "required": true
+    },
+    {
+      "name": "test_file",
+      "description": "Provides a `policy_test.rego` with at least one `test_deny_` case (wildcard → deny) and one `test_allow_` case (scoped action → no deny).",
+      "required": true
+    },
+    {
+      "name": "ci_placement",
+      "description": "Correctly states conftest runs after `terraform validate` and before `terraform plan` (or alongside plan as a gate).",
+      "required": true
+    }
+  ]
+}

--- a/evals/opa-policy/task.md
+++ b/evals/opa-policy/task.md
@@ -1,0 +1,15 @@
+# Task: Write an OPA/Rego policy to block wildcard IAM actions
+
+A security audit found that several Terraform-managed AWS IAM policies use `"Action": "*"`. You need to prevent this from reaching production.
+
+Write an OPA/Rego policy that:
+
+1. Blocks any `aws_iam_policy` resource where any statement contains `"Action": "*"` or `"Action": ["*"]`.
+2. Uses proper METADATA annotation (title, description, entrypoint).
+3. Uses `import rego.v1`.
+4. Produces a clear `deny` message naming the offending resource.
+
+Also provide:
+- A `conftest` test file (`policy_test.rego`) with one passing and one failing test case.
+- The exact `conftest test` command to run it in CI.
+- Where in the GitHub Actions pipeline this check should run relative to `terraform plan`.

--- a/evals/pr-triage/capability.txt
+++ b/evals/pr-triage/capability.txt
@@ -1,0 +1,1 @@
+PR triage: classify review comments as ACTIONABLE_FIX, INFORMATIONAL, or NOT_APPLICABLE, apply fixes, and reply with evidence.

--- a/evals/pr-triage/criteria.json
+++ b/evals/pr-triage/criteria.json
@@ -1,0 +1,29 @@
+{
+  "criteria": [
+    {
+      "name": "correct_classification",
+      "description": "Classifies the comment as ACTIONABLE_FIX (missing resource limits is a real correctness/safety issue that must be fixed)",
+      "required": true
+    },
+    {
+      "name": "correct_yaml",
+      "description": "Provides corrected YAML with both resources.requests (cpu, memory) and resources.limits (memory) set. CPU limit is intentionally omitted or justified — CPU limits cause throttling.",
+      "required": true
+    },
+    {
+      "name": "blast_radius",
+      "description": "Mentions blast radius: pods may be throttled or rescheduled if requests are set higher than current actual usage; rolling update will replace pods one by one.",
+      "required": true
+    },
+    {
+      "name": "rollback_plan",
+      "description": "Provides a rollback approach: revert the manifest and re-apply, or use kubectl rollout undo.",
+      "required": true
+    },
+    {
+      "name": "reply_quality",
+      "description": "The review thread reply is concise, references the specific file and change, and ends with the appropriate resolution marker (✅ Fixed).",
+      "required": false
+    }
+  ]
+}

--- a/evals/pr-triage/task.md
+++ b/evals/pr-triage/task.md
@@ -1,0 +1,25 @@
+# Task: Triage a PR review comment
+
+A reviewer left the following comment on a pull request that modifies a Kubernetes Deployment manifest:
+
+---
+
+**File:** `apps/api/deployment.yaml`
+**Comment:** "The container has no resource limits set. This will allow it to consume unbounded memory and get OOMKilled during a memory spike, taking down other pods on the same node."
+
+**Diff context:**
+```yaml
+spec:
+  containers:
+    - name: api
+      image: my-org/api:v1.2.3
+      ports:
+        - containerPort: 8080
+```
+
+---
+
+1. Classify this comment as ACTIONABLE_FIX, INFORMATIONAL, or NOT_APPLICABLE.
+2. If ACTIONABLE_FIX: show the corrected YAML with appropriate resource requests and limits.
+3. Explain the blast radius of the change and provide a rollback plan.
+4. Write the reply you would post on the review thread.


### PR DESCRIPTION
## Summary

Adds 3 Tessl evaluation scenarios under `evals/` for quality testing of the platform-skills tile. Part of the v1.26.0 milestone.

| Scenario | Capability tested |
|---|---|
| `evals/pr-triage/` | Classify PR comment, apply ACTIONABLE_FIX, write review reply with blast radius + rollback |
| `evals/opa-policy/` | Write OPA/Rego deny rule with metadata, conftest test, CI placement |
| `evals/flux-helmrelease/` | Layer classification, evidence collection, root cause, fix, blast radius, validation |

Each scenario contains:
- `task.md` — the task brief presented to the agent
- `criteria.json` — scoring rubric with required/optional criteria
- `capability.txt` — identifies the skill capability under test

`evals/instructions.json` — shared agent instructions for all scenarios.

## Test plan

- [ ] CI checks pass
- [ ] After merge: `tessl eval run .` executes all 3 scenarios
- [ ] Version bump to `1.26.0` in follow-up PR