### PR TITLE
chore: release v1.26.0 — source.sha update and geetika-sv credit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -168,7 +168,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "601f69336e4010a40b1119d5d240b8b22c5e26f0"
+        "sha": "e04827a0e88d3f3f7480c7fc2eca79a5d4f57aa6"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Platform Skills will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.26.0] - 2026-05-25
+## [1.26.0] - 2026-05-26
 
 ### Added
 
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `COMMANDS.md`: TOC entry and full `/platform-skills:aws-profile` command section (30 commands total).
 - `references/mcp.md`: AWS Multi-Account Profiles pointer section.
 - Tessl evaluation scenarios (`evals/`) for quality testing: `pr-triage`, `opa-policy`, `flux-helmrelease`. Each scenario includes `task.md`, `criteria.json`, and `capability.txt`.
+
+### Contributors
+
+- [@geetika-sv](https://github.com/geetika-sv) — AWS MCP profile management feature
 
 ## [1.25.20] - 2026-05-24
 


### PR DESCRIPTION
## Summary

- Updates `source.sha` in `.claude-plugin/marketplace.json` to the post-merge main HEAD (`e04827a`) — required for release workflow validation
- Fixes release date in CHANGELOG from 2026-05-25 → 2026-05-26
- Adds [@geetika-sv](https://github.com/geetika-sv) contributor credit for the AWS MCP profile management feature

## Test plan

- [ ] Handbook consistency check passes (`bash tests/handbook-consistency.sh`)
- [ ] `source.sha` is a reachable ancestor of the v1.26.0 tag
- [ ] Release workflow triggers cleanly after merge and tag