### PR TITLE
fix(ci): run tessl eval after publish to link scenarios to registry version

### DIFF
--- a/.github/workflows/tessl-publish.yml
+++ b/.github/workflows/tessl-publish.yml
@@ -5,10 +5,13 @@ on:
   push:
     branches: [main]
     paths:
+      - 'SKILL.md'
+      - 'tile.json'
       - 'skills/platform-skills/**'
       - 'references/**'
       - 'commands/**'
       - 'examples/**'
+      - 'evals/**'
 
 jobs:
   publish:
@@ -22,4 +25,6 @@ jobs:
         with:
           token: ${{ secrets.TESSL_TOKEN }}
       - name: Publish skill
-        run: tessl tile publish .
+        run: tessl tile publish . --skip-evals
+      - name: Run eval scenarios
+        run: tessl eval run . --context-ref ${{ github.sha }} --label "ci-${{ github.sha }}"

--- a/tile.json
+++ b/tile.json
@@ -1,6 +1,6 @@
 {
   "name": "nitinjain999/platform-skills",
-  "version": "1.26.4",
+  "version": "1.26.5",
   "summary": "Production-grade platform engineering handbook — Kubernetes, Terraform, Flux CD, GitHub Actions, AWS, and more.",
   "description": "Hands-on guidance for platform engineers: Kubernetes, Terraform, Flux CD (Operator, FluxInstance, gitless OCI, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, OIDC, SHA pinning), AWS, Azure, GKE, Linkerd, Linux, networking, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA metrics, Datadog/Dynatrace observability, LLM Observability, SOC 2 compliance, PR review and triage, and animated docs.",
   "skills": {


### PR DESCRIPTION
## Problem

The publish step auto-triggers an eval run which fails with 500 (Tessl server-side). This leaves the `/evals` tab empty on the registry page.

## Fix

- Split publish and eval into two explicit steps: `publish --skip-evals` then `eval run`
- `--context-ref ${{ github.sha }}` pins eval context to the exact published commit
- `--label "ci-<sha>"` makes each run traceable back to its commit
- Added `SKILL.md`, `tile.json`, and `evals/**` to push path triggers so eval-only changes also run the workflow

## Version

Bumps `tile.json` to `1.26.5`.