### PR TITLE
chore: release v1.26.0 — Tessl evaluation scenarios

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.25.4",
+      "version": "1.26.0",
       "description": "Production-grade platform engineering handbook for Claude. 29 slash commands covering: Kubernetes, Helm, Terraform (blast radius, SOC 2, IAM), Flux CD (Flux Operator, FluxInstance, gitless OCI delivery, 5-workflow cluster debug, 6-phase repo audit), Argo CD, GitHub Actions (composite actions, SHA pinning, OIDC), AWS (CloudFront, WAF, Lambda@Edge), Kyverno, OPA/Rego, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, chaos engineering (Litmus/Chaos Mesh), DORA metrics, Datadog, Dynatrace, Linkerd, and animated docs. Every answer includes blast radius, validation steps, and rollback plan.",
       "author": {
         "name": "Nitin Jain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-skills",
-  "version": "1.25.4",
+  "version": "1.26.0",
   "description": "Practical guidance for platform engineers: Kubernetes, Kyverno, Helm, Terraform, Flux CD (Flux Operator, FluxInstance, gitless OCI delivery, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, SHA pinning, OIDC, 11 production examples), AWS (CloudFront, WAF, Lambda@Edge, IAM, IRSA), Azure (AKS workload identity), GKE (Workload Identity Federation), Linkerd, Linux, networking, MCP development, observability, SOC 2 compliance, PR review, PR triage, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA Metrics, LLM Observability (Datadog LLMObs), and animated docs. Every answer includes blast radius, validation steps, and rollback plan.",
   "author": {
     "name": "Nitin Jain",

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 # Platform Engineering Instructions for GitHub Copilot
-# Version: 1.25.4
+# Version: 1.26.0
 # Source: https://github.com/nitinjain999/platform-skills
 # Scope: project-level — applies to every Copilot Chat in this workspace
 # Upgrade: git pull in the platform-skills clone → copy updated file → commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Platform Skills will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.26.0] - 2026-05-24
+
+### Added
+
+- Tessl evaluation scenarios (`evals/`) for quality testing: `pr-triage`, `opa-policy`, `flux-helmrelease`. Each scenario includes `task.md`, `criteria.json`, and `capability.txt`.
+
 ## [1.25.4] - 2026-05-24
 
 ### Changed

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -60,7 +60,7 @@ claude plugin install platform-skills
 
 ```bash
 claude plugin list
-# platform-skills  v1.25.4  enabled
+# platform-skills  v1.26.0  enabled
 ```
 
 **Upgrade:**

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "nitinjain999/platform-skills",
-  "version": "1.25.4",
+  "version": "1.26.0",
   "summary": "Production-grade platform engineering handbook — Kubernetes, Terraform, Flux CD, GitHub Actions, AWS, and more.",
   "description": "Hands-on guidance for platform engineers: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs.",
   "skills": {


### PR DESCRIPTION
## Summary

Version bump to `1.26.0` for the Tessl evaluation scenarios added in #67.

| File | Change |
|---|---|
| `.claude-plugin/plugin.json` | `1.25.4` → `1.26.0` |
| `.claude-plugin/marketplace.json` | `1.25.4` → `1.26.0` |
| `tile.json` | `1.25.4` → `1.26.0` |
| `INSTALLATION.md` | version string updated |
| `.github/copilot-instructions.md` | version comment updated |
| `CHANGELOG.md` | `[1.26.0]` entry added |