### PR TITLE
fix(tile): exclude skills/ subdir to prevent broken-link errors

### DIFF
--- a/tile.json
+++ b/tile.json
@@ -8,6 +8,7 @@
   },
   "exclude": [
     "examples/agent-self-improve/scripts/**",
+    "skills/**",
     ".github/**",
     ".claude-plugin/**",
     ".tessl/**",


### PR DESCRIPTION
Tessl scans all included files and tries to resolve links in `skills/platform-skills/SKILL.md` relative to its location (`skills/platform-skills/references/`), which doesn't exist. The root `SKILL.md` is the defined skill path — the `skills/` copy is only needed for the Claude Code plugin loader. Excluding `skills/**` stops the duplicate scan.