### PR TITLE
fix(evals): strengthen triage reply format and add OPA CI placement rule

### DIFF
--- a/commands/opa.md
+++ b/commands/opa.md
@@ -21,6 +21,7 @@ Steps:
    - Generate a descriptive `msg` that includes the offending resource name/value and a remediation hint
    - Use `some` for iteration, `in` for membership, `startswith`/`contains` for string matching
 4. Show the Conftest command to test the policy against sample input
+5. State CI placement: conftest runs **after `terraform validate`** and **before `terraform plan`** as a blocking gate — failing conftest must prevent plan from running
 
 Reference: `references/opa.md` → Rule Types, Input Shape, Rego v1 Syntax
 

--- a/commands/triage.md
+++ b/commands/triage.md
@@ -113,9 +113,9 @@ gh pr comment <pr_number> --body "<reply>"
 Reply rules:
 - First-person, concise, no filler
 - Reference the specific line or file
-- **ACTIONABLE_FIX**: describe what was changed and why. End with: `✅ Fixed — thread resolved.`
-- **INFORMATIONAL**: answer or acknowledge, explain why no code change. End with: `ℹ️ Thread resolved — no code change needed.`
-- **NOT_APPLICABLE**: state why this does not apply. End with: `❌ Not applicable — thread resolved.`
+- **ACTIONABLE_FIX**: one sentence describing what changed and why, referencing the specific file (e.g. `deployment.yaml`). Reply MUST end with exactly: `✅ Fixed`
+- **INFORMATIONAL**: answer or acknowledge, explain why no code change. End with: `ℹ️ No change needed.`
+- **NOT_APPLICABLE**: state why this does not apply. End with: `❌ Not applicable.`
 
 ---
 

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "nitinjain999/platform-skills",
-  "version": "1.26.3",
+  "version": "1.26.4",
   "summary": "Production-grade platform engineering handbook — Kubernetes, Terraform, Flux CD, GitHub Actions, AWS, and more.",
   "description": "Hands-on guidance for platform engineers: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs.",
   "skills": {


### PR DESCRIPTION
## What's failing in evals

- **PR Triage `reply_quality` (0/1)**: criteria checks reply ends with `✅ Fixed` — the instruction said "✅ Fixed — thread resolved." which the model was paraphrasing instead of using verbatim
- **OPA `ci_placement` (0/1)**: criteria checks conftest runs after `terraform validate` and before `terraform plan` — the generate mode had no CI placement instruction at all

## Changes

- `commands/triage.md`: tightened ACTIONABLE_FIX reply rule — must end with exactly `✅ Fixed`, reference the specific file
- `commands/opa.md`: added step 5 to generate mode — explicitly states conftest placement in CI pipeline (after validate, before plan, blocking gate)