### PR TITLE
feat: /platform-skills:codex+cursor install support — v1.28.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -169,7 +169,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "4af74a3d96761bf8854fddce4450766799ffb770"
+        "sha": "7c9f65defdd3b5aef2375428aa4f36b0ef8d6121"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
## Summary

- Codex skill support: `agents/openai.yaml` so Codex can display and invoke `platform-skills` with a default `$platform-skills` prompt
- Cursor support refresh: updated `.cursorrules` and `.cursor/rules/*.mdc` to current release with project/global Cursor installation docs
- Adoption polish: `install.sh`, README install matrix, copy-ready prompts for platform/DevOps/cloud/SRE teams
- Copilot instructions refresh: documented installer path, added Copilot-specific response behavior, validated handbook file references
- Community growth assets: `PROMPTS.md` plus issue templates for agent/editor support, domain guide requests, and example contributions
- Release validation now checks Codex skill metadata and Cursor rule files in addition to Claude plugin structure
- `marketplace.json` `source.sha` updated to v1.28.0 merge commit

## Validation

```bash
bash tests/handbook-consistency.sh
diff SKILL.md skills/platform-skills/SKILL.md
grep "1.28.0" INSTALLATION.md .claude-plugin/marketplace.json .claude-plugin/plugin.json tile.json
```

## Rollback

Revert `.claude-plugin/marketplace.json` `source.sha` to `4af74a3d96761bf8854fddce4450766799ffb770`.