### PR TITLE
fix(gitops): correct security grep commands in phase 5 audit

### DIFF
--- a/commands/gitops.md
+++ b/commands/gitops.md
@@ -1,6 +1,6 @@
 ---
 name: gitops
-description: Flux CD and Argo CD — two modes. debug: five structured debug workflows for live clusters (installation, source, HelmRelease, Kustomization, ResourceSet) producing a five-section report. audit: six-phase read-only repo analysis (discovery, validation, API compliance, best practices, security) producing a prioritised Critical/Warning/Info report.
+description: "Flux CD and Argo CD — two modes. debug: five structured debug workflows for live clusters (installation, source, HelmRelease, Kustomization, ResourceSet) producing a five-section report. audit: six-phase read-only repo analysis (discovery, validation, API compliance, best practices, security) producing a prioritised Critical/Warning/Info report."
 argument-hint: "debug [describe symptom or paste flux/argocd output] | audit [repo path or paste directory listing]"
 ---
 
@@ -407,10 +407,12 @@ grep -rn -e "password:" -e "token:" -e "apiKey:" -e "_SECRET=" -e "ACCESS_KEY=" 
 grep -rn "insecure: true" . --include="*.yaml"
 
 # Cloud registries without Workload Identity
-grep -rn "ecr\.\|\.gcr\.io\|\.azurecr\.io" . --include="*.yaml" -B5 | grep -v "provider:"
+grep -rn "\.ecr\.amazonaws\.com\|\.gcr\.io\|\.azurecr\.io" . --include="*.yaml" -B5 | grep -v "provider:"
 
 # OCIRepository without Cosign verification
-grep -rn "kind: OCIRepository" . --include="*.yaml" -A20 | grep -v "verify:"
+grep -rln "kind: OCIRepository" . --include="*.yaml" | while read f; do
+  grep -q "verify:" "$f" || echo "NO COSIGN VERIFY: $f"
+done
 
 # cluster-admin bindings
 grep -rn "cluster-admin" . --include="*.yaml"


### PR DESCRIPTION
## What

Two buggy shell commands in the Phase 5 Security Review section of `commands/gitops.md`.

## Why

### 1. ECR registry regex too broad (line 410)

```bash
# Before
grep -rn "ecr\.\|\.gcr\.io\|\.azurecr\.io"
```

`ecr.` matches any string containing those characters (e.g. comments, unrelated values). Anchored to the actual AWS ECR domain:

```bash
# After
grep -rn "\.ecr\.amazonaws\.com\|\.gcr\.io\|\.azurecr\.io"
```

### 2. OCIRepository Cosign check logic wrong (line 413)

```bash
# Before — broken: strips verify: lines but still prints all OCIRepository blocks,
# including ones that DO have verify:. No way to distinguish compliant vs non-compliant.
grep -rn "kind: OCIRepository" . --include="*.yaml" -A20 | grep -v "verify:"
```

```bash
# After — correct: prints only files that are missing verify: entirely
grep -rln "kind: OCIRepository" . --include="*.yaml" | while read f; do
  grep -q "verify:" "$f" || echo "NO COSIGN VERIFY: $f"
done
```

## Validation

Run both commands against a test directory with a mix of OCIRepository files (some with `verify:`, some without) and confirm only the non-compliant ones are reported.