### PR TITLE
chore: update marketplace.json source.sha to v1.26.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -160,7 +160,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "2cf5d71356f3b81caebd0fb5fc80d95a2c877a6a"
+        "sha": "ec357cb0cbf6a000e3ef24ddae0645d93349e215"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
Updates source.sha to `ec357cb0cbf6a000e3ef24ddae0645d93349e215` — the v1.26.0 release merge commit.