### PR TITLE
feat: AWS MCP profile management — v1.26.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -168,7 +168,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "d6cc0271d8e55fa59c0965ab0cb2ff7e1765be2b"
+        "sha": "0e1cb19efe22b419bee468c64c0567204bcb3c9c"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.25.20",
-      "description": "Production-grade platform engineering handbook for Claude. 29 slash commands covering: Kubernetes, Helm, Terraform (blast radius, SOC 2, IAM), Flux CD (Flux Operator, FluxInstance, gitless OCI delivery, 5-workflow cluster debug, 6-phase repo audit), Argo CD, GitHub Actions (composite actions, SHA pinning, OIDC), AWS (CloudFront, WAF, Lambda@Edge), Kyverno, OPA/Rego, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, chaos engineering (Litmus/Chaos Mesh), DORA metrics, Datadog, Dynatrace, Linkerd, and animated docs. Every answer includes blast radius, validation steps, and rollback plan.",
+      "version": "1.26.0",
+      "description": "Production-grade platform engineering handbook for Claude. 29 slash commands covering: Kubernetes, Helm, Terraform (blast radius, SOC 2, IAM), Flux CD (Flux Operator, FluxInstance, gitless OCI delivery, 5-workflow cluster debug, 6-phase repo audit), Argo CD, GitHub Actions (composite actions, SHA pinning, OIDC), AWS (CloudFront, WAF, Lambda@Edge), Kyverno, OPA/Rego, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, chaos engineering (Litmus/Chaos Mesh), DORA metrics, Datadog, Dynatrace, Linkerd, and animated docs. Every answer includes blast radius, validation steps, and rollback plan., AWS MCP profile management (multi-account SSO, Granted, credential_process, profile discovery, VS Code and Claude Code config generation)",
       "author": {
         "name": "Nitin Jain"
       },
@@ -155,7 +155,15 @@
         "fluxinstance",
         "resourceset",
         "gitless-delivery",
-        "oci-gitops"
+        "oci-gitops",
+        "aws-mcp",
+        "aws-profile",
+        "mcp-server",
+        "aws-sso",
+        "granted",
+        "multi-account",
+        "credential-process",
+        "aws-identity-center"
       ],
       "source": {
         "source": "url",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -168,7 +168,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "88d5bd3126d6ec70369fc23b71003fcd95715327"
+        "sha": "601f69336e4010a40b1119d5d240b8b22c5e26f0"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -168,7 +168,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "62039f84b1e3b7ed5730e36f1e4d7f1c66298da3"
+        "sha": "a14a5b457c2fd96cf00bb75a1b09b1f873cdbf42"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -168,7 +168,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "fa9a3f982086d9502948670283f9863bfc2f5847"
+        "sha": "62039f84b1e3b7ed5730e36f1e4d7f1c66298da3"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -168,7 +168,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "0e1cb19efe22b419bee468c64c0567204bcb3c9c"
+        "sha": "ef1f3fdaed32ed716bc7bb1d6a8fb29baebbef52"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -168,7 +168,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "a14a5b457c2fd96cf00bb75a1b09b1f873cdbf42"
+        "sha": "d6cc0271d8e55fa59c0965ab0cb2ff7e1765be2b"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -168,7 +168,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "4395b0a0cac90e08264681d98821430142e2ba34"
+        "sha": "88d5bd3126d6ec70369fc23b71003fcd95715327"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -168,7 +168,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "ef1f3fdaed32ed716bc7bb1d6a8fb29baebbef52"
+        "sha": "4395b0a0cac90e08264681d98821430142e2ba34"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "platform-skills",
       "version": "1.26.0",
-      "description": "Production-grade platform engineering handbook for Claude. 29 slash commands covering: Kubernetes, Helm, Terraform (blast radius, SOC 2, IAM), Flux CD (Flux Operator, FluxInstance, gitless OCI delivery, 5-workflow cluster debug, 6-phase repo audit), Argo CD, GitHub Actions (composite actions, SHA pinning, OIDC), AWS (CloudFront, WAF, Lambda@Edge), Kyverno, OPA/Rego, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, chaos engineering (Litmus/Chaos Mesh), DORA metrics, Datadog, Dynatrace, Linkerd, and animated docs. Every answer includes blast radius, validation steps, and rollback plan., AWS MCP profile management (multi-account SSO, Granted, credential_process, profile discovery, VS Code and Claude Code config generation)",
+      "description": "Production-grade platform engineering handbook for Claude. 30 slash commands covering: Kubernetes, Helm, Terraform (blast radius, SOC 2, IAM), Flux CD (Flux Operator, FluxInstance, gitless OCI delivery, 5-workflow cluster debug, 6-phase repo audit), Argo CD, GitHub Actions (composite actions, SHA pinning, OIDC), AWS (CloudFront, WAF, Lambda@Edge), Kyverno, OPA/Rego, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, chaos engineering (Litmus/Chaos Mesh), DORA metrics, Datadog, Dynatrace, Linkerd, animated docs, and AWS MCP profile management (multi-account SSO, Granted, credential_process, profile discovery, VS Code and Claude Code config generation). Every answer includes blast radius, validation steps, and rollback plan.",
       "author": {
         "name": "Nitin Jain"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-skills",
-  "version": "1.25.20",
+  "version": "1.26.0",
   "description": "Practical guidance for platform engineers: Kubernetes, Kyverno, Helm, Terraform, Flux CD (Flux Operator, FluxInstance, gitless OCI delivery, cluster debug, repo audit), Argo CD, GitHub Actions (composite actions, SHA pinning, OIDC, 11 production examples), AWS (CloudFront, WAF, Lambda@Edge, IAM, IRSA), Azure (AKS workload identity), GKE (Workload Identity Federation), Linkerd, Linux, networking, MCP development, observability, SOC 2 compliance, PR review, PR triage, KEDA autoscaling, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA Metrics, LLM Observability (Datadog LLMObs), and animated docs. Every answer includes blast radius, validation steps, and rollback plan.",
   "author": {
     "name": "Nitin Jain",
@@ -105,6 +105,7 @@
     "./commands/awesome-docs.md",
     "./commands/aws.md",
     "./commands/composite-actions.md",
-    "./commands/fluxcd.md"
+    "./commands/fluxcd.md",
+    "./commands/aws-profile.md"
   ]
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 # Platform Engineering Instructions for GitHub Copilot
-# Version: 1.25.20
+# Version: 1.26.0
 # Source: https://github.com/nitinjain999/platform-skills
 # Scope: project-level — applies to every Copilot Chat in this workspace
 # Upgrade: git pull in the platform-skills clone → copy updated file → commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `commands/mcp.md`: new `configure-aws` mode with upfront cost/token warning, CLI-first alternative check, `credential_process` validation, version-pinned config generation for VS Code and Claude Code, `--multi-account` EKS named instances, and AWS MCP server catalog with 5 starter kits.
 - `examples/mcp/aws-multiprofile/`: 13 example files — VS Code global/workspace/input/template configs, Claude Code snippet, `aws-config-credential-process.ini`, `.gitignore.snippet`, and 5 starter-kit JSON files (eks-debug, observe, knowledge, deploy, cost) with real PyPI version pins.
 - `SKILL.md`: `AWS MCP Profiles` row in tool table; `/platform-skills:aws-profile` slash command entry.
-- `COMMANDS.md`: TOC entry and full `/platform-skills:aws-profile` command section.
+- `COMMANDS.md`: TOC entry and full `/platform-skills:aws-profile` command section (30 commands total).
+- `references/aws-mcp-profiles.md`: new reference file added to skill coverage.
 - `references/mcp.md`: AWS Multi-Account Profiles pointer section.
+- Tessl evaluation scenarios (`evals/`) for quality testing: `pr-triage`, `opa-policy`, `flux-helmrelease`. Each scenario includes `task.md`, `criteria.json`, and `capability.txt`.
 
 ## [1.25.20] - 2026-05-24
 
@@ -46,12 +48,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FluxCD debug mode: error-pattern routing table prevents HelmRelease errors from being routed through installation check workflow.
 - HelmRelease ownership conflict (`rendered manifests contain a resource that already exists`) added to troubleshooting reference with evidence commands and fix.
 - Triage reply format: concrete example and literal `✅ Fixed` ending requirement added to `commands/triage.md`.
-
-## [1.26.0] - 2026-05-24
-
-### Added
-
-- Tessl evaluation scenarios (`evals/`) for quality testing: `pr-triage`, `opa-policy`, `flux-helmrelease`. Each scenario includes `task.md`, `criteria.json`, and `capability.txt`.
 
 ## [1.25.4] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to Platform Skills will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.26.0] - 2026-05-25
+
+### Added
+
+- `commands/aws-profile.md`: new `/platform-skills:aws-profile` command with five modes — `discover` (profile table with TTL traffic-light), `status` (per-server credential health), `switch` (prod-gated profile patching across VS Code + Claude Code), `login` (type-aware auth command), `org-scan` (AWS Org account coverage).
+- `references/aws-mcp-profiles.md`: 15-section reference covering AWS MCP server catalog, context budget table, profile type detection, auth flows, credential lifecycle, `credential_process` pattern, config file locations, VS Code input variables, team sharing, multi-account EKS, health check checklist, and prod safety.
+- `commands/mcp.md`: new `configure-aws` mode with upfront cost/token warning, CLI-first alternative check, `credential_process` validation, version-pinned config generation for VS Code and Claude Code, `--multi-account` EKS named instances, and AWS MCP server catalog with 5 starter kits.
+- `examples/mcp/aws-multiprofile/`: 13 example files — VS Code global/workspace/input/template configs, Claude Code snippet, `aws-config-credential-process.ini`, `.gitignore.snippet`, and 5 starter-kit JSON files (eks-debug, observe, knowledge, deploy, cost) with real PyPI version pins.
+- `SKILL.md`: `AWS MCP Profiles` row in tool table; `/platform-skills:aws-profile` slash command entry.
+- `COMMANDS.md`: TOC entry and full `/platform-skills:aws-profile` command section.
+- `references/mcp.md`: AWS Multi-Account Profiles pointer section.
+
 ## [1.25.20] - 2026-05-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `examples/mcp/aws-multiprofile/`: 13 example files — VS Code global/workspace/input/template configs, Claude Code snippet, `aws-config-credential-process.ini`, `.gitignore.snippet`, and 5 starter-kit JSON files (eks-debug, observe, knowledge, deploy, cost) with real PyPI version pins.
 - `SKILL.md`: `AWS MCP Profiles` row in tool table; `/platform-skills:aws-profile` slash command entry.
 - `COMMANDS.md`: TOC entry and full `/platform-skills:aws-profile` command section (30 commands total).
-- `references/aws-mcp-profiles.md`: new reference file added to skill coverage.
 - `references/mcp.md`: AWS Multi-Account Profiles pointer section.
 - Tessl evaluation scenarios (`evals/`) for quality testing: `pr-triage`, `opa-policy`, `flux-helmrelease`. Each scenario includes `task.md`, `criteria.json`, and `capability.txt`.
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -33,6 +33,7 @@ Commands work in any conversation — type the slash command or describe your pr
 | [/platform-skills:dynatrace](#platform-skillsdynatrace) | Dynatrace Operator, OneAgent, SLOs, incidents |
 | [/platform-skills:document](#platform-skillsdocument) | Docstrings, OpenAPI specs, docs sites, guides |
 | [/platform-skills:mcp](#platform-skillsmcp) | MCP server scaffold, review, debug |
+| [/platform-skills:aws-profile](#platform-skillsaws-profile) | AWS profile management for MCP servers — discover, switch, login, org-scan |
 | [/platform-skills:product](#platform-skillsproduct) | DevEx, RFC/ADR, post-mortems, capacity, cost |
 | [/platform-skills:pr-review](#platform-skillspr-review) | Comprehensive PR risk review |
 | [/platform-skills:triage](#platform-skillstriage) | Triage and resolve PR comments |
@@ -1460,6 +1461,38 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | node dist/in
 ```
 ```
 /platform-skills:mcp debug schema validation rejecting a valid input — Zod error: "Expected string, received number"
+```
+
+---
+
+## `/platform-skills:aws-profile`
+
+**What it does:** Discover all AWS profiles from `~/.aws/config`, check credential TTL, switch profiles across VS Code and Claude Code MCP server configs, and scan AWS Organization accounts for unconfigured entries.
+
+```
+/platform-skills:aws-profile [discover|status|switch <profile>|login <profile>|org-scan] [flags]
+```
+
+**Modes:**
+
+| Mode | What it does |
+|------|-------------|
+| `discover` | List all profiles classified by type (SSO/assumed-role/Granted/static) with TTL and env tags |
+| `status` | Show which profile each MCP server uses and whether it will auto-refresh on expiry |
+| `switch` | Patch `AWS_PROFILE` in VS Code and/or Claude Code MCP configs, with prod safety guard |
+| `login` | Emit the correct auth command for the profile type (sso login / assume / role chain) |
+| `org-scan` | List all AWS Org accounts, flag those without configured profiles |
+
+**Common usage:**
+
+```
+/platform-skills:aws-profile discover
+/platform-skills:aws-profile discover --type sso --chain
+/platform-skills:aws-profile status --watch
+/platform-skills:aws-profile switch prod-platform-eu --scope workspace --confirm
+/platform-skills:aws-profile switch --env dev --scope global
+/platform-skills:aws-profile login dev-sandbox
+/platform-skills:aws-profile org-scan --profile org-management --generate-profiles
 ```
 
 ---

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -143,7 +143,7 @@ My Flux Kustomization `apps` is stuck in NotReady with: "context deadline exceed
 - It cannot see your cluster or cloud account — paste the relevant output
 - It works best on one concrete problem at a time, not "review everything"
 
-### All 29 command workflows
+### All 30 command workflows
 
 See [COMMANDS.md](COMMANDS.md) for every command with modes and example prompts:
 
@@ -166,6 +166,7 @@ See [COMMANDS.md](COMMANDS.md) for every command with modes and example prompts:
 | `dynatrace` | Operator, instrumentation, SLOs, Davis AI investigation |
 | `document` | Docstrings, OpenAPI specs, docs sites, guides |
 | `mcp` | Scaffold, review, or debug an MCP server |
+| `aws-profile` | Discover, switch, and validate AWS profiles for MCP servers |
 | `product` | DevEx audit, RFC/ADR, incident update, post-mortem |
 | `triage` | Use `/platform-skills:triage` to classify, fix, reply to, and resolve PR comments |
 | `keda` | Use `/platform-skills:keda` to generate, debug, review, or design a KEDA scaling strategy |

--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -99,6 +99,7 @@ Slash commands are predefined workflows. Use them instead of writing a long prom
 | `/platform-skills:compliance` | SOC 2 gap analysis or Checkov remediation for Terraform |
 | `/platform-skills:product` | RFC/ADR drafting, DevEx audit, incident communication, post-mortem |
 | `/platform-skills:mcp` | Scaffold, review, or debug an MCP server or client |
+| `/platform-skills:aws-profile` | Discover, switch, and validate AWS profiles for MCP servers across VS Code and Claude Code |
 | `/platform-skills:observability` | Instrument services, build dashboards, write alerts, run load tests, plan capacity |
 | `/platform-skills:document` | Generate docstrings, OpenAPI specs, documentation sites, or getting started guides |
 | `/platform-skills:datadog` | Datadog Agent setup, APM instrumentation, monitors, dashboards, SLOs, and debugging |

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -60,7 +60,7 @@ claude plugin install platform-skills
 
 ```bash
 claude plugin list
-# platform-skills  v1.25.20  enabled
+# platform-skills  v1.26.0  enabled
 ```
 
 **Upgrade:**

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -66,7 +66,7 @@ Generate a production-ready Helm chart for a Node.js service with HPA and Networ
 | Full install + troubleshooting | [INSTALLATION.md](INSTALLATION.md) |
 | Understand how the skill works | [HOW_IT_WORKS.md](HOW_IT_WORKS.md) |
 | Learn the ownership model | [GETTING_STARTED.md](GETTING_STARTED.md) |
-| See all 28 commands with examples | [COMMANDS.md](COMMANDS.md) |
+| See all 30 commands with examples | [COMMANDS.md](COMMANDS.md) |
 | Triage PR review comments | `/platform-skills:triage` |
 | Scale workloads with KEDA | `/platform-skills:keda` |
 | Browse reference guides | [references/](references/) |

--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ Both layers work independently. The plugin is optional.
 | <img src="https://cdn.simpleicons.org/redhatopenshift/EE0000" width="16" height="16" alt="OpenShift"> OpenShift | [references/openshift.md](references/openshift.md) | Routes, SCC compatibility, operator usage, tenant isolation |
 | <img src="https://cdn.simpleicons.org/argo/EF7B4D" width="16" height="16" alt="Argo CD"> Argo CD | [references/argocd.md](references/argocd.md) | App-of-apps design, ApplicationSet, sync control, promotion flows |
 | <img src="https://cdn.simpleicons.org/flux/5468FF" width="16" height="16" alt="Flux CD"> Flux CD | [references/fluxcd.md](references/fluxcd.md) | Monorepo structure, reconciliation, multi-tenancy, image automation |
+| ↳ Flux CD Sources | [references/fluxcd-sources.md](references/fluxcd-sources.md) | GitRepository, OCIRepository, HelmRepository, Bucket, ArtifactGenerator |
+| ↳ Flux CD ResourceSets | [references/fluxcd-resourcesets.md](references/fluxcd-resourcesets.md) | ResourceSet templating, input strategies, gitless fleet patterns |
+| ↳ Flux CD Notifications | [references/fluxcd-notifications.md](references/fluxcd-notifications.md) | Provider, Alert, Receiver, Slack/Datadog/GitHub commit status |
+| ↳ Flux CD Operator | [references/fluxcd-operator.md](references/fluxcd-operator.md) | FluxInstance sizing, multi-tenancy, kustomize patches, FluxReport |
+| ↳ Flux CD Kustomization | [references/fluxcd-kustomization.md](references/fluxcd-kustomization.md) | CEL readyExpr, postBuild substitution, SOPS, SSA annotations |
+| ↳ Flux CD HelmRelease | [references/fluxcd-helmrelease.md](references/fluxcd-helmrelease.md) | chartRef vs chart.spec, drift detection, post-renderers, CRD lifecycle |
+| ↳ Flux CD Terraform | [references/fluxcd-terraform.md](references/fluxcd-terraform.md) | Flux Operator bootstrap via Terraform |
+| ↳ Flux CD MCP | [references/fluxcd-mcp.md](references/fluxcd-mcp.md) | AI-assisted FluxCD debugging via Flux MCP server |
+| ↳ Flux CD Migration | [references/fluxcd-migration.md](references/fluxcd-migration.md) | v2.7/v2.8 API removals, CLI and Operator upgrade paths |
+| ↳ Flux CD Security | [references/fluxcd-security.md](references/fluxcd-security.md) | Secrets, source auth, OCI supply chain, RBAC, image automation security |
+| ↳ Flux CD Troubleshooting | [references/fluxcd-troubleshooting.md](references/fluxcd-troubleshooting.md) | Incident cheat-sheet — symptom → cause → fix per controller |
 | <img src="https://cdn.simpleicons.org/amazonaws/FF9900" width="16" height="16" alt="AWS"> AWS | [references/aws.md](references/aws.md) | IAM least-privilege, IRSA, EKS, resource tagging, cost allocation |
 | <img src="https://cdn.simpleicons.org/amazonaws/FF9900" width="16" height="16" alt="AWS"> AWS CloudFront | [references/aws-cloudfront.md](references/aws-cloudfront.md) | Distributions, OAC, cache policies, security headers, Lambda@Edge, CloudFront Functions, multi-account |
 | <img src="https://cdn.simpleicons.org/amazonaws/FF9900" width="16" height="16" alt="AWS"> AWS WAF | [references/aws-waf.md](references/aws-waf.md) | Web ACLs, managed rule groups, rate limiting, Bot Control, Firewall Manager, Shield Advanced |
@@ -66,6 +77,7 @@ Both layers work independently. The plugin is optional.
 | 🔒 Compliance | [references/compliance.md](references/compliance.md) | SOC 2 Trust Services Criteria in Terraform: IAM, encryption, detection, audit logging, backup, Checkov enforcement |
 | <img src="https://cdn.simpleicons.org/helm/0F1689" width="16" height="16" alt="Helm"> Helm | [references/helm.md](references/helm.md) | Chart scaffolding, values design, template patterns, security hardening, lint/validation pipeline, GitOps integration |
 | 🔌 MCP | [references/mcp.md](references/mcp.md) | Model Context Protocol server/client development, TypeScript and Python SDKs, stdio/SSE transports, security, testing |
+| ☁️ AWS MCP Profiles | [references/aws-mcp-profiles.md](references/aws-mcp-profiles.md) | Multi-account AWS MCP server management — SSO, Granted, credential_process, profile discovery, VS Code and Claude Code config generation |
 | <img src="https://cdn.simpleicons.org/prometheus/E6522C" width="16" height="16" alt="Prometheus"> Observability | [references/observability.md](references/observability.md) | Structured logging, Prometheus metrics, OpenTelemetry tracing, Grafana dashboards, alerting rules, k6 load testing, capacity planning |
 | 📝 Documentation | [references/documentation.md](references/documentation.md) | Docstrings (Google/NumPy/JSDoc), OpenAPI 3.1 specs, doc sites (MkDocs/TypeDoc), developer guides |
 | <img src="https://cdn.simpleicons.org/datadog/632CA6" width="16" height="16" alt="Datadog"> Datadog | [references/datadog.md](references/datadog.md) | Agent Helm setup, APM instrumentation, log management, monitors/dashboards/SLOs as Terraform, pup CLI, Datadog Labs skills |

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 > A production-grade handbook for platform engineers — 35 domain guides covering Kubernetes, Flux CD, Terraform, GitHub Actions, AWS, OPA/Rego, KEDA, supply chain security, Falco, observability, and more. Use it on GitHub, as a local reference, or install as a Claude skill for interactive guidance with blast radius, validation steps, and rollback plans built in.
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v1.25.20-0e1117)](CHANGELOG.md)
-[![Domains](https://img.shields.io/badge/Domains-35-4c8eda)](references/)
-[![Commands](https://img.shields.io/badge/Commands-28-e87c2b)](commands/)
+[![Version](https://img.shields.io/badge/Version-v1.26.0-0e1117)](CHANGELOG.md)
+[![Domains](https://img.shields.io/badge/Domains-36-4c8eda)](references/)
+[![Commands](https://img.shields.io/badge/Commands-30-e87c2b)](commands/)
 [![Examples](https://img.shields.io/badge/Examples-27-6f42c1)](examples/)
 [![Editors](https://img.shields.io/badge/Editors-VSCode%20%7C%20Cursor%20%7C%20Copilot-2ea44f)](EDITOR_INTEGRATIONS.md)
 [![GitHub Stars](https://img.shields.io/github/stars/nitinjain999/platform-skills?style=flat&label=Stars&color=0e1117)](https://github.com/nitinjain999/platform-skills/stargazers)
@@ -221,7 +221,7 @@ platform-skills/
 
 ## Roadmap
 
-**Current release: v1.25.20** — 28 commands, 35 domain reference guides, 50+ wiki pages.
+**Current release: v1.26.0** — 30 commands, 36 domain reference guides, 50+ wiki pages.
 
 Full version history is in [CHANGELOG.md](CHANGELOG.md).
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -95,6 +95,7 @@ Load only the files needed for the current request.
 | references/fluxcd-troubleshooting.md | Incident cheat-sheet — symptom → cause → fix per controller |
 | references/argocd.md | App delivery, ApplicationSet, sync policies |
 | references/aws.md | Landing zones, IAM, EKS patterns |
+| references/aws-mcp-profiles.md | AWS MCP profile management — multi-account SSO, Granted, credential_process, context budget, starter kits |
 | references/azure.md | Management groups, identity, AKS patterns |
 | references/aws-cloudfront.md | CloudFront distributions, OAC, Lambda@Edge, security headers |
 | references/aws-waf.md | Web ACLs, managed rules, rate limiting, Firewall Manager |

--- a/SKILL.md
+++ b/SKILL.md
@@ -22,6 +22,7 @@ Use this skill for hands-on help with Kubernetes, GitOps, cloud infrastructure, 
 | `Compliance` | SOC 2 controls in Terraform — IAM, encryption, audit logging, Checkov |
 | `Helm (Helmcheck)` | Chart scaffolding, lint/validate pipeline, values design, security hardening |
 | `MCP` | Build/debug MCP servers — tools, resources, transports, auth |
+| `AWS MCP Profiles` | Discover/switch AWS profiles across VS Code + Claude Code MCP configs — multi-account, SSO, Granted, credential_process |
 | `Observability` | Prometheus, OpenTelemetry, Grafana, alerting, k6 load tests, capacity |
 | `Documentation` | Docstrings (Google/NumPy/JSDoc), OpenAPI 3.1, MkDocs, guides |
 | `Datadog` | Agent on Kubernetes, APM, monitors, dashboards, SLOs, LLMObs |
@@ -139,6 +140,7 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:compliance` — SOC 2 gap analysis, control implementation, evidence collection, and Checkov remediation for Terraform
 - `/platform-skills:helmcheck` — Helm chart scaffolding, structural review, and security audit with full lint/validation pipeline
 - `/platform-skills:mcp` — MCP server/client scaffolding, protocol review, and integration debugging
+- `/platform-skills:aws-profile` — discover, switch, and validate AWS profiles for MCP servers across VS Code and Claude Code
 - `/platform-skills:observability` — instrument services, build dashboards, write alerts, run load tests, plan capacity
 - `/platform-skills:document` — generate docstrings, OpenAPI specs, documentation sites, and getting started guides
 - `/platform-skills:datadog` — Datadog Agent setup, APM instrumentation, monitors, dashboards, SLOs, pup CLI operations, LLM Observability instrumentation, evaluators, and debugging

--- a/commands/aws-profile.md
+++ b/commands/aws-profile.md
@@ -38,7 +38,7 @@ security              static       890123456     -          -                 ne
 2. Parse credential cache files for expiration timestamps. Field names differ by type:
    - SSO (`~/.aws/sso/cache/*.json`): top-level `expiresAt`
    - Assumed role (`~/.aws/cli/cache/*.json`): `Credentials.Expiration`
-   - Granted (`~/.granted/*.json`, if present): top-level `expiresAt`
+   - Granted: no separate cache — SSO-backed profiles use `~/.aws/sso/cache/*.json` (`expiresAt`); role-chained profiles use `~/.aws/cli/cache/*.json` (`Credentials.Expiration`)
    Apply traffic-light TTL:
    - ✓ Green: >30 min
    - ⚠ Amber: 10–30 min

--- a/commands/aws-profile.md
+++ b/commands/aws-profile.md
@@ -35,7 +35,11 @@ security              static       890123456     -          -                 ne
    - Granted: `granted_sso_*` keys or `assume` binary in PATH
    - Static: `aws_access_key_id` directly in profile block → warn to rotate
 
-2. Parse `~/.aws/sso/cache/*.json`, `~/.aws/cli/cache/*.json`, and `~/.granted/*.json` (if present) for `expiresAt` fields. Apply traffic-light TTL:
+2. Parse credential cache files for expiration timestamps. Field names differ by type:
+   - SSO (`~/.aws/sso/cache/*.json`): top-level `expiresAt`
+   - Assumed role (`~/.aws/cli/cache/*.json`): `Credentials.Expiration`
+   - Granted (`~/.granted/*.json`, if present): top-level `expiresAt`
+   Apply traffic-light TTL:
    - ✓ Green: >30 min
    - ⚠ Amber: 10–30 min
    - ✗ Red: <10 min or expired

--- a/commands/aws-profile.md
+++ b/commands/aws-profile.md
@@ -35,7 +35,7 @@ security              static       890123456     -          -                 ne
    - Granted: `granted_sso_*` keys or `assume` binary in PATH
    - Static: `aws_access_key_id` directly in profile block → warn to rotate
 
-2. Parse `~/.aws/sso/cache/*.json` and `~/.aws/cli/cache/*.json` for `expiresAt` fields. Apply traffic-light TTL:
+2. Parse `~/.aws/sso/cache/*.json`, `~/.aws/cli/cache/*.json`, and `~/.granted/*.json` (if present) for `expiresAt` fields. Apply traffic-light TTL:
    - ✓ Green: >30 min
    - ⚠ Amber: 10–30 min
    - ✗ Red: <10 min or expired
@@ -118,10 +118,12 @@ aws-profile switch staging-assume --server eks-staging
 aws-profile switch --env prod --confirm
 ```
 
+**Pre-condition:** If `~/.aws-profile-tags.yaml` does not exist, run `aws-profile discover` first to generate it.
+
 **Steps:**
 
 1. Resolve target profile:
-   - If `--env <tag>`: look up profile in `~/.aws-profile-tags.yaml` that matches the tag. Error if multiple profiles share the tag — require explicit profile name.
+   - If `--env <tag>`: look up the profile in `~/.aws-profile-tags.yaml` that matches the tag — this selects which *profile* to switch to, not which servers to patch. Error if multiple profiles share the tag — require explicit profile name.
    - Otherwise: use the profile name directly.
 
 2. Safety check — if profile name contains `prod` or `production` or is tagged `prod` in `~/.aws-profile-tags.yaml`:
@@ -135,7 +137,7 @@ aws-profile switch --env prod --confirm
 3. Determine target files by `--scope`:
    - `global` (default): `~/.vscode/mcp.json` + `~/.claude/settings.json`
    - `workspace`: `.vscode/mcp.json` in current directory only
-   - `--server <name>`: patch only that named entry across all scopes
+   - `--server <name>`: patch only that named entry, searching all scope files regardless of `--scope` (overrides scope)
 
 4. For each matched server entry, update `env.AWS_PROFILE` to the new profile. If `--region` provided, also update `env.AWS_REGION` and any `--region` arg in the `args` array.
 
@@ -204,7 +206,7 @@ aws-profile login <profile>
      See: references/aws-mcp-profiles.md → Auth Flows
    ```
 
-3. After emitting the command, run `status` to show TTL confirmation.
+3. After emitting the command, run `status` to confirm that the TTL for `<profile>` now shows green (>30 min). Other expired profiles in the output are unrelated to this login.
 
 Reference: `references/aws-mcp-profiles.md` → Auth Flows
 
@@ -257,6 +259,7 @@ credential_process = granted credential-process --profile shared-services
 **Steps:**
 
 1. Run: `aws organizations list-accounts --profile <mgmt-profile> --output json`
+   If `--profile` is omitted, use the default profile from `~/.aws/config` (or `AWS_DEFAULT_PROFILE` if set).
 2. For each account, check if any profile in `~/.aws/config` references that account ID via `sso_account_id` or call `aws sts get-caller-identity --profile <p>` to resolve.
 3. Cross-reference `~/.aws-profile-tags.yaml` for env tags.
 4. If `--generate-profiles`: generate SSO stanzas using the `sso_start_url` and `sso_region` from an existing SSO profile as the template.

--- a/commands/aws-profile.md
+++ b/commands/aws-profile.md
@@ -10,6 +10,33 @@ Reference: `references/aws-mcp-profiles.md`
 
 ---
 
+## Interactive Wizard (fires when no mode is provided)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Mode?**
+```
+What do you need?
+  1. discover  — list all AWS profiles with type, account ID, env tag, and credential TTL
+  2. status    — show which profile each MCP server is using and whether credentials are fresh
+  3. switch    — update MCP config files to use a different profile
+  4. login     — authenticate and refresh credentials for a specific profile
+  5. org-scan  — list all AWS Organization accounts and cross-reference with configured profiles
+
+Enter 1–5 or mode name:
+```
+
+**Q2 — Mode-specific follow-up** (one question, after mode is selected):
+- **discover**: `Any filters? (e.g. --expired to show only expired, --type sso, --env prod) — or press enter to list all:`
+- **switch**: Read `~/.aws/config` and list available profiles, then ask: `Which profile should MCP servers switch to?`
+- **login**: Read `~/.aws/config` and list available profiles, then ask: `Which profile needs authentication?`
+- **status**: no follow-up — proceed directly
+- **org-scan**: `Which management account profile has organizations:ListAccounts permission? (default: current profile):`
+
+Then proceed into the relevant mode below.
+
+---
+
 ## Mode: discover
 
 Parse `~/.aws/config` and output a classified profile table with credential TTL.

--- a/commands/aws-profile.md
+++ b/commands/aws-profile.md
@@ -1,0 +1,266 @@
+---
+name: aws-profile
+description: AWS profile management for MCP servers — discover profiles across SSO, Granted, and assumed-role chains, check credential TTL, switch profiles across VS Code and Claude Code MCP configs, and scan AWS Organization accounts.
+argument-hint: "[discover|status|switch <profile>|login <profile>|org-scan] [flags]"
+---
+
+Manage AWS profiles for MCP server configurations across VS Code (GitHub Copilot) and Claude Code.
+
+Reference: `references/aws-mcp-profiles.md`
+
+---
+
+## Mode: discover
+
+Parse `~/.aws/config` and output a classified profile table with credential TTL.
+
+```
+aws-profile discover [--type sso|assume-role|granted|static] [--env prod|staging|dev] [--account <id>] [--chain] [--expired]
+```
+
+**Output:**
+```
+Profile               Type         Account ID    Env Tag    Permission Set    Expires      TTL
+prod-platform-eu      sso          123456789     prod       PowerUser         14:32 UTC    47m ✓
+staging-assume        assume-role  456789123     staging    -                 13:58 UTC    13m ⚠
+dev-sandbox           granted      987654321     dev        Developer         09:00 UTC    EXPIRED ✗
+security              static       890123456     -          -                 never        ⚠ rotate
+```
+
+**Steps:**
+
+1. Parse `~/.aws/config` — classify each `[profile name]` block by type:
+   - SSO: `sso_start_url` present
+   - Assumed role: `role_arn` + `source_profile`
+   - Granted: `granted_sso_*` keys or `assume` binary in PATH
+   - Static: `aws_access_key_id` directly in profile block → warn to rotate
+
+2. Parse `~/.aws/sso/cache/*.json` and `~/.aws/cli/cache/*.json` for `expiresAt` fields. Apply traffic-light TTL:
+   - ✓ Green: >30 min
+   - ⚠ Amber: 10–30 min
+   - ✗ Red: <10 min or expired
+
+3. Read `~/.aws-profile-tags.yaml` for env tags. If the file does not exist, generate a starter file:
+   ```yaml
+   # ~/.aws-profile-tags.yaml — edit to correct heuristic guesses
+   prod-platform-eu: prod    # detected: name contains 'prod'
+   staging-assume: staging   # detected: name contains 'stag'
+   dev-sandbox: dev          # detected: name contains 'dev'
+   security: shared-services # detected: name contains 'security'
+   ```
+   Print: `Generated ~/.aws-profile-tags.yaml — review and correct environment tags.`
+
+4. Apply filters if flags provided.
+
+**With `--chain`** — show full role assumption chain for assumed-role profiles:
+```
+staging-assume role chain:
+  dev-sso (identity: 111111111)
+    └── assume → security-role (222222222)
+        └── assume → staging-platform (456789123)  ← this profile
+```
+
+Parse the chain by following `source_profile` → `role_arn` links recursively in `~/.aws/config`.
+
+Reference: `references/aws-mcp-profiles.md` → Profile Type Detection, Credential Lifecycle
+
+---
+
+## Mode: status
+
+Show which profile each configured MCP server uses, the credential TTL, and whether the credential method will auto-refresh.
+
+**Note:** `status` reads config files and `~/.aws/sso/cache/` — it does not read the `AWS_PROFILE` shell environment variable, which is per-session and invisible to this command.
+
+```
+aws-profile status [--watch] [--all-hosts]
+```
+
+**Output:**
+```
+Profile in MCP configs: prod-platform-eu
+  Type: SSO | Account: 123456789 | Permission: PowerUser
+  Token expires: 14:32 UTC (47 minutes) ✓
+
+MCP Servers:
+  eks-prod-eu      ~/.vscode/mcp.json          credential_process ✓   47m
+  cloudwatch       ~/.claude/settings.json      AWS_PROFILE ⚠         47m (will not auto-refresh on expiry)
+  eks-prod-us      .vscode/mcp.json            credential_process ✓   47m
+
+⚠ 'cloudwatch' uses raw AWS_PROFILE without credential_process.
+  When the token expires, this server will fail silently.
+  Fix: add credential_process to the 'prod-platform-eu' profile in ~/.aws/config.
+  See: references/aws-mcp-profiles.md → credential_process Pattern
+```
+
+**Steps:**
+
+1. Scan `~/.vscode/mcp.json`, `~/.claude/settings.json`, and `.vscode/mcp.json` (if present in cwd). Extract `AWS_PROFILE` from each server's `env` block.
+2. For each unique profile found, parse TTL from `~/.aws/sso/cache/` or `~/.aws/cli/cache/`.
+3. Check whether the profile in `~/.aws/config` has `credential_process` configured. Flag servers without it as ⚠.
+4. If `--watch`: re-run every 60 seconds. Print a warning when any TTL drops below 30 minutes, and a loud alert when any TTL drops below 10 minutes.
+
+---
+
+## Mode: switch
+
+Patch `AWS_PROFILE` (and `AWS_REGION` if `--region` provided) in MCP server config files. Requires `--confirm` for any profile tagged `prod` or whose name contains `prod` or `production`.
+
+```
+aws-profile switch <profile> [--scope global|workspace] [--server <name>] [--env <tag>] [--region <region>] [--confirm]
+```
+
+**Examples:**
+```
+aws-profile switch prod-platform-eu --scope workspace --confirm
+aws-profile switch dev-sandbox --scope global
+aws-profile switch staging-assume --server eks-staging
+aws-profile switch --env prod --confirm
+```
+
+**Steps:**
+
+1. Resolve target profile:
+   - If `--env <tag>`: look up profile in `~/.aws-profile-tags.yaml` that matches the tag. Error if multiple profiles share the tag — require explicit profile name.
+   - Otherwise: use the profile name directly.
+
+2. Safety check — if profile name contains `prod` or `production` or is tagged `prod` in `~/.aws-profile-tags.yaml`:
+   ```
+   ⚠ WARNING: Switching to prod-platform-eu (tagged: prod, Account: 123456789).
+     MCP operations will run against production.
+     Pass --confirm to proceed.
+   ```
+   Halt without `--confirm`.
+
+3. Determine target files by `--scope`:
+   - `global` (default): `~/.vscode/mcp.json` + `~/.claude/settings.json`
+   - `workspace`: `.vscode/mcp.json` in current directory only
+   - `--server <name>`: patch only that named entry across all scopes
+
+4. For each matched server entry, update `env.AWS_PROFILE` to the new profile. If `--region` provided, also update `env.AWS_REGION` and any `--region` arg in the `args` array.
+
+5. Show a diff of what was patched:
+   ```
+   Patched 3 server entries:
+     eks-prod-eu     ~/.vscode/mcp.json          AWS_PROFILE: old-profile → prod-platform-eu
+     cloudwatch      ~/.claude/settings.json     AWS_PROFILE: old-profile → prod-platform-eu
+     eks-staging     .vscode/mcp.json            AWS_PROFILE: old-profile → prod-platform-eu
+   ```
+
+6. Always emit restart instructions:
+   ```
+   ⚠ Restart required — config changes do not affect running server processes:
+     VS Code / Copilot: Cmd+Shift+P → "MCP: Restart Server"  (or: Developer: Reload Window)
+     Claude Code: exit this session and start a new one
+   ```
+
+Reference: `references/aws-mcp-profiles.md` → Config File Locations, Prod Safety
+
+---
+
+## Mode: login
+
+Detect the profile type and emit the correct authentication command. After successful login, run `status` automatically.
+
+```
+aws-profile login <profile>
+```
+
+**Steps:**
+
+1. Read `~/.aws/config` for `[profile <name>]`. Classify type.
+
+2. Emit and explain the auth command:
+
+   **SSO:**
+   ```
+   aws sso login --profile prod-platform-eu
+   
+   This opens a browser for SSO authentication. After approval, your token
+   is cached in ~/.aws/sso/cache/ (TTL: 8–12h, org-configured).
+   ```
+
+   **Granted:**
+   ```
+   assume prod-platform-eu
+   
+   Granted will authenticate via SSO and cache credentials.
+   If prompted for duration, 4h is a reasonable default for a workday session.
+   ```
+
+   **Assumed role:**
+   ```
+   The source profile 'dev-sso' must be authenticated first:
+     aws sso login --profile dev-sso
+   
+   Then validate the role assumption:
+     aws sts get-caller-identity --profile staging-assume
+   ```
+
+   **Static:**
+   ```
+   ⚠ Static credentials do not have a login flow — they are long-lived and do not expire cleanly.
+     Recommendation: Rotate this profile to AWS SSO (IAM Identity Center).
+     See: references/aws-mcp-profiles.md → Auth Flows
+   ```
+
+3. After emitting the command, run `status` to show TTL confirmation.
+
+Reference: `references/aws-mcp-profiles.md` → Auth Flows
+
+---
+
+## Mode: org-scan
+
+List all accounts in the AWS Organization and cross-reference with configured profiles. Requires `organizations:ListAccounts` permission — available only from the management account or a delegated admin account.
+
+```
+aws-profile org-scan [--profile <mgmt-profile>] [--generate-profiles]
+```
+
+**Output:**
+```
+AWS Organization accounts (via profile: org-management):
+
+Account ID    Account Name          Env Tag    Profiles configured
+123456789     prod-platform         prod       ✓ prod-platform-eu, prod-platform-us
+456789123     staging               staging    ✓ staging-assume
+789012345     dev-sandbox-1         dev        ✓ dev-sandbox
+890123456     security-tooling      -          ✗ NO PROFILE — add to ~/.aws/config
+901234567     shared-services       -          ✗ NO PROFILE — add to ~/.aws/config
+
+2 accounts have no profile configured.
+Run with --generate-profiles to emit ~/.aws/config stanzas for them.
+```
+
+**With `--generate-profiles`** — emit SSO-based stanzas for unconfigured accounts:
+```ini
+# Add to ~/.aws/config — replace ROLE_NAME with your SSO permission set
+
+[profile security-tooling]
+sso_start_url = https://myorg.awsapps.com/start
+sso_region = eu-west-1
+sso_account_id = 890123456
+sso_role_name = ROLE_NAME
+region = eu-west-1
+credential_process = granted credential-process --profile security-tooling
+
+[profile shared-services]
+sso_start_url = https://myorg.awsapps.com/start
+sso_region = eu-west-1
+sso_account_id = 901234567
+sso_role_name = ROLE_NAME
+region = eu-west-1
+credential_process = granted credential-process --profile shared-services
+```
+
+**Steps:**
+
+1. Run: `aws organizations list-accounts --profile <mgmt-profile> --output json`
+2. For each account, check if any profile in `~/.aws/config` references that account ID via `sso_account_id` or call `aws sts get-caller-identity --profile <p>` to resolve.
+3. Cross-reference `~/.aws-profile-tags.yaml` for env tags.
+4. If `--generate-profiles`: generate SSO stanzas using the `sso_start_url` and `sso_region` from an existing SSO profile as the template.
+
+**Note:** `organizations:ListAccounts` requires management account access. Most platform engineers work from member accounts and will not have this permission. This mode is intended for platform leads and account vending workflows.
+
+Reference: `references/aws-mcp-profiles.md` → Profile Type Detection, credential_process Pattern

--- a/commands/aws.md
+++ b/commands/aws.md
@@ -1,7 +1,7 @@
 ---
 name: aws
 description: Structured guidance for AWS CloudFront distributions, WAF web ACLs, Lambda@Edge, CloudFront Functions, Firewall Manager multi-account enforcement, and IAM/IRSA patterns. Covers OAC, cache policies, security headers, managed rule groups, rate limiting, FMS FIRST/MIDDLE/LAST ownership model, and production-ready Terraform generation.
-argument-hint: "[cloudfront|waf|lambda-edge|multi-account|review|terraform] [description or code]"
+argument-hint: "[cloudfront|waf|lambda-edge|multi-account|orgs|review|terraform] [description or code]"
 ---
 
 # AWS Command

--- a/commands/aws.md
+++ b/commands/aws.md
@@ -8,6 +8,34 @@ argument-hint: "[cloudfront|waf|lambda-edge|multi-account|review|terraform] [des
 
 Structured guidance for AWS CloudFront, WAF, Lambda@Edge, and multi-account security patterns.
 
+## Interactive Wizard (fires when no mode is provided)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Mode?**
+```
+What do you need?
+  1. cloudfront   — distributions, OAC, cache policies, security headers, Lambda@Edge
+  2. waf          — web ACLs, managed rule groups, rate limiting, false positive tuning
+  3. lambda-edge  — CloudFront Functions vs Lambda@Edge, viewer/origin events
+  4. multi-account — Firewall Manager, cross-account OAC, FMS WAF enforcement
+  5. orgs         — Organizations, SCPs, OU design, account vending, Control Tower
+  6. review       — production-readiness review of CloudFront + WAF config
+  7. terraform    — generate a Terraform module scaffold
+
+Enter 1–7 or mode name:
+```
+
+**Q2 — Context** (after mode selected):
+- **cloudfront**: `Describe the issue or what you want to build (distribution, OAC, cache, edge function):`
+- **waf**: `Describe the use case — new WebACL, false positive, adding a rule, or multi-account enforcement:`
+- **lambda-edge**: `What does the edge function need to do? (auth, URL rewrite, A/B test, dynamic routing):`
+- **multi-account**: `How many accounts? Do you have FMS administrator configured in the security account?`
+- **orgs**: `Describe what you need — SCP enforcement, OU design, account vending, or Control Tower setup:`
+- **review / terraform**: no follow-up needed — proceed directly
+
+---
+
 ## Activation
 
 Invoke with `/platform-skills:aws` followed by a mode, or describe your problem and the command will route automatically.
@@ -172,6 +200,97 @@ Steps:
 
 ---
 
+## Mode: orgs
+
+**Triggers:** Organizations, SCPs, OU, account vending, Control Tower, delegated admin, account factory, guardrails
+
+Steps:
+
+1. **Identify the request:**
+   - **SCP design** — what to restrict and at which OU level
+   - **OU structure** — hierarchy that reflects environment and risk boundary
+   - **Account vending** — automated account creation with baseline config
+   - **Control Tower** — managed landing zone setup and customizations
+
+2. **OU design principles:**
+
+   | OU | Accounts | SCP stance |
+   |----|----------|------------|
+   | Security | Log archive, Audit | Deny all except security tooling |
+   | Infrastructure | Network, Shared services | Restricted; platform team only |
+   | Workloads/Prod | Production app accounts | Deny risky actions (delete trail, disable GuardDuty) |
+   | Workloads/SDLC | Dev, staging accounts | More permissive; deny prod data access |
+   | Sandbox | Developer personal accounts | Deny spend > threshold; deny production-touching actions |
+
+3. **Essential SCPs (apply at root or Workloads OU):**
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Sid": "DenyLeavingOrg",
+         "Effect": "Deny",
+         "Action": "organizations:LeaveOrganization",
+         "Resource": "*"
+       },
+       {
+         "Sid": "DenyDisableCloudTrail",
+         "Effect": "Deny",
+         "Action": ["cloudtrail:StopLogging", "cloudtrail:DeleteTrail"],
+         "Resource": "*"
+       },
+       {
+         "Sid": "DenyDisableGuardDuty",
+         "Effect": "Deny",
+         "Action": ["guardduty:DeleteDetector", "guardduty:DisassociateFromMasterAccount"],
+         "Resource": "*"
+       },
+       {
+         "Sid": "DenyRootUser",
+         "Effect": "Deny",
+         "Action": "*",
+         "Resource": "*",
+         "Condition": {
+           "StringLike": { "aws:PrincipalArn": "arn:aws:iam::*:root" }
+         }
+       }
+     ]
+   }
+   ```
+
+4. **Account vending (Account Factory for Terraform — AFT):**
+   ```hcl
+   module "account_request" {
+     source = "github.com/aws-ia/terraform-aws-control_tower_account_factory"
+     control_tower_parameters = {
+       AccountEmail = "platform+prod-payments@company.com"
+       AccountName  = "prod-payments"
+       ManagedOrganizationalUnit = "Workloads/Prod"
+       SSOUserEmail = "admin@company.com"
+     }
+     account_tags = { env = "prod", team = "payments", cost-center = "eng" }
+     account_customizations_name = "prod-baseline"
+   }
+   ```
+
+5. **Delegated administrators** — always delegate to a dedicated account, never the management account:
+   - GuardDuty: `aws organizations register-delegated-administrator --service-principal guardduty.amazonaws.com`
+   - SecurityHub: `--service-principal securityhub.amazonaws.com`
+   - FMS: designated separately via FMS console or Terraform
+
+6. **Validate SCP effect before attaching:**
+   ```bash
+   # Simulate an action under the SCP (requires aws-cli v2)
+   aws iam simulate-custom-policy \
+     --policy-input-list file://scp.json \
+     --action-names cloudtrail:StopLogging \
+     --resource-arns "*"
+   ```
+
+→ **Next:** Run `/platform-skills:aws review` to audit the account configuration, or `/platform-skills:compliance checklist` to validate SOC 2 controls across the org.
+
+---
+
 ## Mode: review
 
 **Triggers:** review, production ready, production checklist, audit my CloudFront, audit my WAF
@@ -233,6 +352,17 @@ Then generate complete module files:
 ```
 
 **Non-negotiable patterns in every generated module:**
+
+---
+
+## Common mistakes
+
+- **WAF scope in wrong region** — `CLOUDFRONT` scope WebACLs must be created in `us-east-1`. Any other region returns `WAFInvalidParameterException`. Use a provider alias `aws.us_east_1` explicitly
+- **OAI instead of OAC** — OAI (Origin Access Identity) is legacy. New distributions must use OAC (`aws_cloudfront_origin_access_control`). OAI does not support non-S3 origins or newer signing protocols
+- **Lambda@Edge using `$LATEST`** — `$LATEST` is not a publishable version and cannot be associated with CloudFront. Set `publish = true` in the resource and reference `aws_lambda_function.this.qualified_arn`
+- **ACM certificate not in us-east-1** — CloudFront only accepts ACM certificates created in `us-east-1`, regardless of where the distribution serves traffic
+- **SCP accidentally blocking the management account** — SCPs do not apply to the management account. Policies intended to restrict member accounts work correctly; don't expect them to constrain root
+- **Attaching WAF rules directly in Block mode** — always Count first for 24–48h before switching to Block. A misconfigured rule in Block mode silently drops legitimate traffic
 
 ```hcl
 # versions.tf — always pin providers

--- a/commands/chaos.md
+++ b/commands/chaos.md
@@ -6,6 +6,37 @@ argument-hint: "[install|experiment|schedule|gameday|debug|report] [description 
 
 Design, run, and debug Chaos Engineering experiments on Kubernetes.
 
+---
+
+## Interactive Wizard (fires when no arguments are provided)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Mode?**
+```
+What do you need?
+  1. install    — install Litmus Chaos or Chaos Mesh via Helm
+  2. experiment — design a fault injection experiment
+  3. schedule   — wrap an experiment in a recurring schedule
+  4. gameday    — run a structured GameDay experiment
+  5. debug      — diagnose a failed or stuck experiment
+  6. report     — summarize results after an experiment completes
+
+Enter 1–6 or mode name:
+```
+
+After collecting the mode, ask one follow-up:
+- **install**: `Which tool? Litmus Chaos (recommended default) or Chaos Mesh (network/IO faults)?`
+- **experiment**: `Describe the workload to target — name, namespace, fault type (pod-delete / network-loss / cpu-stress / node-drain):`
+- **schedule**: `Provide the experiment YAML or describe the experiment to wrap in a schedule:`
+- **gameday**: `State the steady-state hypothesis — what metric or probe proves the system is healthy?`
+- **debug**: `Describe the symptom or paste the ChaosEngine/ChaosResult status:`
+- **report**: `Paste the ChaosResult output or describe the experiment that ran:`
+
+Then proceed into the relevant mode below.
+
+---
+
 ## Mode: install
 
 Install Litmus Chaos or Chaos Mesh via Helm.

--- a/commands/compliance.md
+++ b/commands/compliance.md
@@ -10,6 +10,35 @@ You are acting as a senior platform engineer with deep knowledge of SOC 2 compli
 
 Read `references/compliance.md` before responding.
 
+---
+
+## Interactive Wizard (fires when no arguments are provided)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Topic?**
+```
+What do you need?
+  1. gap       — SOC 2 gap analysis of Terraform configuration
+  2. control   — implement a specific SOC 2 control
+  3. evidence  — collect audit evidence for an auditor
+  4. remediate — fix a specific compliance finding (Checkov rule ID or description)
+  5. checklist — full SOC 2 readiness checklist
+
+Enter 1–5 or topic name:
+```
+
+**Q2 — Context** (after topic selected, one at a time):
+- **gap**: `Paste your Terraform resource(s) or describe the configuration to assess:`
+- **control**: `Which SOC 2 criterion? (e.g. CC6.7, CC7.2, A1.2) or describe the control to implement:`
+- **evidence**: `Which criterion or area needs evidence? (e.g. CC7.2 CloudTrail, CC6.7 encryption):`
+- **remediate**: `Paste the finding or Checkov rule ID (e.g. CKV_AWS_19) and the failing resource:`
+- **checklist**: no follow-up needed — proceed directly
+
+Then proceed into the relevant section below.
+
+---
+
 ## How to respond
 
 Identify the topic from the input and apply the matching framework:

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -1,7 +1,7 @@
 ---
 name: debug
 description: Structured platform troubleshooting — classifies the problem layer, collects evidence, forms a root-cause hypothesis, and proposes a fix with validation and rollback steps.
-argument-hint: "[symptom or error message]"
+argument-hint: "[timeline <minutes>|symptom or error message]"
 ---
 
 ---

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -60,3 +60,77 @@ Commands to confirm the fix worked.
 ## 6. Rollback
 
 How to safely undo the change if validation fails.
+
+---
+
+## Mode: timeline
+
+Reconstruct what happened in a cluster in the last N minutes. Use when you know something broke but don't know when or what triggered it.
+
+**Steps:**
+
+1. **Collect events across all namespaces, sorted by time:**
+   ```bash
+   kubectl get events -A --sort-by='.lastTimestamp' | tail -50
+   kubectl get events -A --sort-by='.lastTimestamp' \
+     --field-selector type=Warning | tail -30
+   ```
+
+2. **Check recent pod state changes:**
+   ```bash
+   # Pods that restarted or are not Running
+   kubectl get pods -A | grep -v Running | grep -v Completed
+   # Restart counts
+   kubectl get pods -A -o custom-columns=\
+   'NS:.metadata.namespace,NAME:.metadata.name,RESTARTS:.status.containerStatuses[0].restartCount' \
+   | sort -k3 -rn | head -20
+   ```
+
+3. **Controller-level changes (what Kubernetes itself did):**
+   ```bash
+   kubectl get events -A --sort-by='.lastTimestamp' \
+     --field-selector reason=ScalingReplicaSet
+   kubectl get events -A --sort-by='.lastTimestamp' \
+     --field-selector reason=FailedScheduling
+   ```
+
+4. **Recent deployments and rollouts:**
+   ```bash
+   kubectl rollout history deployment -A 2>/dev/null | grep -v "<none>"
+   # Check who deployed and when
+   kubectl get replicasets -A --sort-by='.metadata.creationTimestamp' | tail -10
+   ```
+
+5. **Node-level events (pressure, cordoning, OOM):**
+   ```bash
+   kubectl describe nodes | grep -A5 "Conditions:\|Events:"
+   kubectl get events -A --field-selector involvedObject.kind=Node \
+     --sort-by='.lastTimestamp' | tail -20
+   ```
+
+6. **Flux / GitOps reconciliation timeline (if applicable):**
+   ```bash
+   flux get all -A | grep -v "True"
+   kubectl get events -n flux-system --sort-by='.lastTimestamp' | tail -20
+   ```
+
+7. **Produce a timeline** — order all findings chronologically:
+   ```
+   HH:MM  [Node]       node-3 reports MemoryPressure
+   HH:MM  [Scheduler]  pod/payment-api-7d9f unable to schedule (Insufficient memory)
+   HH:MM  [ReplicaSet] payment-api scaled down from 5 → 3 replicas
+   HH:MM  [HPA]        payment-api HPA unable to compute desired replica count
+   HH:MM  [Alert]      ErrorRateCritical fires on payment-api
+   ```
+
+→ **Next:** Once the timeline is established, run `/platform-skills:debug` with the root-cause symptom for structured fix guidance, or `/platform-skills:product postmortem` to convert the timeline into a post-mortem.
+
+---
+
+## Common mistakes
+
+- **Fixing symptoms without collecting evidence first** — `kubectl delete pod` before reading logs loses the crash context permanently. Always gather evidence before acting
+- **Checking only the failing pod's logs** — the root cause is often in a dependency (upstream service, database, config source). Follow the call chain
+- **Ignoring event timestamps** — Kubernetes events expire after 1h by default; check them immediately after an incident
+- **Assuming the first error in logs is the root cause** — cascading failures produce many errors; work backwards from the first anomaly in the timeline
+- **Applying a fix without a rollback plan** — every production change needs a known undo path before it is applied, not after

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -4,6 +4,24 @@ description: Structured platform troubleshooting — classifies the problem laye
 argument-hint: "[symptom or error message]"
 ---
 
+---
+
+## Interactive Wizard (fires when $ARGUMENTS is empty)
+
+When invoked with no arguments, ask before troubleshooting:
+
+**Q1 — What is the symptom?**
+```
+Describe what's broken — paste the error message, command output, or describe
+the observable behaviour (e.g. "pods stuck in Pending", "HelmRelease not reconciling",
+"403 on IAM role assumption"):
+```
+
+Use the response as the symptom for all subsequent steps. Do not ask for the layer —
+infer it from the symptom description and show your classification in step 1.
+
+---
+
 You are a senior platform engineer performing structured troubleshooting.
 
 The user reports: $ARGUMENTS

--- a/commands/gitops.md
+++ b/commands/gitops.md
@@ -4,6 +4,29 @@ description: Flux CD and Argo CD — two modes. debug: five structured debug wor
 argument-hint: "debug [describe symptom or paste flux/argocd output] | audit [repo path or paste directory listing]"
 ---
 
+---
+
+## Interactive Wizard (fires when $ARGUMENTS is empty)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Mode?**
+```
+Are you debugging a live cluster issue or auditing a GitOps repository?
+  1. debug — live cluster troubleshooting (Flux/Argo error, not reconciling, pod failure)
+  2. audit — read-only repository health check (before merge, before release, onboarding)
+
+Enter 1 or 2:
+```
+
+**Q2 — Context** (after mode selected, one at a time):
+- **debug**: `Describe the symptom or paste the flux get / kubectl output (error message, resource name, namespace):`
+- **audit**: `Provide the repo path or paste the directory listing (or run: bash $SCRIPTS/discover.sh -d . if tooling is set up):`
+
+Then proceed with the relevant mode below.
+
+---
+
 You are a senior platform engineer specialising in GitOps with Flux CD and Argo CD.
 
 The input is: $ARGUMENTS

--- a/commands/helmcheck.md
+++ b/commands/helmcheck.md
@@ -4,6 +4,31 @@ description: Scaffold, review, lint, and security-audit Helm charts. Runs helm l
 argument-hint: "[create <workload-type> | review | security] [chart path or description]"
 ---
 
+---
+
+## Interactive Wizard (fires when $ARGUMENTS is empty)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Mode?**
+```
+What do you need?
+  1. create   — scaffold a new production-ready Helm chart
+  2. review   — analyse an existing chart for structural and quality issues
+  3. security — audit a chart for security misconfigurations
+
+Enter 1–3 or mode name:
+```
+
+**Q2 — Details** (after mode selected, one at a time):
+- **create**: `What type of workload? (web-service / worker / cronjob / stateful)` then `Chart name?`
+- **review**: `Paste the chart directory listing or file content to review (or provide the chart path):`
+- **security**: `Paste the chart directory listing or file content to audit (or provide the chart path):`
+
+Then proceed into the relevant mode below.
+
+---
+
 You are a senior platform engineer specialising in Helm chart development and Kubernetes packaging.
 
 The input is: $ARGUMENTS

--- a/commands/kyverno.md
+++ b/commands/kyverno.md
@@ -8,6 +8,35 @@ Write, test, audit, debug, and migrate Kyverno policies using the new CEL-based 
 
 All new policies use `apiVersion: policies.kyverno.io/v1`. Legacy `ClusterPolicy` (`kyverno.io/v1`) still works but is deprecated in v1.17 and planned for removal in v1.20.
 
+---
+
+## Interactive Wizard (fires when no arguments are provided)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Mode?**
+```
+What do you need?
+  1. generate — write a new production-ready Kyverno policy
+  2. test     — write kyverno-test.yaml fixtures and run kyverno-cli
+  3. audit    — analyse PolicyReport data from a running cluster
+  4. debug    — diagnose why a policy is not behaving as expected
+  5. migrate  — convert a legacy ClusterPolicy or PodSecurityPolicy
+
+Enter 1–5 or mode name:
+```
+
+**Q2 — Context** (after mode selected, one at a time):
+- **generate**: `Describe the policy — what should it validate, mutate, or enforce? (e.g. "require app.kubernetes.io/team label on all Deployments"):`
+- **test**: `Paste or describe the policy to test:`
+- **audit**: `Paste the PolicyReport JSON or run: kubectl get policyreport -A -o json | jq '[.items[].results[] | select(.result == "fail")]'`
+- **debug**: `Describe the symptom — is the policy not blocking, not mutating, or not appearing in PolicyReport?`
+- **migrate**: `Paste the existing ClusterPolicy or PodSecurityPolicy YAML to migrate:`
+
+Then proceed into the relevant mode below.
+
+---
+
 ## Mode: generate
 
 Write a production-ready Kyverno policy from a description.

--- a/commands/linux.md
+++ b/commands/linux.md
@@ -10,6 +10,35 @@ You are acting as a senior platform engineer. The user has invoked `/platform-sk
 
 Read `references/linux-networking.md` before responding.
 
+---
+
+## Interactive Wizard (fires when $ARGUMENTS is empty)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Topic?**
+```
+What do you need?
+  1. dns            — DNS resolution failures, CoreDNS, propagation
+  2. lb             — Load balancer (ALB/NLB/Ingress) health checks, routing
+  3. vpc            — VPC/VNet design, peering, Transit Gateway, PrivateLink
+  4. process        — systemctl, journald, service crashes, resource exhaustion
+  5. disk           — space, inode exhaustion, deleted-but-not-freed files
+  6. network        — L3/L4/L7 connectivity, interface state, kernel tuning
+  7. security-groups — security group / NSG rule debugging
+  8. systemd        — unit files, overrides, dependencies, failed services
+  9. cgroups        — container resource isolation, OOMKill diagnosis, cgroupv2
+  10. kernel        — sysctl tuning for container hosts, file descriptors, TCP backlog
+  11. troubleshoot  — general connectivity or system issue (guided checklist)
+
+Enter 1–11 or topic name:
+```
+
+**Q2 — Symptom** (after topic selected):
+`Describe the symptom or paste the error output:`
+
+---
+
 ## How to respond
 
 Identify the topic from the input and apply the matching framework:
@@ -58,6 +87,112 @@ Identify the topic from the input and apply the matching framework:
 3. For NLB: note that source IP is preserved — targets must allow the client CIDR directly
 4. Provide the corrected Terraform `aws_security_group_rule` or `azurerm_network_security_rule`
 
+### systemd — Service Management and Journald
+
+1. **Check service status and recent log lines:**
+   ```bash
+   systemctl status <service>
+   journalctl -u <service> -n 100 --no-pager
+   journalctl -u <service> --since "10 minutes ago"
+   ```
+2. **For a failed unit, inspect the exact error:**
+   ```bash
+   systemctl show <service> --property=Result,ExecStart,FailureAction
+   journalctl -u <service> -p err -b  # errors since last boot
+   ```
+3. **Override a system unit without editing the package file:**
+   ```bash
+   systemctl edit <service>           # creates /etc/systemd/system/<service>.d/override.conf
+   # Add [Service] + the changed key — systemd merges it
+   systemctl daemon-reload && systemctl restart <service>
+   ```
+4. **Common fixes:**
+
+   | Symptom | Cause | Fix |
+   |---------|-------|-----|
+   | `failed (Result: exit-code)` | Process exited non-zero | Check `ExecStart`, test command manually |
+   | `failed (Result: timeout)` | `TimeoutStartSec` exceeded | Increase timeout in override or fix slow start |
+   | `Activating (auto-restart)` | CrashLoop with `Restart=always` | Check exit code; add `StartLimitBurst` and `StartLimitIntervalSec` |
+   | Unit not found | Wrong name or not installed | `systemctl list-units --all | grep <name>` |
+   | Changes not applied | `daemon-reload` not run | Always run `systemctl daemon-reload` after editing unit files |
+
+5. **Validate a unit file before deploying:**
+   ```bash
+   systemd-analyze verify /etc/systemd/system/<service>.service
+   ```
+
+### cgroups — Container Resource Isolation and OOMKill Diagnosis
+
+1. **Identify OOMKilled containers:**
+   ```bash
+   kubectl get pods -A | grep OOMKilled
+   kubectl describe pod <name> -n <namespace> | grep -A5 "OOMKilled\|Last State\|Reason"
+   ```
+2. **Find the actual memory usage vs limit:**
+   ```bash
+   kubectl top pod <name> -n <namespace> --containers
+   kubectl get pod <name> -n <namespace> -o jsonpath='{.spec.containers[*].resources}'
+   ```
+3. **Read cgroup memory stats directly on the node (cgroupv2):**
+   ```bash
+   # Find the container cgroup path
+   docker inspect <container-id> | jq '.[].HostConfig.CgroupParent'
+   # Or via containerd:
+   crictl inspect <container-id> | jq '.info.runtimeSpec.linux.cgroupsPath'
+
+   # Read memory stats
+   cat /sys/fs/cgroup/<path>/memory.current        # current usage in bytes
+   cat /sys/fs/cgroup/<path>/memory.max            # limit (or "max" = unlimited)
+   cat /sys/fs/cgroup/<path>/memory.events         # oom_kill count
+   ```
+4. **Confirm cgroupv2 is active:**
+   ```bash
+   stat -f /sys/fs/cgroup  # type 0x63677270 = cgroupv2 (cgroup2fs)
+   ```
+5. **Fix**: increase memory limit in the pod spec; if memory usage is genuinely unbounded, profile the application. Never remove the limit — set `resources.limits.memory` always.
+6. **CPU throttling** (distinct from OOMKill):
+   ```bash
+   # CPU throttled periods as a % of total
+   cat /sys/fs/cgroup/<path>/cpu.stat | grep throttled
+   ```
+   If throttle rate > 25%, either remove the CPU limit (preferred) or increase it. CPU limits cause throttling even when other cores are idle.
+
+### kernel — Kernel Tuning for Container Hosts
+
+Always apply via `/etc/sysctl.d/99-platform.conf` and persist with `sysctl --system`. Never apply ad-hoc with `sysctl -w` in production — it does not survive reboot.
+
+**Connection handling (high-traffic nodes):**
+```ini
+# /etc/sysctl.d/99-platform.conf
+net.core.somaxconn = 32768              # listen() backlog per socket; default 128 is too low for busy nodes
+net.ipv4.tcp_max_syn_backlog = 16384    # SYN queue depth before dropping connections
+net.ipv4.ip_local_port_range = 1024 65535  # ephemeral port range for outbound connections
+net.ipv4.tcp_tw_reuse = 1              # reuse TIME_WAIT sockets for new connections
+```
+
+**File descriptors (pods with many connections):**
+```ini
+fs.file-max = 2097152        # system-wide fd limit
+fs.inotify.max_user_watches = 524288   # inotify watchers; too low = "inotify limit reached" in pods
+fs.inotify.max_user_instances = 512
+```
+
+**Memory and OOM behaviour:**
+```ini
+vm.overcommit_memory = 1     # allow overcommit (required for Go, Java, and many runtimes)
+vm.panic_on_oom = 0          # do not panic on OOM — let the OOM killer select a process
+vm.oom_kill_allocating_task = 1  # kill the task that triggered OOM rather than a random process
+```
+
+**Validate after applying:**
+```bash
+sysctl --system                                 # apply all /etc/sysctl.d/ files
+sysctl net.core.somaxconn                       # confirm value
+ss -s                                           # confirm socket state distribution
+```
+
+**Node-level tuning vs pod-level:** sysctl values in `/etc/sysctl.d/` affect the entire node. Pod-level overrides for safe sysctls (e.g. `net.ipv4.tcp_tw_reuse`) require `securityContext.sysctls` — only allowed if the cluster admin permits unsafe sysctls.
+
 ### troubleshoot — General Connectivity or System Troubleshoot
 Apply the structured checklist from `references/linux-networking.md`:
 1. Symptom classification: DNS? L4? L7? Load balancer? Resource exhaustion?
@@ -74,3 +209,14 @@ If the input does not match a topic, infer the closest match and state which fra
 Always end with:
 - **Validation command** — the exact command that confirms the fix worked
 - **Rollback** — how to safely undo the change if the fix makes things worse
+
+---
+
+## Common mistakes
+
+- **Editing package-owned unit files directly** — use `systemctl edit <service>` (override.conf) so package updates don't overwrite changes
+- **Forgetting `daemon-reload`** — systemd does not pick up unit file changes until `systemctl daemon-reload` is run
+- **Setting CPU limits on containers** — CPU limits cause throttling even when cores are idle; omit `resources.limits.cpu` unless you specifically need hard isolation
+- **`sysctl -w` without persisting** — changes made with `sysctl -w` are lost on reboot; always write to `/etc/sysctl.d/`
+- **Checking space but not inodes** — `df -h` shows space free but `df -i` may show inodes exhausted; both must be checked
+- **Diagnosing OOMKill without checking CPU throttle** — throttled containers appear healthy but respond slowly; check `cpu.stat` alongside `memory.events`

--- a/commands/mcp.md
+++ b/commands/mcp.md
@@ -62,3 +62,180 @@ node -e "require('./dist/index.js')" 2>&1
 ```
 
 Provide: observed symptom → likely root cause → evidence command → fix → validation step
+
+## Mode: configure-aws
+
+Generate version-pinned, credential_process-backed MCP server configs for AWS services, with upfront cost warnings and CLI-first alternatives.
+
+```
+/platform-skills:mcp configure-aws [service|kit] [--profile <profile>] [--region <region>] [--host vscode|claude|both] [--scope global|workspace] [--multi-account]
+```
+
+**Examples:**
+```
+/platform-skills:mcp configure-aws eks-debug --profile prod-platform-eu --region eu-west-1 --host both
+/platform-skills:mcp configure-aws eks --profile dev-sandbox --host vscode --scope workspace
+/platform-skills:mcp configure-aws knowledge --host claude
+/platform-skills:mcp configure-aws eks --profile prod-eu --region eu-west-1 --multi-account
+```
+
+### Step 1: Cost Warning
+
+Before generating any config, show tool count and token cost. If total exceeds 5,000 tokens, flag it:
+
+```
+Servers requested: eks-mcp-server + cloudwatch-mcp-server
+
+  awslabs.eks-mcp-server           ~40 tools   ~2,000 tokens
+  awslabs.cloudwatch-mcp-server    ~35 tools   ~1,750 tokens
+  ──────────────────────────────────────────────────────────
+  Total                            ~75 tools   ~3,750 tokens
+
+✓ Within recommended budget (<5,000 tokens). Continue? [y/N]
+```
+
+If over 5,000 tokens:
+```
+⚠ Over budget — ~8,500 tokens will be consumed by tool definitions before any conversation.
+  This will noticeably compress available context for reasoning.
+  Recommended: split into separate sessions, one kit per task.
+  Continue anyway? [y/N]
+```
+
+### Step 2: CLI-First Check
+
+For simple single-service requests, show the CLI alternative before generating MCP config:
+
+```
+💡 For common EKS queries, the AWS CLI costs zero context:
+
+  aws eks list-clusters --profile prod-platform-eu --region eu-west-1
+  aws eks describe-cluster --name my-cluster --profile prod-platform-eu --region eu-west-1
+  aws eks list-nodegroups --cluster-name my-cluster --profile prod-platform-eu
+
+MCP adds value when the AI needs to chain calls — e.g., list clusters → describe all nodegroups →
+correlate with CloudWatch alarms → identify degraded nodes → suggest remediation.
+
+Is that the task you need? [y to continue with MCP / n to use CLI]
+```
+
+### Step 3: credential_process Check
+
+Before generating the config, check whether the target profile in `~/.aws/config` has `credential_process` configured:
+
+- **Has credential_process** → generate config with `AWS_PROFILE` env var (credential_process handles refresh)
+- **No credential_process** → warn and emit both the MCP config AND the recommended `~/.aws/config` stanza:
+
+```
+⚠ Profile 'prod-platform-eu' does not have credential_process configured.
+  MCP servers using this profile will fail silently when the SSO token expires (TTL: ~8h).
+
+  Add this to ~/.aws/config for automatic credential refresh:
+
+  [profile prod-platform-eu]
+  # ... existing fields ...
+  credential_process = granted credential-process --profile prod-platform-eu
+
+  See: references/aws-mcp-profiles.md → credential_process Pattern
+```
+
+### Step 4: Config Generation
+
+Emit ready-to-paste JSON for the target host(s). Always version-pin. Always set both `AWS_PROFILE` and `AWS_REGION`. Always include an `_account` comment.
+
+**VS Code (`.vscode/mcp.json`):**
+```json
+{
+  "mcpServers": {
+    "eks-prod-eu": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==VERSION", "--region", "eu-west-1"],
+      "env": {
+        "AWS_PROFILE": "prod-platform-eu",
+        "AWS_REGION": "eu-west-1"
+      },
+      "_account": "Account: 123456789 | Env: prod | Permission: PowerUser"
+    },
+    "cloudwatch-prod-eu": {
+      "command": "uvx",
+      "args": ["awslabs.cloudwatch-mcp-server==VERSION"],
+      "env": {
+        "AWS_PROFILE": "prod-platform-eu",
+        "AWS_REGION": "eu-west-1"
+      },
+      "_account": "Account: 123456789 | Env: prod | Permission: PowerUser"
+    }
+  }
+}
+```
+
+**Claude Code (`~/.claude/settings.json` → `mcpServers`):**
+```json
+{
+  "eks-prod-eu": {
+    "command": "uvx",
+    "args": ["awslabs.eks-mcp-server==VERSION", "--region", "eu-west-1"],
+    "env": {
+      "AWS_PROFILE": "prod-platform-eu",
+      "AWS_REGION": "eu-west-1"
+    }
+  }
+}
+```
+
+Replace `VERSION` with the current version from PyPI:
+```bash
+pip index versions awslabs.eks-mcp-server 2>/dev/null | head -1
+```
+
+### Multi-Account Mode (`--multi-account`)
+
+When `--multi-account` is passed for the `eks` service, generate distinct named instances for each prod-tagged profile in `~/.aws-profile-tags.yaml`:
+
+```json
+{
+  "mcpServers": {
+    "eks-prod-eu": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==VERSION", "--region", "eu-west-1"],
+      "env": { "AWS_PROFILE": "prod-platform-eu", "AWS_REGION": "eu-west-1" },
+      "_account": "123456789 | prod-eu"
+    },
+    "eks-prod-us": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==VERSION", "--region", "us-east-1"],
+      "env": { "AWS_PROFILE": "prod-platform-us", "AWS_REGION": "us-east-1" },
+      "_account": "234567890 | prod-us"
+    }
+  }
+}
+```
+
+Show updated token cost after generating multi-instance config.
+
+### AWS MCP Server Catalog
+
+| Kit / Service | Package | ~Tokens | Use case |
+|--------------|---------|---------|---------|
+| `eks` | `awslabs.eks-mcp-server` | ~2,000 | Cluster ops, nodegroups |
+| `cloudwatch` | `awslabs.cloudwatch-mcp-server` | ~1,750 | Logs, metrics, alarms |
+| `prometheus` | `awslabs.prometheus-mcp-server` | ~1,000 | AMP metrics, rule groups |
+| `iam` | `awslabs.iam-mcp-server` | ~1,500 | IAM queries (read-only) |
+| `bedrock-kb` | `awslabs.bedrock-kb-retrieval-mcp-server` | ~750 | KB retrieve + generate |
+| `docs` | `awslabs.aws-documentation-mcp-server` | ~500 | Real-time AWS docs |
+| `api` | `awslabs.aws-api-mcp-server` | ~2,500 | All AWS services (catch-all) |
+| `billing` | `awslabs.billing-cost-management-mcp-server` | ~1,000 | Cost Explorer, budgets |
+| `serverless` | `awslabs.aws-serverless-mcp-server` | ~1,250 | SAM, Lambda lifecycle |
+| `dynamodb` | `awslabs.dynamodb-mcp-server` | ~1,250 | Table ops, queries |
+
+**Starter kits** (pass kit name instead of service):
+
+| Kit | Servers | ~Tokens |
+|-----|---------|---------|
+| `eks-debug` | eks + cloudwatch | ~3,750 |
+| `observe` | cloudwatch + prometheus | ~2,750 |
+| `knowledge` | docs + bedrock-kb | ~1,250 |
+| `deploy` | api + serverless | ~3,750 |
+| `cost` | billing | ~1,000 |
+
+Reference: `references/aws-mcp-profiles.md`

--- a/commands/mcp.md
+++ b/commands/mcp.md
@@ -79,6 +79,106 @@ Generate version-pinned, credential_process-backed MCP server configs for AWS se
 /platform-skills:mcp configure-aws eks --profile prod-eu --region eu-west-1 --multi-account
 ```
 
+### Step 0: Gather Inputs (interactive — fires when any required value is missing)
+
+When the user invokes `configure-aws` without arguments, or omits any required value, prompt for each missing piece **one question at a time** before proceeding.
+
+**Question 1 — Service or kit** (skip if already provided as positional arg):
+```
+Which AWS service or starter kit do you need?
+
+Services:
+  eks         EKS cluster ops, nodegroups           (~2,000 tokens)
+  cloudwatch  Logs, metrics, alarms                 (~1,750 tokens)
+  prometheus  AMP metrics, rule groups              (~1,000 tokens)
+  iam         IAM queries, read-only                (~1,500 tokens)
+  bedrock-kb  Knowledge base retrieve + generate    (~750 tokens)
+  docs        Real-time AWS documentation           (~500 tokens)
+  api         All AWS services, catch-all           (~2,500 tokens)
+  billing     Cost Explorer, budgets                (~1,000 tokens)
+  serverless  SAM, Lambda lifecycle                 (~1,250 tokens)
+  dynamodb    Table ops, queries                    (~1,250 tokens)
+
+Starter kits (pre-bundled):
+  eks-debug   eks + cloudwatch                      (~3,750 tokens)
+  observe     cloudwatch + prometheus               (~2,750 tokens)
+  knowledge   docs + bedrock-kb                     (~1,250 tokens)
+  deploy      api + serverless                      (~3,750 tokens)
+  cost        billing                               (~1,000 tokens)
+
+Enter service or kit name:
+```
+
+**Question 2 — Host** (skip if `--host` provided):
+```
+Which tool are you configuring for?
+  1. VS Code
+  2. Claude Code
+  3. Both
+
+Enter 1, 2, or 3:
+```
+
+**Question 3 — AWS profile** (skip if `--profile` provided):
+
+Read `~/.aws/config`, list available profiles with type and environment tag (from `~/.aws-profile-tags.yaml` if present):
+```
+Which AWS profile should MCP servers use?
+
+Available profiles (from ~/.aws/config):
+  prod-platform-eu   SSO          [prod]     123456789
+  staging-assume     assumed-role [staging]  456789123
+  dev-sandbox        SSO          [dev]      987654321
+
+Enter profile name (or press enter for no profile — uses ambient credentials):
+```
+
+If `~/.aws/config` is not readable or has no profiles, show: `Could not read ~/.aws/config. Enter profile name manually (or press enter to skip):`
+
+**Question 4 — Region** (skip if `--region` provided):
+
+Detect the profile's `region` field from `~/.aws/config` and offer it as the default:
+```
+AWS region? [detected from profile 'prod-platform-eu': eu-west-1]
+Press enter to accept or type a different region:
+```
+
+If no region is detected in the profile: `AWS region? (e.g. us-east-1):`
+
+**Question 5 — Scope** (VS Code only; skip if `--scope` provided):
+```
+VS Code config scope?
+  1. Workspace — .vscode/mcp.json (this project only)
+  2. Global    — applies to all VS Code windows
+
+Enter 1 or 2:
+```
+
+**Question 6 — Multi-account** (`eks` service only; skip if `--multi-account` provided or service is not eks):
+```
+Generate named instances for all prod-tagged profiles? (multi-account mode)
+  This creates eks-prod-eu, eks-prod-us, etc. from ~/.aws-profile-tags.yaml.
+  Requires ~/.aws-profile-tags.yaml with env: prod entries.
+
+[y/N]:
+```
+
+After collecting all answers, confirm before proceeding:
+```
+Summary:
+  Service/kit : eks-debug (eks + cloudwatch)
+  Host        : both (VS Code + Claude Code)
+  Profile     : prod-platform-eu
+  Region      : eu-west-1
+  VS Code scope: workspace
+
+Proceeding with cost check...
+```
+
+Then continue with Steps 1–4 below using the collected values.
+
+---
+
 ### Step 1: Cost Warning
 
 Before generating any config, show tool count and token cost. If total exceeds 5,000 tokens, flag it:

--- a/commands/mcp.md
+++ b/commands/mcp.md
@@ -178,7 +178,8 @@ Emit ready-to-paste JSON for the target host(s). Always version-pin. Always set 
     "env": {
       "AWS_PROFILE": "prod-platform-eu",
       "AWS_REGION": "eu-west-1"
-    }
+    },
+    "_account": "Account: 123456789 | Env: prod | Permission: PowerUser"
   }
 }
 ```

--- a/commands/observability.md
+++ b/commands/observability.md
@@ -6,6 +6,35 @@ argument-hint: "[instrument|dashboard|alert|loadtest|capacity] [service descript
 
 Set up or improve observability for a service or platform component.
 
+---
+
+## Interactive Wizard (fires when no arguments are provided)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Mode?**
+```
+What do you need?
+  1. instrument — add structured logs, Prometheus metrics, and OTel tracing to a service
+  2. dashboard  — create a Grafana RED/USE dashboard for a service
+  3. alert      — write Prometheus alerting rules for a service
+  4. slo        — define SLIs, error budgets, and SLO burn-rate alerts
+  5. loadtest   — write and run a k6 load test
+  6. capacity   — estimate resource requirements and HPA configuration
+
+Enter 1–6 or mode name:
+```
+
+**Q2 — Context** (after mode selected):
+- **instrument**: `What language/framework and which metrics/tracing backend (Prometheus, Datadog, Jaeger, Tempo)?`
+- **dashboard**: `Service name and which signal to lead with — request-based (RED) or resource-based (USE)?`
+- **alert**: `Service name and what SLIs matter most — error rate, latency, availability?`
+- **slo**: `Service name, expected availability target (e.g. 99.9%), and current p95 latency baseline:`
+- **loadtest**: `Target endpoint, expected peak RPS, and SLO thresholds (p95 latency, max error rate):`
+- **capacity**: `Expected peak RPS, measured p99 latency at current load, and memory per pod:`
+
+---
+
 ## Mode: instrument
 
 Add the three pillars — logs, metrics, traces — to a service.
@@ -21,6 +50,8 @@ Steps:
 
 Reference: `references/observability.md` → Structured Logging, Prometheus Metrics, OpenTelemetry Tracing
 
+→ **Next:** Run `/platform-skills:observability alert` to write alerting rules for the metrics just added, then `/platform-skills:observability slo` to wrap them in an error budget.
+
 ## Mode: dashboard
 
 Create a Grafana dashboard for a service.
@@ -33,6 +64,8 @@ Steps:
 5. Configure template variables for environment and service filtering
 
 Reference: `references/observability.md` → Grafana Dashboards
+
+→ **Next:** Run `/platform-skills:observability slo` to add SLO burn-rate alerts and an error budget panel to this dashboard.
 
 ## Mode: alert
 
@@ -51,6 +84,8 @@ Alert design rules:
 - Derive SLO burn-rate alerts from error budget, not raw thresholds
 
 Reference: `references/observability.md` → Alerting Rules
+
+→ **Next:** Run `/platform-skills:observability slo` to promote these symptom alerts to proper SLO burn-rate alerts backed by an error budget.
 
 ## Mode: loadtest
 
@@ -79,3 +114,86 @@ Steps:
 6. Define min/max replica bounds
 
 Reference: `references/observability.md` → Capacity Planning
+
+→ **Next:** After sizing, run `/platform-skills:observability loadtest` to validate the HPA triggers correctly under synthetic load.
+
+---
+
+## Mode: slo
+
+Define SLIs, set error budgets, and generate SLO burn-rate alerts from first principles.
+
+Steps:
+1. **Define SLIs** — identify what "good" looks like for this service:
+   - Availability: `sum(rate(http_requests_total{status!~"5.."}[5m])) / sum(rate(http_requests_total[5m]))`
+   - Latency: `histogram_quantile(0.95, rate(http_request_duration_seconds_bucket[5m])) < 0.3`
+   - Choose one primary SLI per service; add a secondary only if the first doesn't capture the user journey
+
+2. **Set the SLO target** — start conservative, tighten over time:
+   ```
+   SLO:           99.9% availability over a 30-day rolling window
+   Error budget:  0.1% = 43.2 minutes per 30 days
+   ```
+
+3. **Generate burn-rate alerts** — multiwindow, multi-burn-rate (Google SRE Book approach):
+   ```yaml
+   # Fast burn — consumes 5% of monthly budget in 1h → page immediately
+   - alert: SLOFastBurn
+     expr: |
+       (
+         rate(http_requests_total{status=~"5.."}[1h])
+         / rate(http_requests_total[1h])
+       ) > (14.4 * 0.001)   # 14.4× burn rate exhausts budget in ~2 days
+     for: 2m
+     labels:
+       severity: critical
+     annotations:
+       summary: "Fast error budget burn on {{ $labels.service }}"
+       runbook: "https://runbooks.internal/slo-fast-burn"
+
+   # Slow burn — consumes 10% of monthly budget in 6h → ticket
+   - alert: SLOSlowBurn
+     expr: |
+       (
+         rate(http_requests_total{status=~"5.."}[6h])
+         / rate(http_requests_total[6h])
+       ) > (6 * 0.001)      # 6× burn rate exhausts budget in ~5 days
+     for: 15m
+     labels:
+       severity: warning
+     annotations:
+       summary: "Slow error budget burn on {{ $labels.service }}"
+       runbook: "https://runbooks.internal/slo-slow-burn"
+   ```
+
+4. **Track remaining error budget** — add to the Grafana dashboard:
+   ```promql
+   # Error budget remaining (%) over 30d
+   1 - (
+     sum(increase(http_requests_total{status=~"5.."}[30d]))
+     / sum(increase(http_requests_total[30d]))
+   ) / 0.001   # divide by error budget fraction (1 - SLO target)
+   ```
+
+5. **Error budget policy** — state in writing what happens when the budget is depleted:
+   - >50% remaining → normal feature velocity
+   - 10–50% remaining → reliability improvements prioritised alongside features
+   - <10% remaining → feature freeze; only reliability work until budget recovers
+
+Key rules:
+- Alert on burn rate, not on raw error count — burn rate is predictive
+- The `for:` on fast burn should be short (1–2m); slow burn needs longer (10–15m)
+- Latency SLOs need histogram buckets aligned to the SLO threshold at chart creation time — you cannot retroactively add buckets
+
+→ **Next:** Run `/platform-skills:observability alert` to add symptom-based alerts alongside SLO burn-rate alerts.
+
+---
+
+## Common mistakes
+
+- **Alerting on CPU% or memory%** — these are causes, not symptoms. Alert on error rate and latency; let CPU/memory be dashboard panels only
+- **Missing `for:` duration** — without it, a single bad scrape triggers a page. Minimum 1m for slow alerts, 2m for fast SLO burn
+- **Not defining SLOs before writing alerts** — without an SLO, you don't know what threshold to alert at. Define the SLO first (`slo` mode), then write alerts
+- **Histogram bucket boundaries misaligned with SLO** — if your SLO is p95 < 300ms and you have no bucket at 0.3s, `histogram_quantile` interpolates inaccurately. Set `le` values at 0.1, 0.25, 0.3, 0.5, 1.0, 2.5
+- **Labelling with high-cardinality dimensions** — never use `user_id`, `session_id`, or `request_id` as Prometheus label values. Cardinality explodes memory usage
+- **Alert fatigue from symptom + cause alerts** — if you alert on both "error rate high" and "database connection pool exhausted", both fire simultaneously for the same incident. Alert on the symptom; include cause investigation in the runbook

--- a/commands/observability.md
+++ b/commands/observability.md
@@ -1,7 +1,7 @@
 ---
 name: observability
 description: Instrument services with structured logging, Prometheus metrics, and OpenTelemetry tracing. Build Grafana dashboards, write Prometheus alerting rules, run k6 load tests, and plan infrastructure capacity.
-argument-hint: "[instrument|dashboard|alert|loadtest|capacity] [service description]"
+argument-hint: "[instrument|dashboard|alert|slo|loadtest|capacity] [service description]"
 ---
 
 Set up or improve observability for a service or platform component.

--- a/commands/opa.md
+++ b/commands/opa.md
@@ -6,6 +6,35 @@ argument-hint: "[generate|test|validate|explain|debug] [policy description or fi
 
 Write, test, validate, explain, and debug OPA Rego policies with Conftest.
 
+---
+
+## Interactive Wizard (fires when no arguments are provided)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Mode?**
+```
+What do you need?
+  1. generate — write a new production-ready Rego policy
+  2. test     — write _test.rego unit tests for an existing policy
+  3. validate — run the full pipeline (fmt, lint, tests) against a directory
+  4. explain  — translate an existing Rego policy into plain English
+  5. debug    — diagnose why a policy is not firing as expected
+
+Enter 1–5 or mode name:
+```
+
+**Q2 — Context** (after mode selected, one at a time):
+- **generate**: `Describe the policy — target resource type (Terraform/Kubernetes/GHA/Dockerfile) and what to deny or warn on:`
+- **test**: `Paste the Rego policy to write tests for:`
+- **validate**: `Provide the directory path containing your .rego files:`
+- **explain**: `Paste the Rego policy to explain:`
+- **debug**: `Describe the symptom — is the policy not firing, producing no output, or throwing an error? Paste the conftest output:`
+
+Then proceed into the relevant mode below.
+
+---
+
 ## Mode: generate
 
 Write a production-ready Rego policy from a description.

--- a/commands/product.md
+++ b/commands/product.md
@@ -10,6 +10,39 @@ You are acting as a senior platform engineer with a product mindset. The user ha
 
 Read `references/platform-mindset.md` before responding.
 
+---
+
+## Interactive Wizard (fires when $ARGUMENTS is empty)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Topic?**
+```
+What do you need?
+  1. devex      — Developer Experience audit and SPACE analysis
+  2. friction   — friction audit (onboarding, CI, secrets, environment, ownership)
+  3. rfc        — draft a full RFC document
+  4. adr        — draft an Architecture Decision Record
+  5. incident   — write a structured incident status update
+  6. postmortem — write a blameless post-mortem
+  7. capacity   — capacity planning for a service or platform
+  8. cost       — cost optimisation analysis
+  9. review     — platform health review
+
+Enter 1–9 or topic name:
+```
+
+**Q2 — Context** (after topic selected):
+- **devex / friction**: `Describe the friction point or what developers are complaining about:`
+- **rfc**: `What problem needs to be solved and why now? (1-2 sentences):`
+- **adr**: `What decision was made and what forced it?`
+- **incident**: `Severity, affected component, and what is known so far:`
+- **postmortem**: `Paste the incident timeline or describe what happened and when:`
+- **capacity**: `Service name, current baseline RPS/users, and projected growth over the next 6 months:`
+- **cost / review**: no follow-up — proceed directly
+
+---
+
 ## How to respond
 
 Identify the topic from the input and apply the matching framework:
@@ -27,18 +60,99 @@ Identify the topic from the input and apply the matching framework:
 4. Define "done" — what does success look like in measurable terms?
 
 ### rfc — RFC Draft
-Produce a complete RFC using the template:
-- Problem (what is broken, why now)
-- Proposal (concrete change)
-- Alternatives considered
-- Impact (which teams, what migration)
-- Open questions
+
+Produce a complete RFC document using this exact structure. Fill every section — no placeholders:
+
+```markdown
+# RFC-NNNN: <Title>
+
+**Status:** Draft  
+**Author:** <name>  
+**Date:** <YYYY-MM-DD>  
+**Stakeholders:** <teams who must approve or are affected>
+
+---
+
+## Problem
+
+<2–3 paragraphs. What is broken or suboptimal? What is the user-visible impact?
+Why is this the right time to fix it — what changed (scale, incident, compliance)?
+Do not describe the solution here.>
+
+## Proposal
+
+<Concrete description of the change. Be specific: what gets built, changed, or removed.
+Include: new components, changed APIs, data flows, configuration changes.
+A diagram or example config snippet is worth more than paragraphs.>
+
+## Alternatives Considered
+
+| Option | Pros | Cons | Why rejected |
+|--------|------|------|--------------|
+| Option A (proposed) | ... | ... | (not rejected) |
+| Option B | ... | ... | ... |
+| Do nothing | ... | ... | ... |
+
+## Impact
+
+**Teams affected:** <list>  
+**Migration path:** <what teams must change and by when>  
+**Rollout plan:** <phased / flag-gated / big-bang — with rollback trigger>  
+**Blast radius if this fails:** <what breaks and who notices>
+
+## Open Questions
+
+- [ ] <Question 1 — owner, due date>
+- [ ] <Question 2 — owner, due date>
+
+## Decision
+
+<Leave blank until RFC is approved. Record the outcome and who approved.>
+```
+
+→ **Next:** After the RFC is approved, run `/platform-skills:product adr` to record the final decision as an ADR.
 
 ### adr — Architecture Decision Record
-Produce a complete ADR using the template:
-- Context (what forced this decision)
-- Decision (what was decided)
-- Consequences (easier / harder / must monitor)
+
+Produce a complete ADR using this exact structure. ADRs are immutable once accepted — record the state at decision time:
+
+```markdown
+# ADR-NNNN: <Title>
+
+**Date:** <YYYY-MM-DD>  
+**Status:** Accepted  
+**Deciders:** <names or roles>
+
+---
+
+## Context
+
+<What situation forced this decision? Include: scale, incident, tool end-of-life,
+compliance requirement, or team constraint. State facts, not opinions.
+This section must be understandable by someone who wasn't in the room.>
+
+## Decision
+
+<What was decided, stated plainly. Use active voice: "We will use X" not "X was chosen".
+Include: what is being adopted, replaced, or deprecated.>
+
+## Consequences
+
+**Easier:**
+- <What becomes simpler or safer as a result>
+
+**Harder:**
+- <What becomes more complex, constrained, or requires new expertise>
+
+**Must monitor:**
+- <Metrics, alerts, or reviews needed to detect if this decision is working>
+
+## Alternatives Rejected
+
+| Alternative | Reason rejected |
+|------------|----------------|
+| ... | ... |
+```
 
 ### incident — Incident Update
 Produce a structured incident status update:

--- a/commands/review.md
+++ b/commands/review.md
@@ -4,6 +4,31 @@ description: Reviews a Kubernetes manifest, Terraform file, GitHub Actions workf
 argument-hint: "[paste file content or describe what to review] [--bot to emit GitHub-flavoured markdown for PR comments]"
 ---
 
+---
+
+## Interactive Wizard (fires when $ARGUMENTS is empty)
+
+When invoked with no arguments, ask before reviewing:
+
+**Q1 — What should be reviewed?**
+```
+Paste the file content to review, or describe what you want reviewed
+(e.g. "my EKS Terraform module", "this GitHub Actions workflow", "Helm values file"):
+```
+
+**Q2 — Output mode?** (ask after Q1)
+```
+Output format:
+  1. Standard   — narrative findings, for human review
+  2. Bot / PR   — GitHub-flavoured markdown comment (use with --bot flag or in CI)
+
+Enter 1 or 2 [default: 1]:
+```
+
+Then proceed with the review framework below using the provided content.
+
+---
+
 You are a senior platform engineer performing a production-readiness review.
 
 Review the following: $ARGUMENTS

--- a/commands/runtime-security.md
+++ b/commands/runtime-security.md
@@ -6,6 +6,35 @@ argument-hint: "[install|rules|alerts|debug|harden] [description or symptom]"
 
 Detect and respond to threats inside running containers using Falco.
 
+---
+
+## Interactive Wizard (fires when no arguments are provided)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Mode?**
+```
+What do you need?
+  1. install  — deploy Falco on Kubernetes (EKS or GKE) with eBPF driver
+  2. rules    — write and test a custom Falco rule
+  3. alerts   — configure Falcosidekick to route alerts (Slack, webhook, etc.)
+  4. debug    — diagnose why a Falco rule is not firing
+  5. harden   — map runtime Falco alerts to Kyverno admission policies
+
+Enter 1–5 or mode name:
+```
+
+**Q2 — Context** (after mode selected, one at a time):
+- **install**: `Which cloud platform? EKS / GKE / other (specify node OS if known):`
+- **rules**: `Describe the behaviour to detect (e.g. "shell spawned in a container", "unexpected outbound connection"):`
+- **alerts**: `Which output destination? Slack / webhook / PagerDuty / other:`
+- **debug**: `Describe the symptom — which rule is not firing, and what event should trigger it?`
+- **harden**: `Which Falco alert or rule output should block re-admission? (paste the alert or rule name):`
+
+Then proceed into the relevant mode below.
+
+---
+
 ## Mode: install
 
 Deploy Falco on Kubernetes (EKS or GKE) using the eBPF driver via Helm.

--- a/commands/supply-chain.md
+++ b/commands/supply-chain.md
@@ -6,6 +6,37 @@ argument-hint: "[audit|sign|sbom|scan|enforce|slsa] [description or file path]"
 
 Secure the software supply chain — from the build pipeline to running containers.
 
+---
+
+## Interactive Wizard (fires when no arguments are provided)
+
+When invoked with no arguments, ask before proceeding:
+
+**Q1 — Mode?**
+```
+What do you need?
+  1. audit    — review an existing CI/CD pipeline for supply chain security gaps
+  2. sign     — set up keyless image signing with Cosign (Sigstore/Rekor, no key management)
+  3. sbom     — generate and attest an SBOM with Syft
+  4. scan     — add a CVE vulnerability gate with Trivy or Grype
+  5. enforce  — write a Kyverno policy to block unsigned images at admission
+  6. slsa     — generate a SLSA Level 2 provenance workflow
+
+Enter 1–6 or mode name:
+```
+
+**Q2 — Context** (after mode selected, one at a time):
+- **audit**: `Paste your GitHub Actions workflow file(s) or describe your current CI/CD pipeline:`
+- **sign**: `Which container registry? (ECR / GHCR / Docker Hub / other):`
+- **sbom**: `Which image and registry? (e.g. ghcr.io/org/image):`
+- **scan**: `Which scanner preference? Trivy (recommended) or Grype — or no preference:`
+- **enforce**: `Which registry or image prefix should the policy cover? (e.g. ghcr.io/myorg/*):`
+- **slsa**: `Which registry and repo? (e.g. ghcr.io/org/image from github.com/org/repo):`
+
+Then proceed into the relevant mode below.
+
+---
+
 ## Mode: audit
 
 Review an existing CI/CD pipeline and cluster admission configuration for supply chain security gaps.

--- a/commands/terraform.md
+++ b/commands/terraform.md
@@ -4,6 +4,33 @@ description: Runs through the full Terraform validation pipeline — fmt, valida
 argument-hint: "[paste terraform code, plan output, or describe the change]"
 ---
 
+---
+
+## Interactive Wizard (fires when $ARGUMENTS is empty)
+
+When invoked with no arguments, ask before reviewing:
+
+**Q1 — What to review?**
+```
+Paste the Terraform code or plan output, or describe the change
+(e.g. "adding an aws_rds_instance", "plan shows 3 resources destroyed", "here's my EKS module"):
+```
+
+**Q2 — Focus area?** (ask after Q1)
+```
+Any specific focus, or full review?
+  1. Full review     — validation pipeline + blast radius + IAM + state impact
+  2. IAM / security  — least privilege, wildcard actions, sensitive vars
+  3. Blast radius    — what gets replaced vs updated, downstream impact
+  4. Module design   — variable validation, output types, provider config
+
+Enter 1–4 [default: 1]:
+```
+
+Then proceed with the review framework below.
+
+---
+
 You are a senior platform engineer reviewing Terraform.
 
 The input is: $ARGUMENTS

--- a/examples/chaos/chaos-validate.sh
+++ b/examples/chaos/chaos-validate.sh
@@ -13,13 +13,17 @@ EXAMPLE_DIR="examples/chaos"
 echo ""
 echo "=== Chaos Engineering Examples: YAML syntax ==="
 
-for f in "$EXAMPLE_DIR"/*.yaml; do
-  if yq eval 'true' "$f" > /dev/null 2>&1; then
-    pass "$f is valid YAML"
-  else
-    fail "$f has invalid YAML"
-  fi
-done
+if ! command -v yq &> /dev/null; then
+  echo "  INFO: yq not found — skipping YAML lint (install: https://github.com/mikefarah/yq)"
+else
+  for f in "$EXAMPLE_DIR"/*.yaml; do
+    if yq eval 'true' "$f" > /dev/null 2>&1; then
+      pass "$f is valid YAML"
+    else
+      fail "$f has invalid YAML"
+    fi
+  done
+fi
 
 echo ""
 if [ "$ERRORS" -gt 0 ]; then

--- a/examples/mcp/aws-multiprofile/.gitignore.snippet
+++ b/examples/mcp/aws-multiprofile/.gitignore.snippet
@@ -1,0 +1,4 @@
+# AWS MCP configs — contain real profile names and account structure
+# Commit the template, not the real config
+.vscode/mcp.json
+!.vscode/mcp.json.template

--- a/examples/mcp/aws-multiprofile/README.md
+++ b/examples/mcp/aws-multiprofile/README.md
@@ -1,0 +1,51 @@
+# AWS Multi-Profile MCP Examples
+
+**Status:** Stable
+
+Working examples for managing AWS MCP servers across multiple accounts in VS Code and Claude Code.
+
+## Files
+
+| File | What it shows |
+|------|--------------|
+| `vscode-global-mcp.json` | `~/.vscode/mcp.json` — 1 always-on docs server, zero account risk |
+| `vscode-workspace-mcp.json` | `.vscode/mcp.json` — eks-debug kit, hardcoded profile |
+| `vscode-workspace-input-mcp.json` | `.vscode/mcp.json` — interactive profile picker via VS Code inputs |
+| `vscode-mcp.json.template` | Commit this to git — placeholders, not real profile names |
+| `claude-settings-snippet.json` | Paste into `~/.claude/settings.json` under `mcpServers` |
+| `aws-config-credential-process.ini` | Add to `~/.aws/config` — structural fix for stale credentials |
+| `.gitignore.snippet` | Add to your `.gitignore` |
+| `starter-kits/eks-debug.json` | eks + cloudwatch, version-pinned |
+| `starter-kits/observe.json` | cloudwatch + prometheus |
+| `starter-kits/knowledge.json` | docs + bedrock-kb |
+| `starter-kits/deploy.json` | aws-api + serverless |
+| `starter-kits/cost.json` | billing (cost-management) |
+
+## Quickstart
+
+```bash
+# 1. Discover your profiles
+/platform-skills:aws-profile discover
+
+# 2. Pick a starter kit and generate config
+/platform-skills:mcp configure-aws eks-debug --profile dev-sandbox --region eu-west-1 --host both
+
+# 3. Check credentials are healthy
+/platform-skills:aws-profile status
+
+# 4. When switching accounts
+/platform-skills:aws-profile switch prod-platform-eu --scope workspace --confirm
+```
+
+## Team Onboarding
+
+```bash
+# Commit the template (not the real config)
+git add .vscode/mcp.json.template
+echo ".vscode/mcp.json" >> .gitignore
+echo "!.vscode/mcp.json.template" >> .gitignore
+
+# New engineer hydrates locally
+AWS_PROFILE=dev-sandbox AWS_REGION=eu-west-1 \
+  envsubst < .vscode/mcp.json.template > .vscode/mcp.json
+```

--- a/examples/mcp/aws-multiprofile/aws-config-credential-process.ini
+++ b/examples/mcp/aws-multiprofile/aws-config-credential-process.ini
@@ -1,0 +1,22 @@
+# Add these stanzas to ~/.aws/config to enable credential_process.
+# The AWS SDK calls this binary on every API call — no cached token goes stale.
+
+# Option A: Granted (recommended for Granted users)
+[profile prod-platform-eu]
+sso_start_url = https://REPLACE_WITH_YOUR_ORG.awsapps.com/start
+sso_region = eu-west-1
+sso_account_id = REPLACE_WITH_ACCOUNT_ID
+sso_role_name = PowerUser
+region = eu-west-1
+credential_process = granted credential-process --profile prod-platform-eu
+
+# Option B: aws-vault
+[profile prod-platform-eu]
+credential_process = aws-vault export --format=json prod-platform-eu
+
+# Assumed role — credential_process handles the full chain
+[profile staging-assume]
+role_arn = arn:aws:iam::REPLACE_WITH_ACCOUNT_ID:role/PlatformEngineer
+source_profile = dev-sso
+region = eu-west-1
+credential_process = aws-vault export --format=json staging-assume

--- a/examples/mcp/aws-multiprofile/aws-config-credential-process.ini
+++ b/examples/mcp/aws-multiprofile/aws-config-credential-process.ini
@@ -1,5 +1,5 @@
 # Add these stanzas to ~/.aws/config to enable credential_process.
-# The AWS SDK calls this binary on every API call — no cached token goes stale.
+# The AWS SDK invokes this binary when credentials are needed or have expired — returned creds are cached in-memory until refresh.
 
 # Option A: Granted (recommended for Granted users)
 [profile prod-platform-eu]
@@ -10,9 +10,9 @@ sso_role_name = PowerUser
 region = eu-west-1
 credential_process = granted credential-process --profile prod-platform-eu
 
-# Option B: aws-vault
-[profile prod-platform-eu]
-credential_process = aws-vault export --format=json prod-platform-eu
+# Option B: aws-vault (use a distinct profile name to avoid conflicting with Option A)
+[profile prod-platform-eu-vault]
+credential_process = aws-vault export --format=json prod-platform-eu-vault
 
 # Assumed role — credential_process handles the full chain
 [profile staging-assume]

--- a/examples/mcp/aws-multiprofile/claude-settings-snippet.json
+++ b/examples/mcp/aws-multiprofile/claude-settings-snippet.json
@@ -1,0 +1,18 @@
+{
+  "_purpose": "Add the mcpServers block to ~/.claude/settings.json — merge, do not replace the full file.",
+  "mcpServers": {
+    "eks-dev": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==0.1.31", "--region", "eu-west-1"],
+      "env": {
+        "AWS_PROFILE": "dev-sandbox",
+        "AWS_REGION": "eu-west-1"
+      }
+    },
+    "aws-docs": {
+      "command": "uvx",
+      "args": ["awslabs.aws-documentation-mcp-server==1.1.24"],
+      "env": {}
+    }
+  }
+}

--- a/examples/mcp/aws-multiprofile/claude-settings-snippet.json
+++ b/examples/mcp/aws-multiprofile/claude-settings-snippet.json
@@ -4,6 +4,7 @@
     "eks-dev": {
       "command": "uvx",
       "args": ["awslabs.eks-mcp-server==0.1.31", "--region", "eu-west-1"],
+      "_account": "Account: 987654321 | Env: dev | Permission: Developer",
       "env": {
         "AWS_PROFILE": "dev-sandbox",
         "AWS_REGION": "eu-west-1"

--- a/examples/mcp/aws-multiprofile/starter-kits/cost.json
+++ b/examples/mcp/aws-multiprofile/starter-kits/cost.json
@@ -4,6 +4,7 @@
     "billing": {
       "command": "uvx",
       "args": ["awslabs.billing-cost-management-mcp-server==0.0.22"],
+      "_account": "Account: 987654321 | Env: dev | Permission: Developer",
       "env": { "AWS_PROFILE": "dev-sandbox", "AWS_REGION": "us-east-1" }
     }
   }

--- a/examples/mcp/aws-multiprofile/starter-kits/cost.json
+++ b/examples/mcp/aws-multiprofile/starter-kits/cost.json
@@ -1,0 +1,10 @@
+{
+  "_kit": "cost | ~1,000 tokens | Best for: cost anomaly investigation, budget alerts, pricing queries",
+  "mcpServers": {
+    "billing": {
+      "command": "uvx",
+      "args": ["awslabs.billing-cost-management-mcp-server==0.0.22"],
+      "env": { "AWS_PROFILE": "dev-sandbox", "AWS_REGION": "us-east-1" }
+    }
+  }
+}

--- a/examples/mcp/aws-multiprofile/starter-kits/deploy.json
+++ b/examples/mcp/aws-multiprofile/starter-kits/deploy.json
@@ -4,11 +4,13 @@
     "aws-api": {
       "command": "uvx",
       "args": ["awslabs.aws-api-mcp-server==1.3.38"],
+      "_account": "Account: 987654321 | Env: dev | Permission: Developer",
       "env": { "AWS_PROFILE": "dev-sandbox", "AWS_REGION": "eu-west-1" }
     },
     "serverless": {
       "command": "uvx",
       "args": ["awslabs.aws-serverless-mcp-server==0.1.19"],
+      "_account": "Account: 987654321 | Env: dev | Permission: Developer",
       "env": { "AWS_PROFILE": "dev-sandbox", "AWS_REGION": "eu-west-1" }
     }
   }

--- a/examples/mcp/aws-multiprofile/starter-kits/deploy.json
+++ b/examples/mcp/aws-multiprofile/starter-kits/deploy.json
@@ -1,0 +1,15 @@
+{
+  "_kit": "deploy | ~3,750 tokens | Best for: serverless debugging, Lambda lifecycle, S3/ECR via aws-api",
+  "mcpServers": {
+    "aws-api": {
+      "command": "uvx",
+      "args": ["awslabs.aws-api-mcp-server==1.3.38"],
+      "env": { "AWS_PROFILE": "dev-sandbox", "AWS_REGION": "eu-west-1" }
+    },
+    "serverless": {
+      "command": "uvx",
+      "args": ["awslabs.aws-serverless-mcp-server==0.1.19"],
+      "env": { "AWS_PROFILE": "dev-sandbox", "AWS_REGION": "eu-west-1" }
+    }
+  }
+}

--- a/examples/mcp/aws-multiprofile/starter-kits/eks-debug.json
+++ b/examples/mcp/aws-multiprofile/starter-kits/eks-debug.json
@@ -1,0 +1,23 @@
+{
+  "_kit": "eks-debug | ~3,750 tokens | Best for: cluster troubleshooting, nodegroup issues, pod debugging",
+  "mcpServers": {
+    "eks": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==0.1.31", "--region", "eu-west-1"],
+      "env": {
+        "AWS_PROFILE": "dev-sandbox",
+        "AWS_REGION": "eu-west-1"
+      },
+      "_account": "Account: 987654321 | Env: dev | Permission: Developer"
+    },
+    "cloudwatch": {
+      "command": "uvx",
+      "args": ["awslabs.cloudwatch-mcp-server==0.1.4"],
+      "env": {
+        "AWS_PROFILE": "dev-sandbox",
+        "AWS_REGION": "eu-west-1"
+      },
+      "_account": "Account: 987654321 | Env: dev | Permission: Developer"
+    }
+  }
+}

--- a/examples/mcp/aws-multiprofile/starter-kits/knowledge.json
+++ b/examples/mcp/aws-multiprofile/starter-kits/knowledge.json
@@ -9,6 +9,7 @@
     "bedrock-kb": {
       "command": "uvx",
       "args": ["awslabs.bedrock-kb-retrieval-mcp-server==1.0.22"],
+      "_account": "Account: 987654321 | Env: dev | Permission: Developer",
       "env": {
         "AWS_PROFILE": "dev-sandbox",
         "AWS_REGION": "eu-west-1",

--- a/examples/mcp/aws-multiprofile/starter-kits/knowledge.json
+++ b/examples/mcp/aws-multiprofile/starter-kits/knowledge.json
@@ -1,0 +1,19 @@
+{
+  "_kit": "knowledge | ~1,250 tokens | Best for: AWS research, internal KB queries, runbook generation",
+  "mcpServers": {
+    "aws-docs": {
+      "command": "uvx",
+      "args": ["awslabs.aws-documentation-mcp-server==1.1.24"],
+      "env": {}
+    },
+    "bedrock-kb": {
+      "command": "uvx",
+      "args": ["awslabs.bedrock-kb-retrieval-mcp-server==1.0.22"],
+      "env": {
+        "AWS_PROFILE": "dev-sandbox",
+        "AWS_REGION": "eu-west-1",
+        "KNOWLEDGE_BASE_IDS": "REPLACE_WITH_YOUR_KB_IDS"
+      }
+    }
+  }
+}

--- a/examples/mcp/aws-multiprofile/starter-kits/observe.json
+++ b/examples/mcp/aws-multiprofile/starter-kits/observe.json
@@ -1,0 +1,15 @@
+{
+  "_kit": "observe | ~2,750 tokens | Best for: metrics investigation, alerting, AMP rule debugging",
+  "mcpServers": {
+    "cloudwatch": {
+      "command": "uvx",
+      "args": ["awslabs.cloudwatch-mcp-server==0.1.4"],
+      "env": { "AWS_PROFILE": "dev-sandbox", "AWS_REGION": "eu-west-1" }
+    },
+    "prometheus": {
+      "command": "uvx",
+      "args": ["awslabs.prometheus-mcp-server==0.2.17"],
+      "env": { "AWS_PROFILE": "dev-sandbox", "AWS_REGION": "eu-west-1" }
+    }
+  }
+}

--- a/examples/mcp/aws-multiprofile/starter-kits/observe.json
+++ b/examples/mcp/aws-multiprofile/starter-kits/observe.json
@@ -4,11 +4,13 @@
     "cloudwatch": {
       "command": "uvx",
       "args": ["awslabs.cloudwatch-mcp-server==0.1.4"],
+      "_account": "Account: 987654321 | Env: dev | Permission: Developer",
       "env": { "AWS_PROFILE": "dev-sandbox", "AWS_REGION": "eu-west-1" }
     },
     "prometheus": {
       "command": "uvx",
       "args": ["awslabs.prometheus-mcp-server==0.2.17"],
+      "_account": "Account: 987654321 | Env: dev | Permission: Developer",
       "env": { "AWS_PROFILE": "dev-sandbox", "AWS_REGION": "eu-west-1" }
     }
   }

--- a/examples/mcp/aws-multiprofile/vscode-global-mcp.json
+++ b/examples/mcp/aws-multiprofile/vscode-global-mcp.json
@@ -1,0 +1,10 @@
+{
+  "_purpose": "Global MCP config (~/.vscode/mcp.json). One always-on server: AWS docs only. No credentials required.",
+  "mcpServers": {
+    "aws-docs": {
+      "command": "uvx",
+      "args": ["awslabs.aws-documentation-mcp-server==1.1.24"],
+      "env": {}
+    }
+  }
+}

--- a/examples/mcp/aws-multiprofile/vscode-mcp.json.template
+++ b/examples/mcp/aws-multiprofile/vscode-mcp.json.template
@@ -1,5 +1,6 @@
 {
   "_setup": "Run: AWS_PROFILE=your-profile AWS_REGION=eu-west-1 envsubst < .vscode/mcp.json.template > .vscode/mcp.json",
+  "_note": "Both --region arg and AWS_REGION env are set intentionally: the EKS server requires the CLI flag; AWS_REGION env is a convention for other servers that read it directly.",
   "mcpServers": {
     "eks": {
       "command": "uvx",

--- a/examples/mcp/aws-multiprofile/vscode-mcp.json.template
+++ b/examples/mcp/aws-multiprofile/vscode-mcp.json.template
@@ -1,0 +1,21 @@
+{
+  "_setup": "Run: AWS_PROFILE=your-profile AWS_REGION=eu-west-1 envsubst < .vscode/mcp.json.template > .vscode/mcp.json",
+  "mcpServers": {
+    "eks": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==0.1.31", "--region", "${AWS_REGION}"],
+      "env": {
+        "AWS_PROFILE": "${AWS_PROFILE}",
+        "AWS_REGION": "${AWS_REGION}"
+      }
+    },
+    "cloudwatch": {
+      "command": "uvx",
+      "args": ["awslabs.cloudwatch-mcp-server==0.1.4"],
+      "env": {
+        "AWS_PROFILE": "${AWS_PROFILE}",
+        "AWS_REGION": "${AWS_REGION}"
+      }
+    }
+  }
+}

--- a/examples/mcp/aws-multiprofile/vscode-workspace-input-mcp.json
+++ b/examples/mcp/aws-multiprofile/vscode-workspace-input-mcp.json
@@ -1,0 +1,35 @@
+{
+  "_purpose": "VS Code interactive profile picker. VS Code prompts for profile and region at server start.",
+  "inputs": [
+    {
+      "id": "awsProfile",
+      "type": "promptString",
+      "description": "AWS profile name — run 'aws-profile discover' to list available profiles",
+      "default": "dev-sandbox"
+    },
+    {
+      "id": "awsRegion",
+      "type": "promptString",
+      "description": "AWS region",
+      "default": "eu-west-1"
+    }
+  ],
+  "mcpServers": {
+    "eks": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==0.1.31", "--region", "${input:awsRegion}"],
+      "env": {
+        "AWS_PROFILE": "${input:awsProfile}",
+        "AWS_REGION": "${input:awsRegion}"
+      }
+    },
+    "cloudwatch": {
+      "command": "uvx",
+      "args": ["awslabs.cloudwatch-mcp-server==0.1.4"],
+      "env": {
+        "AWS_PROFILE": "${input:awsProfile}",
+        "AWS_REGION": "${input:awsRegion}"
+      }
+    }
+  }
+}

--- a/examples/mcp/aws-multiprofile/vscode-workspace-mcp.json
+++ b/examples/mcp/aws-multiprofile/vscode-workspace-mcp.json
@@ -1,0 +1,23 @@
+{
+  "_purpose": "Workspace MCP config (.vscode/mcp.json). eks-debug kit — hardcoded profile. Add to .gitignore.",
+  "mcpServers": {
+    "eks-dev": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==0.1.31", "--region", "eu-west-1"],
+      "env": {
+        "AWS_PROFILE": "dev-sandbox",
+        "AWS_REGION": "eu-west-1"
+      },
+      "_account": "Account: 987654321 | Env: dev | Permission: Developer"
+    },
+    "cloudwatch-dev": {
+      "command": "uvx",
+      "args": ["awslabs.cloudwatch-mcp-server==0.1.4"],
+      "env": {
+        "AWS_PROFILE": "dev-sandbox",
+        "AWS_REGION": "eu-west-1"
+      },
+      "_account": "Account: 987654321 | Env: dev | Permission: Developer"
+    }
+  }
+}

--- a/examples/runtime-security/runtime-security-validate.sh
+++ b/examples/runtime-security/runtime-security-validate.sh
@@ -13,13 +13,17 @@ EXAMPLE_DIR="examples/runtime-security"
 echo ""
 echo "=== Runtime Security Examples: YAML syntax ==="
 
-for f in "$EXAMPLE_DIR"/*.yaml; do
-  if yq eval 'true' "$f" > /dev/null 2>&1; then
-    pass "$f is valid YAML"
-  else
-    fail "$f has invalid YAML"
-  fi
-done
+if ! command -v yq &> /dev/null; then
+  echo "  INFO: yq not found — skipping YAML lint (install: https://github.com/mikefarah/yq)"
+else
+  for f in "$EXAMPLE_DIR"/*.yaml; do
+    if yq eval 'true' "$f" > /dev/null 2>&1; then
+      pass "$f is valid YAML"
+    else
+      fail "$f has invalid YAML"
+    fi
+  done
+fi
 
 echo ""
 if [ "$ERRORS" -gt 0 ]; then

--- a/examples/supply-chain/supply-chain-validate.sh
+++ b/examples/supply-chain/supply-chain-validate.sh
@@ -13,13 +13,17 @@ EXAMPLE_DIR="examples/supply-chain"
 echo ""
 echo "=== Supply Chain Examples: YAML syntax ==="
 
-for f in "$EXAMPLE_DIR"/*.yaml; do
-  if yq eval 'true' "$f" > /dev/null 2>&1; then
-    pass "$f is valid YAML"
-  else
-    fail "$f has invalid YAML"
-  fi
-done
+if ! command -v yq &> /dev/null; then
+  echo "  INFO: yq not found — skipping YAML lint (install: https://github.com/mikefarah/yq)"
+else
+  for f in "$EXAMPLE_DIR"/*.yaml; do
+    if yq eval 'true' "$f" > /dev/null 2>&1; then
+      pass "$f is valid YAML"
+    else
+      fail "$f has invalid YAML"
+    fi
+  done
+fi
 
 echo ""
 if [ "$ERRORS" -gt 0 ]; then

--- a/references/aws-mcp-profiles.md
+++ b/references/aws-mcp-profiles.md
@@ -182,7 +182,7 @@ Two cache locations with different TTLs:
 |-------|----------|-----|-------------|
 | SSO token | `~/.aws/sso/cache/*.json` | 8–12h (org-configured) | All profiles using this SSO session |
 | Assumed role | `~/.aws/cli/cache/*.json` | 1h default | Specific role assumption |
-| Granted | `~/.granted/` | Org-configured | Granted session |
+| Granted | Same as SSO: `~/.aws/sso/cache/*.json` | Org-configured | No separate cache — delegates to SSO or role cache |
 
 **Parse expiry manually:**
 ```bash

--- a/references/aws-mcp-profiles.md
+++ b/references/aws-mcp-profiles.md
@@ -486,7 +486,7 @@ Any profile tagged `prod` or with a name containing `prod` or `production` requi
   This will update MCP server configs to use production credentials.
   Any AI-driven operations will execute against production.
   
-  Confirm with --confirm flag or type 'yes' to proceed.
+  Pass --confirm to proceed.
 ```
 
 **Recommended practice:**

--- a/references/aws-mcp-profiles.md
+++ b/references/aws-mcp-profiles.md
@@ -1,0 +1,505 @@
+# AWS MCP Profiles Reference
+
+Deep-dive guide for managing AWS MCP servers across VS Code (GitHub Copilot) and Claude Code with multiple AWS accounts.
+
+## Contents
+
+1. [When MCP vs CLI](#1-when-mcp-vs-cli)
+2. [Context Budget Table](#2-context-budget-table)
+3. [AWS MCP Server Catalog](#3-aws-mcp-server-catalog)
+4. [Profile Type Detection](#4-profile-type-detection)
+5. [Auth Flows](#5-auth-flows)
+6. [Credential Lifecycle](#6-credential-lifecycle)
+7. [credential_process Pattern](#7-credential_process-pattern)
+8. [Config File Locations](#8-config-file-locations)
+9. [VS Code Input Variables](#9-vs-code-input-variables)
+10. [Team Sharing Pattern](#10-team-sharing-pattern)
+11. [Multi-Region Handling](#11-multi-region-handling)
+12. [Multi-Account EKS](#12-multi-account-eks)
+13. [Health Check Checklist](#13-health-check-checklist)
+14. [Prod Safety](#14-prod-safety)
+15. [Starter Kits](#15-starter-kits)
+
+---
+
+## 1. When MCP vs CLI
+
+MCP servers cost context window tokens the moment they are configured — every registered tool definition is loaded at session start, before you type a single character.
+
+**Use the CLI when:**
+- You need one answer: `aws eks list-clusters --profile prod-eu`
+- The operation is a single API call with no follow-up reasoning
+- You are scripting or automating
+
+**Use MCP when:**
+- You need AI to chain multiple AWS API calls and reason across the results
+- Example: list EKS clusters → describe nodegroups → correlate with CloudWatch alarms → summarise degraded nodes
+- Example: query Bedrock KB → cross-reference AWS docs → generate runbook
+
+**Rule of thumb:** If the task fits in one AWS CLI command, use the CLI. MCP earns its context cost when the AI needs to make 3+ calls and synthesise the results.
+
+| Task | CLI sufficient? | MCP adds value? |
+|------|----------------|----------------|
+| List EKS clusters | ✓ `aws eks list-clusters` | ✗ |
+| Describe a nodegroup | ✓ `aws eks describe-nodegroup` | ✗ |
+| Debug why pods are evicted | ✗ | ✓ (cluster + CW + nodes) |
+| Find cost anomaly | ✗ | ✓ (billing + pricing + tags) |
+| Retrieve from knowledge base | ✗ | ✓ (KB + docs synthesis) |
+
+---
+
+## 2. Context Budget Table
+
+Each MCP server registers all its tools at session start. Approximate tool counts and token costs:
+
+| Server | Package | ~Tools | ~Tokens | Notes |
+|--------|---------|--------|---------|-------|
+| EKS | `awslabs.eks-mcp-server` | ~40 | ~2,000 | Cluster, nodegroups, pods |
+| CloudWatch | `awslabs.cloudwatch-mcp-server` | ~35 | ~1,750 | Logs, metrics, alarms |
+| Prometheus (AMP) | `awslabs.prometheus-mcp-server` | ~20 | ~1,000 | AMP workspaces, rules |
+| IAM | `awslabs.iam-mcp-server` | ~30 | ~1,500 | Read-only IAM queries |
+| Bedrock KB | `awslabs.bedrock-kb-retrieval-mcp-server` | ~15 | ~750 | KB retrieve + generate |
+| AWS Docs | `awslabs.aws-documentation-mcp-server` | ~10 | ~500 | Real-time docs search |
+| AWS API (general) | `awslabs.aws-api-mcp-server` | ~50 | ~2,500 | All AWS services |
+| Billing/Cost | `awslabs.billing-cost-management-mcp-server` | ~20 | ~1,000 | Cost Explorer, budgets |
+| Serverless | `awslabs.aws-serverless-mcp-server` | ~25 | ~1,250 | SAM, Lambda lifecycle |
+| DynamoDB | `awslabs.dynamodb-mcp-server` | ~25 | ~1,250 | Table ops, queries |
+
+**Budget guidance:**
+- Under 5,000 tokens (≤3 servers): comfortable for most conversations
+- 5,000–10,000 tokens: noticeable compression of available context
+- Over 10,000 tokens (5+ servers): model reasoning quality degrades; split into separate sessions
+
+---
+
+## 3. AWS MCP Server Catalog
+
+All servers use `uvx` (Python). Pin versions in production configs — `uvx awslabs.eks-mcp-server` pulls latest on every invocation.
+
+```bash
+# Look up current version before pinning
+pip index versions awslabs.eks-mcp-server 2>/dev/null | head -1
+# or: https://pypi.org/pypi/awslabs.eks-mcp-server/json | jq .info.version
+```
+
+**Version pin syntax in MCP config:**
+```json
+{
+  "command": "uvx",
+  "args": ["awslabs.eks-mcp-server==1.2.3", "--region", "eu-west-1"]
+}
+```
+
+**Transport:** Use `stdio` for all local servers. SSE transport was removed from awslabs servers in May 2025. Streamable HTTP is available for remote deployments only.
+
+---
+
+## 4. Profile Type Detection
+
+Read `~/.aws/config` and classify each `[profile name]` block:
+
+| Type | Detection signal | Example |
+|------|-----------------|---------|
+| SSO | `sso_start_url` present | `sso_start_url = https://myorg.awsapps.com/start` |
+| Assumed role | `role_arn` + `source_profile` | `role_arn = arn:aws:iam::123456789:role/PlatformEngineer` |
+| Granted | `granted_sso_*` keys or `assume` binary in PATH | `granted_sso_account_id = 123456789` |
+| Static | `aws_access_key_id` directly in profile | **Warn:** rotate to SSO |
+
+**Detect Granted:**
+```bash
+which assume 2>/dev/null && echo "Granted installed" || echo "Granted not found"
+# Granted profiles also show: granted_sso_account_id, granted_sso_role_name
+```
+
+**Environment tag file:** `~/.aws-profile-tags.yaml` maps profile names to environment labels:
+```yaml
+prod-platform-eu: prod
+prod-platform-us: prod
+staging-assume: staging
+dev-sandbox: dev
+security: shared-services
+```
+
+If this file does not exist, run `/platform-skills:aws-profile discover` and it will generate a starter file from profile name heuristics for you to review.
+
+---
+
+## 5. Auth Flows
+
+### SSO Login
+```bash
+aws sso login --profile prod-platform-eu
+# Verify:
+aws sts get-caller-identity --profile prod-platform-eu
+```
+
+### Granted Assume
+```bash
+assume prod-platform-eu
+# Or with a duration override:
+assume prod-platform-eu --duration 4h
+# Verify:
+aws sts get-caller-identity
+```
+
+### Role Chain Validation
+
+For profiles with `role_arn` + `source_profile`, validate the full chain bottom-up:
+```bash
+# 1. Validate the source profile first
+aws sts get-caller-identity --profile dev-sso
+
+# 2. Then validate the target profile
+aws sts get-caller-identity --profile staging-assume
+
+# 3. Visualise the chain
+grep -A 5 "\[profile staging-assume\]" ~/.aws/config
+```
+
+**Multi-hop chain example:**
+```
+identity-sso (111111111)
+  └── assume → security-role (222222222)
+      └── assume → prod-platform-eu (123456789)  ← target profile
+```
+
+If step 1 fails, fix the source profile before debugging the target.
+
+### Static profile (warn and migrate)
+```
+⚠ Static credentials in ~/.aws/credentials are long-lived and do not expire cleanly.
+  Rotate to SSO: configure IAM Identity Center and update ~/.aws/config.
+  Interim: set a short session duration in the profile.
+```
+
+---
+
+## 6. Credential Lifecycle
+
+Two cache locations with different TTLs:
+
+| Cache | Location | TTL | What expires |
+|-------|----------|-----|-------------|
+| SSO token | `~/.aws/sso/cache/*.json` | 8–12h (org-configured) | All profiles using this SSO session |
+| Assumed role | `~/.aws/cli/cache/*.json` | 1h default | Specific role assumption |
+| Granted | `~/.granted/` | Org-configured | Granted session |
+
+**Parse expiry manually:**
+```bash
+# SSO cache — find the active token
+cat ~/.aws/sso/cache/*.json | python3 -c "
+import json, sys, datetime
+for line in sys.stdin:
+    try:
+        d = json.loads(line)
+        if 'expiresAt' in d:
+            exp = datetime.datetime.fromisoformat(d['expiresAt'].replace('Z','+00:00'))
+            ttl = exp - datetime.datetime.now(datetime.timezone.utc)
+            print(f\"Expires: {d['expiresAt']} | TTL: {ttl}\")
+    except: pass
+"
+
+# Assumed role cache
+ls -la ~/.aws/cli/cache/
+cat ~/.aws/cli/cache/*.json | python3 -c "
+import json, sys, datetime
+for d in [json.loads(l) for l in sys.stdin if l.strip()]:
+    exp = d.get('Credentials',{}).get('Expiration','')
+    if exp:
+        print(f\"Role creds expire: {exp}\")
+"
+```
+
+**Traffic-light thresholds:**
+- ✓ Green: TTL > 30 minutes
+- ⚠ Amber: TTL 10–30 minutes
+- ✗ Red: TTL < 10 minutes or EXPIRED
+
+**Why MCP servers go stale:** An MCP server running as a long-lived process inherits credentials at startup. When the SSO token or role creds expire, the running server continues using the expired token until it is restarted — `ExpiredTokenException` is the symptom.
+
+---
+
+## 7. credential_process Pattern
+
+`credential_process` is the structural fix for stale credentials. Instead of the SDK caching credentials internally, it calls an external binary on every API call that needs fresh credentials.
+
+**Configure in `~/.aws/config`:**
+
+```ini
+# SSO via Granted (recommended for Granted users)
+[profile prod-platform-eu]
+sso_start_url = https://myorg.awsapps.com/start
+sso_region = eu-west-1
+sso_account_id = 123456789
+sso_role_name = PowerUser
+region = eu-west-1
+credential_process = granted credential-process --profile prod-platform-eu
+
+# SSO via aws-vault
+[profile prod-platform-eu]
+credential_process = aws-vault export --format=json prod-platform-eu
+
+# Assumed role chain — credential_process handles the full chain
+[profile staging-assume]
+credential_process = aws-vault export --format=json staging-assume
+```
+
+**Verify it works:**
+```bash
+aws sts get-caller-identity --profile prod-platform-eu
+# Should return without any cached token — fetches live via credential_process
+```
+
+**MCP config with credential_process profile:**
+```json
+{
+  "mcpServers": {
+    "eks-prod-eu": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==1.2.3", "--region", "eu-west-1"],
+      "env": {
+        "AWS_PROFILE": "prod-platform-eu",
+        "AWS_REGION": "eu-west-1"
+      }
+    }
+  }
+}
+```
+
+When `prod-platform-eu` has `credential_process` configured, `AWS_PROFILE` in the MCP env block is safe — the SDK will call `credential_process` for every API call instead of using a cached token.
+
+---
+
+## 8. Config File Locations
+
+| Host | Scope | Path |
+|------|-------|------|
+| VS Code / Copilot | Global (all workspaces) | `~/.vscode/mcp.json` |
+| VS Code / Copilot | Workspace (current repo) | `.vscode/mcp.json` |
+| Claude Code | Global | `~/.claude/settings.json` → `mcpServers` key |
+
+**Rule:** Put 0–1 servers in global config (docs lookup only). Put task-specific servers in workspace `.vscode/mcp.json`. Never put prod-credential-backed servers in global config.
+
+**Always-on global example (`~/.vscode/mcp.json`):**
+```json
+{
+  "mcpServers": {
+    "aws-docs": {
+      "command": "uvx",
+      "args": ["awslabs.aws-documentation-mcp-server==0.1.3"],
+      "env": {}
+    }
+  }
+}
+```
+
+---
+
+## 9. VS Code Input Variables
+
+VS Code supports interactive profile selection via `${input:variableId}` in `mcp.json`. This avoids hardcoding profile names:
+
+```json
+{
+  "inputs": [
+    {
+      "id": "awsProfile",
+      "type": "promptString",
+      "description": "AWS profile name — run 'aws-profile discover' to list available profiles",
+      "default": "dev-sandbox"
+    },
+    {
+      "id": "awsRegion",
+      "type": "promptString",
+      "description": "AWS region",
+      "default": "eu-west-1"
+    }
+  ],
+  "mcpServers": {
+    "eks": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==1.2.3", "--region", "${input:awsRegion}"],
+      "env": {
+        "AWS_PROFILE": "${input:awsProfile}",
+        "AWS_REGION": "${input:awsRegion}"
+      }
+    }
+  }
+}
+```
+
+VS Code prompts the engineer for profile and region when the server starts.
+
+**When to use input variables vs `switch` command:**
+- Input variables: VS Code only, interactive per-session, good for teams who change accounts frequently
+- `switch` command: patches hardcoded values, works for both VS Code and Claude Code, good for long-lived workspace configs
+
+These are separate patterns — not interchangeable.
+
+---
+
+## 10. Team Sharing Pattern
+
+Never commit `mcp.json` with real profile names to git — profile names leak account structure. Use a template:
+
+**`.vscode/mcp.json.template`** (commit this):
+```json
+{
+  "_setup": "Copy to .vscode/mcp.json and replace AWS_PROFILE and AWS_REGION placeholders",
+  "mcpServers": {
+    "eks": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==1.2.3", "--region", "${AWS_REGION}"],
+      "env": {
+        "AWS_PROFILE": "${AWS_PROFILE}",
+        "AWS_REGION": "${AWS_REGION}"
+      }
+    },
+    "cloudwatch": {
+      "command": "uvx",
+      "args": ["awslabs.cloudwatch-mcp-server==0.2.1"],
+      "env": {
+        "AWS_PROFILE": "${AWS_PROFILE}",
+        "AWS_REGION": "${AWS_REGION}"
+      }
+    }
+  }
+}
+```
+
+**`.gitignore`** entries:
+```
+# MCP configs with real credentials/profile names
+.vscode/mcp.json
+!.vscode/mcp.json.template
+```
+
+**Hydration one-liner** (new engineer onboarding):
+```bash
+AWS_PROFILE=dev-sandbox AWS_REGION=eu-west-1 \
+  envsubst < .vscode/mcp.json.template > .vscode/mcp.json
+```
+
+---
+
+## 11. Multi-Region Handling
+
+AWS MCP servers that interact with regional services need both `AWS_PROFILE` and `AWS_REGION`. Do not rely on the default region in `~/.aws/config` — make it explicit in every server entry.
+
+**Always set both:**
+```json
+{
+  "env": {
+    "AWS_PROFILE": "prod-platform-eu",
+    "AWS_REGION": "eu-west-1"
+  }
+}
+```
+
+**EKS specifically:** Pass `--region` in args AND set `AWS_REGION` in env — some EKS MCP server operations use the CLI flag, others read the env var:
+```json
+{
+  "command": "uvx",
+  "args": ["awslabs.eks-mcp-server==1.2.3", "--region", "eu-west-1"],
+  "env": {
+    "AWS_PROFILE": "prod-platform-eu",
+    "AWS_REGION": "eu-west-1"
+  }
+}
+```
+
+---
+
+## 12. Multi-Account EKS
+
+One EKS MCP server instance = one AWS profile = one account. For engineers working across multiple accounts, generate named instances:
+
+```json
+{
+  "mcpServers": {
+    "eks-prod-eu": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==1.2.3", "--region", "eu-west-1"],
+      "env": { "AWS_PROFILE": "prod-platform-eu", "AWS_REGION": "eu-west-1" },
+      "_account": "123456789 | prod | PowerUser"
+    },
+    "eks-prod-us": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==1.2.3", "--region", "us-east-1"],
+      "env": { "AWS_PROFILE": "prod-platform-us", "AWS_REGION": "us-east-1" },
+      "_account": "234567890 | prod | PowerUser"
+    },
+    "eks-staging": {
+      "command": "uvx",
+      "args": ["awslabs.eks-mcp-server==1.2.3", "--region", "eu-west-1"],
+      "env": { "AWS_PROFILE": "staging-assume", "AWS_REGION": "eu-west-1" },
+      "_account": "345678901 | staging | Developer"
+    }
+  }
+}
+```
+
+**Token cost:** 3 EKS instances = ~6,000 tokens. Use only when cross-account correlation is the explicit goal — for single-account work, use one instance.
+
+---
+
+## 13. Health Check Checklist
+
+Run in order — each layer must pass before checking the next:
+
+```bash
+# 1. Token valid
+aws sts get-caller-identity --profile <profile>
+# Expected: JSON with Account, UserId, Arn
+
+# 2. Server binary available
+uvx awslabs.eks-mcp-server --help 2>&1 | head -5
+# Expected: help text, not "command not found"
+
+# 3. Server responds to tools/list
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  | AWS_PROFILE=<profile> AWS_REGION=eu-west-1 uvx awslabs.eks-mcp-server 2>/dev/null
+# Expected: JSON with "tools" array
+
+# 4. IAM has minimum permissions
+aws eks list-clusters --profile <profile> --region eu-west-1
+# Expected: cluster list (empty list is fine, AccessDenied is not)
+```
+
+If step 1 fails → run `login`. If step 2 fails → `uvx` not installed or package name wrong. If step 3 fails → server startup error, check stderr. If step 4 fails → IAM permissions missing.
+
+---
+
+## 14. Prod Safety
+
+Any profile tagged `prod` or with a name containing `prod` or `production` requires extra care.
+
+**Switch guard:** Always confirm before patching prod-profile configs:
+```
+⚠ WARNING: You are switching to prod-platform-eu (Account: 123456789, env: prod).
+  This will update MCP server configs to use production credentials.
+  Any AI-driven operations will execute against production.
+  
+  Confirm with --confirm flag or type 'yes' to proceed.
+```
+
+**Recommended practice:**
+- Use `ReadOnly` permission set for MCP servers in prod accounts — restrict to `Get*`, `List*`, `Describe*`
+- Never configure write-capable MCP servers (e.g. EKS with deploy permissions) against prod in always-on global config
+- Put prod-backed servers in workspace config only, committed to ops-specific repos with appropriate access controls
+
+---
+
+## 15. Starter Kits
+
+Curated minimal server sets — use these as the starting point, not the full catalog.
+
+| Kit | Servers | ~Tokens | Best for |
+|-----|---------|---------|---------|
+| `eks-debug` | eks + cloudwatch | ~3,750 | Cluster troubleshooting |
+| `observe` | cloudwatch + prometheus | ~2,750 | Metrics and alerting |
+| `knowledge` | aws-docs + bedrock-kb | ~1,250 | AWS research + internal KB |
+| `deploy` | aws-api + serverless | ~3,750 | Serverless CI/CD debugging |
+| `cost` | billing-cost + pricing | ~2,000 | Cost investigation |
+
+See `examples/mcp/aws-multiprofile/starter-kits/` for ready-to-use JSON files.

--- a/references/aws-mcp-profiles.md
+++ b/references/aws-mcp-profiles.md
@@ -221,7 +221,7 @@ for d in [json.loads(l) for l in sys.stdin if l.strip()]:
 
 ## 7. credential_process Pattern
 
-`credential_process` is the structural fix for stale credentials. Instead of the SDK caching credentials internally, it calls an external binary on every API call that needs fresh credentials.
+`credential_process` is the structural fix for stale credentials. Instead of the SDK reading credentials from a static file, it delegates to an external binary — invoked when credentials are needed or have expired, then cached in-memory until the next refresh boundary.
 
 **Configure in `~/.aws/config`:**
 
@@ -272,7 +272,7 @@ aws sts get-caller-identity --profile prod-platform-eu
 }
 ```
 
-When `prod-platform-eu` has `credential_process` configured, `AWS_PROFILE` in the MCP env block is safe — the SDK will call `credential_process` for every API call instead of using a cached token.
+When `prod-platform-eu` has `credential_process` configured, `AWS_PROFILE` in the MCP env block is safe — the credential provider refreshes credentials when they expire, so long-running MCP servers re-auth without restart.
 
 ---
 

--- a/references/aws-mcp-profiles.md
+++ b/references/aws-mcp-profiles.md
@@ -79,7 +79,7 @@ All servers use `uvx` (Python). Pin versions in production configs — `uvx awsl
 ```bash
 # Look up current version before pinning
 pip index versions awslabs.eks-mcp-server 2>/dev/null | head -1
-# or: https://pypi.org/pypi/awslabs.eks-mcp-server/json | jq .info.version
+# or: curl -s https://pypi.org/pypi/awslabs.eks-mcp-server/json | jq -r .info.version
 ```
 
 **Version pin syntax in MCP config:**
@@ -120,7 +120,7 @@ dev-sandbox: dev
 security: shared-services
 ```
 
-If this file does not exist, run `/platform-skills:aws-profile discover` and it will generate a starter file from profile name heuristics for you to review.
+If this file does not exist, run `/platform-skills:aws-profile discover` (see `commands/aws-profile.md`) and it will generate a starter file from profile name heuristics for you to review.
 
 ---
 
@@ -137,7 +137,7 @@ aws sts get-caller-identity --profile prod-platform-eu
 ```bash
 assume prod-platform-eu
 # Or with a duration override:
-assume prod-platform-eu --duration 4h
+assume prod-platform-eu --duration 4h  # Granted v0.1.18+; older versions use seconds
 # Verify:
 aws sts get-caller-identity
 ```
@@ -225,8 +225,8 @@ for d in [json.loads(l) for l in sys.stdin if l.strip()]:
 
 **Configure in `~/.aws/config`:**
 
+**Option A — SSO via Granted (recommended if you use Granted):**
 ```ini
-# SSO via Granted (recommended for Granted users)
 [profile prod-platform-eu]
 sso_start_url = https://myorg.awsapps.com/start
 sso_region = eu-west-1
@@ -234,15 +234,21 @@ sso_account_id = 123456789
 sso_role_name = PowerUser
 region = eu-west-1
 credential_process = granted credential-process --profile prod-platform-eu
+```
 
-# SSO via aws-vault
+**Option B — SSO via aws-vault:**
+```ini
 [profile prod-platform-eu]
 credential_process = aws-vault export --format=json prod-platform-eu
+```
 
-# Assumed role chain — credential_process handles the full chain
+**Option C — Assumed role chain (aws-vault handles the full chain):**
+```ini
 [profile staging-assume]
 credential_process = aws-vault export --format=json staging-assume
 ```
+
+(These are mutually exclusive — pick the one that matches your toolchain.)
 
 **Verify it works:**
 ```bash
@@ -332,7 +338,7 @@ VS Code prompts the engineer for profile and region when the server starts.
 
 **When to use input variables vs `switch` command:**
 - Input variables: VS Code only, interactive per-session, good for teams who change accounts frequently
-- `switch` command: patches hardcoded values, works for both VS Code and Claude Code, good for long-lived workspace configs
+- `switch` command: patches hardcoded values, works for both VS Code and Claude Code, good for long-lived workspace configs (see `commands/aws-profile.md` → Mode: switch)
 
 These are separate patterns — not interchangeable.
 
@@ -500,6 +506,6 @@ Curated minimal server sets — use these as the starting point, not the full ca
 | `observe` | cloudwatch + prometheus | ~2,750 | Metrics and alerting |
 | `knowledge` | aws-docs + bedrock-kb | ~1,250 | AWS research + internal KB |
 | `deploy` | aws-api + serverless | ~3,750 | Serverless CI/CD debugging |
-| `cost` | billing-cost + pricing | ~2,000 | Cost investigation |
+| `cost` | billing-cost-management | ~1,000 | Cost investigation |
 
 See `examples/mcp/aws-multiprofile/starter-kits/` for ready-to-use JSON files.

--- a/references/mcp.md
+++ b/references/mcp.md
@@ -1,5 +1,15 @@
 # MCP (Model Context Protocol) Reference
 
+## AWS Multi-Account Profiles
+
+For managing AWS MCP servers across multiple accounts (SSO, Granted, assumed-role chains, credential_process, team sharing):
+
+→ See `references/aws-mcp-profiles.md`
+
+Commands: `/platform-skills:aws-profile` · `/platform-skills:mcp configure-aws`
+
+---
+
 ## Protocol Fundamentals
 
 MCP is a JSON-RPC 2.0 protocol that connects AI hosts (Claude Desktop, Claude Code) with servers exposing tools, resources, and prompts.

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -22,6 +22,7 @@ Use this skill for hands-on help with Kubernetes, GitOps, cloud infrastructure, 
 | `Compliance` | SOC 2 controls in Terraform — IAM, encryption, audit logging, Checkov |
 | `Helm (Helmcheck)` | Chart scaffolding, lint/validate pipeline, values design, security hardening |
 | `MCP` | Build/debug MCP servers — tools, resources, transports, auth |
+| `AWS MCP Profiles` | Discover/switch AWS profiles across VS Code + Claude Code MCP configs — multi-account, SSO, Granted, credential_process |
 | `Observability` | Prometheus, OpenTelemetry, Grafana, alerting, k6 load tests, capacity |
 | `Documentation` | Docstrings (Google/NumPy/JSDoc), OpenAPI 3.1, MkDocs, guides |
 | `Datadog` | Agent on Kubernetes, APM, monitors, dashboards, SLOs, LLMObs |
@@ -94,6 +95,7 @@ Load only the files needed for the current request.
 | references/fluxcd-troubleshooting.md | Incident cheat-sheet — symptom → cause → fix per controller |
 | references/argocd.md | App delivery, ApplicationSet, sync policies |
 | references/aws.md | Landing zones, IAM, EKS patterns |
+| references/aws-mcp-profiles.md | AWS MCP profile management — multi-account SSO, Granted, credential_process, context budget, starter kits |
 | references/azure.md | Management groups, identity, AKS patterns |
 | references/aws-cloudfront.md | CloudFront distributions, OAC, Lambda@Edge, security headers |
 | references/aws-waf.md | Web ACLs, managed rules, rate limiting, Firewall Manager |
@@ -139,6 +141,7 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:compliance` — SOC 2 gap analysis, control implementation, evidence collection, and Checkov remediation for Terraform
 - `/platform-skills:helmcheck` — Helm chart scaffolding, structural review, and security audit with full lint/validation pipeline
 - `/platform-skills:mcp` — MCP server/client scaffolding, protocol review, and integration debugging
+- `/platform-skills:aws-profile` — discover, switch, and validate AWS profiles for MCP servers across VS Code and Claude Code
 - `/platform-skills:observability` — instrument services, build dashboards, write alerts, run load tests, plan capacity
 - `/platform-skills:document` — generate docstrings, OpenAPI specs, documentation sites, and getting started guides
 - `/platform-skills:datadog` — Datadog Agent setup, APM instrumentation, monitors, dashboards, SLOs, pup CLI operations, LLM Observability instrumentation, evaluators, and debugging


### PR DESCRIPTION
## Summary

- Adds `references/aws-mcp-profiles.md` — 15-section deep-dive covering multi-account MCP credential management, `credential_process` structural fix, `~/.aws-profile-tags.yaml` environment tagging, org-scan, and VS Code `${input:awsProfile}` pattern
- Adds `/platform-skills:aws-profile` slash command with 5 modes: `discover`, `status`, `switch`, `login`, `org-scan`
- Extends `/platform-skills:mcp` with `configure-aws` mode — cost-gated (5,000-token threshold), 10-server catalog, 5 starter kits
- Adds `examples/mcp/aws-multiprofile/` — 13 production-ready files covering VS Code global/workspace/input configs, Claude Code snippet, `credential_process` ini, and starter kits (eks-debug, observe, knowledge, deploy, cost)
- Fixes 3 domain validators (`supply-chain`, `runtime-security`, `chaos`) to guard against missing `yq`
- Bumps plugin to v1.26.0; all 5 test scripts pass clean

## Test plan

- [ ] `bash tests/handbook-consistency.sh` — passes
- [ ] `bash tests/release-consistency.sh` — passes (safe to tag v1.26.0)
- [ ] `bash tests/validate-ci.sh` — passes
- [ ] `bash tests/validate-helmcheck.sh` — passes
- [ ] `bash tests/validate-skill.sh` — passes
- [ ] `/platform-skills:aws-profile discover` resolves correct cache fields per credential type (SSO → `expiresAt`, assumed-role → `Credentials.Expiration`, Granted → `expiresAt`)
- [ ] `/platform-skills:mcp configure-aws` surfaces cost warning before generating config
- [ ] Example JSON files validate as syntactically correct