### PR TITLE
docs: add Claude plugin upgrade instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ cd platform-skills
 claude plugin install .
 ```
 
+**Upgrade to latest version:**
+```bash
+claude plugins marketplace update platform-skills
+claude plugins remove platform-skills
+claude plugins install platform-skills
+```
+
 ### Install as a Codex skill
 
 Codex discovers skills from the local skills directory. Clone this repository as the skill folder so `SKILL.md`, `agents/openai.yaml`, `references/`, and `examples/` stay together:


### PR DESCRIPTION
## Summary

Adds an **Upgrade to latest version** block under the "Install as a Claude plugin" section.

The three-step sequence (`marketplace update` → `remove` → `install`) was missing from the docs and is non-obvious — the marketplace cache must be refreshed before reinstalling or you get the old version.

## Change

```bash
claude plugins marketplace update platform-skills
claude plugins remove platform-skills
claude plugins install platform-skills
```

## Validation

- Read README.md Installation → Install as a Claude plugin section
- Verify upgrade block appears between the local-clone block and the Codex skill section