### PR TITLE
fix(commands): reduce token waste and fill safety gaps across 21 commands

### DIFF
--- a/commands/awesome-docs.md
+++ b/commands/awesome-docs.md
@@ -56,7 +56,7 @@ Steps:
 
 **Theme parameter:** append `--theme github-dark` (default), `--theme docs-light`, or `--theme custom:#bg,#primary,#accent` to override colors. See `references/awesome-docs.md` → Theme System.
 
-Reference: `references/awesome-docs.md` → SVG Patterns, Theme System
+If you need deeper context on SVG patterns, theme configuration, or the quality checklist, load `references/awesome-docs.md`.
 
 ---
 
@@ -86,8 +86,6 @@ Steps:
 5. Commit: `git add <doc-path> assets/ && git commit -m "feat(awesome-docs): animate <doc-filename>"`
    - In batch mode: single commit after all files: `git commit -m "feat(awesome-docs): animate docs in <dir>"`
 
-Reference: `references/awesome-docs.md` → SVG Patterns
-
 ---
 
 ## Mode: update
@@ -102,8 +100,6 @@ Steps:
 5. Show the new SVG — confirm before writing
 6. Overwrite `assets/<filename>.svg`
 7. Commit: `git add assets/<filename>.svg && git commit -m "fix(awesome-docs): update <diagram-name> — <what changed>"`
-
-Reference: `references/awesome-docs.md` → SVG Patterns
 
 ---
 
@@ -132,8 +128,6 @@ Steps:
 6. Include the base ref used: `(diffed against <ref>)` at the top of the report
 7. Suggest: "Run `/platform-skills:awesome-docs update` for each flagged diagram."
 
-Reference: `references/awesome-docs.md` → Quality Checklist
-
 ---
 
 ## Mode: audit
@@ -149,8 +143,6 @@ Steps:
    - All SVG files under 50KB (larger files may not render inline on GitHub)
 3. Report findings as a numbered list: `[PASS]` or `[FAIL] — <what to fix>`
 4. Print total: `X passed, Y failed`
-
-Reference: `references/awesome-docs.md` → Quality Checklist, GitHub SVG Animation Constraints
 
 ---
 
@@ -170,8 +162,6 @@ Steps:
    - Windows: `start http://localhost:8080/<doc-path>`
    - Or paste `http://localhost:8080/<doc-path>` directly into your browser
 4. Tell the user: "Preview running at http://localhost:8080/<doc-path>. Press Ctrl+C to stop the server."
-
-Reference: `references/awesome-docs.md`
 
 ---
 
@@ -194,5 +184,3 @@ Steps:
      for f in assets/*.svg; do svgexport "$f" "${f%.svg}.png" 2x; done
      ```
    - Explain: "PNG export requires `svgexport` or Puppeteer. Install with `npm install -g svgexport` then run the command above."
-
-Reference: `references/awesome-docs.md` → Multi-Platform Export

--- a/commands/chaos.md
+++ b/commands/chaos.md
@@ -77,8 +77,6 @@ Steps:
    ```
    Expected: all pods Running
 
-Reference: `references/chaos.md` → Installation, Decision matrix
-
 ## Mode: experiment
 
 Generate a fault experiment from a description.
@@ -96,8 +94,6 @@ Steps:
 4. Output: experiment YAML + `kubectl apply` command + expected ChaosResult verdict
 
 See `examples/chaos/pod-delete-experiment.yaml` and `examples/chaos/network-loss-experiment.yaml` for complete examples.
-
-Reference: `references/chaos.md` → Fault taxonomy, Steady-state hypothesis, Litmus ChaosEngine structure, Chaos Mesh NetworkChaos structure
 
 ## Mode: schedule
 
@@ -158,8 +154,6 @@ Steps:
 
 3. Recommend staging only — never schedule experiments in production without a change window
 
-Reference: `references/chaos.md` → GitOps integration
-
 ## Mode: gameday
 
 Run a structured GameDay experiment.
@@ -190,9 +184,9 @@ Steps:
    - MTTR observed: time from fault injection to steady-state restoration
    - Recommendation: improve circuit breaker / HPA config / replica count / PDB
 
-Reference: `references/chaos.md` → Steady-state hypothesis, Blast radius scoping, DORA feedback loop
-
 ## Mode: debug
+
+If you need deeper context on troubleshooting, load `references/chaos.md`.
 
 Diagnose a failed or stuck experiment.
 
@@ -226,8 +220,6 @@ Checklist:
    | Experiment won't end | Missing duration | Add `duration: 60s` (Chaos Mesh) or `TOTAL_CHAOS_DURATION` (Litmus) |
    | Controller crashlooping | Version mismatch | Re-install matching chart version |
 
-Reference: `references/chaos.md` → Troubleshooting
-
 ## Mode: report
 
 Summarize experiment results after completion.
@@ -249,15 +241,6 @@ Steps:
    - Recovery time → MTTR observation
    - Feed into DORA `benchmark` mode: `/platform-skills:dora benchmark`
 
-Reference: `references/chaos.md` → DORA feedback loop
-
 ---
 
-## Closing — Log learnings
-
-After completing any chaos mode, log findings while context is fresh:
-
-- Wrong CRD field, incorrect label selector, or probe that always passed → log as `ERR` in `.learnings/ERRORS.md`
-- A fault pattern, probe approach, or blast radius scoping technique that worked → log as `LRN` in `.learnings/LEARNINGS.md`
-
-Use `/platform-skills:self-improve log` for each entry. Do not defer to end of session.
+After completing this task, log errors and learnings via `/platform-skills:self-improve log`.

--- a/commands/composite-actions.md
+++ b/commands/composite-actions.md
@@ -308,6 +308,23 @@ Evaluate and report findings in three tiers:
 - External `uses:` with mutable tag (`@v4`, `@main`, `@latest`) — supply chain risk
 - `run:` step missing `shell:` — error on many runners
 - `${{ inputs.* }}` interpolated directly in `run:` commands — injection risk
+
+**Input injection — safe vs unsafe:**
+
+```yaml
+# ❌ UNSAFE — input interpolated directly into shell, enables injection
+- name: Fetch data
+  run: curl https://example.com?token=${{ inputs.token }}
+
+# ✅ SAFE — input passed via env var, shell reads $TOKEN not the expression
+- name: Fetch data
+  env:
+    TOKEN: ${{ inputs.token }}
+  run: curl https://example.com?token=$TOKEN
+```
+
+This applies to ALL `run:` steps. Never interpolate `${{ inputs.* }}`, `${{ github.event.* }}`, or `${{ steps.*.outputs.* }}` directly into shell commands.
+
 - Secrets accessed via `${{ secrets.* }}` inside the action — always empty, silent failure
 
 **WARNING** (should fix)

--- a/commands/composite-actions.md
+++ b/commands/composite-actions.md
@@ -316,11 +316,11 @@ Evaluate and report findings in three tiers:
 - name: Fetch data
   run: curl https://example.com?token=${{ inputs.token }}
 
-# ✅ SAFE — input passed via env var, shell reads $TOKEN not the expression
+# ✅ SAFE — input passed via env var; always quote the variable to prevent word-splitting
 - name: Fetch data
   env:
     TOKEN: ${{ inputs.token }}
-  run: curl https://example.com?token=$TOKEN
+  run: curl "https://example.com?token=${TOKEN}"
 ```
 
 This applies to ALL `run:` steps. Never interpolate `${{ inputs.* }}`, `${{ github.event.* }}`, or `${{ steps.*.outputs.* }}` directly into shell commands.

--- a/commands/datadog.md
+++ b/commands/datadog.md
@@ -17,8 +17,6 @@ Steps:
 4. Provide verification commands: `kubectl exec -n datadog ds/datadog -- agent status`
 5. Add Unified Service Tagging labels (`DD_ENV`, `DD_SERVICE`, `DD_VERSION`) to app Deployment
 
-Reference: `references/datadog.md` → Agent Setup
-
 ## Mode: instrument
 
 Add APM tracing to a service.
@@ -29,8 +27,6 @@ Steps:
 3. Add Unified Service Tagging env vars to the Deployment manifest
 4. Add custom spans for business-critical paths (payment processing, order creation, etc.)
 5. Show expected APM UI outcome: service map entry, latency/error rate populated
-
-Reference: `references/datadog.md` → APM Instrumentation, Unified Service Tagging
 
 ## Mode: monitor
 
@@ -45,8 +41,6 @@ Steps:
 
 Output monitor query, thresholds, notification message with `@pagerduty-*` and `@slack-*` handles.
 
-Reference: `references/datadog.md` → Monitors, Terraform Monitor
-
 ## Mode: dashboard
 
 Create a Datadog dashboard for a service.
@@ -57,8 +51,6 @@ Steps:
 3. Use APM metrics: `trace.web.request.hits`, `trace.web.request.errors`, `trace.web.request` percentiles
 4. Add template variables for `env` and `service` for reuse across environments
 
-Reference: `references/datadog.md` → Dashboards
-
 ## Mode: slo
 
 Define a Datadog SLO.
@@ -68,8 +60,6 @@ Steps:
 2. Generate Terraform `datadog_service_level_objective` resource
 3. Set both target and warning thresholds
 4. Link SLO to relevant monitors for error budget burn alerts
-
-Reference: `references/datadog.md` → SLOs
 
 ## Mode: investigate
 
@@ -128,9 +118,9 @@ Post to #incidents: "orders-service error rate returning to baseline, fix deploy
 Create a Datadog notebook summarising the orders-service incident timeline.
 ```
 
-Reference: `references/datadog.md` → MCP Server Setup, Incident Investigation Workflow
-
 ## Mode: debug
+
+If you need deeper context on any Datadog component, load `references/datadog.md`.
 
 Diagnose Datadog data gaps or agent issues without the MCP server.
 
@@ -172,8 +162,6 @@ Steps:
 2. Generate the exact `pup` command with flags
 3. For scripting/gate use cases, generate a bash script using the scripting pattern from `references/datadog.md` → pup CLI
 4. Include jq expression to extract the value of interest from `--format json` output
-
-Reference: `references/datadog.md` → pup CLI
 
 ## Mode: llmo
 

--- a/commands/dora.md
+++ b/commands/dora.md
@@ -58,6 +58,16 @@ Steps:
 
 5. Warn: Change Failure Rate requires incident source integration — a rate of 0% without incident data is a configuration gap, not a real metric. Never report 0% CFR without confirmed incident source connectivity.
 
+**Validation:**
+```bash
+# Confirm Pushgateway received the metric
+curl -s http://pushgateway:9091/metrics | grep dora_deployment_timestamp
+
+# Confirm Prometheus scraped it (allow up to 1 scrape interval, default 15s)
+curl -s 'http://prometheus:9090/api/v1/query?query=dora_deployment_timestamp' \
+  | jq '.data.result[0].value[1] // "not yet scraped — wait 15s and retry"'
+```
+
 Reference: `references/dora.md` → Open-source instrumentation pattern
 
 ## Mode: dashboard
@@ -73,7 +83,7 @@ Steps:
 
    Verify with:
    ```bash
-   curl -s 'http://prometheus:9090/api/v1/query?query=dora:deployment_frequency:rate30d' | jq .
+   curl -s 'http://prometheus:9090/api/v1/query?query=dora:deployment_frequency:rate30d' | jq '.data.result[0].value[1] // "no data"'
    ```
    If any query returns no data, check the recording rule deployment — see `references/dora.md` for the full rule set.
 
@@ -105,10 +115,10 @@ Steps:
 1. Accept current metric values — either provided directly or queried from Prometheus:
    ```bash
    # Query current values
-   curl -s 'http://prometheus:9090/api/v1/query?query=dora:deployment_frequency:rate30d'
-   curl -s 'http://prometheus:9090/api/v1/query?query=dora:lead_time_seconds:p50'
-   curl -s 'http://prometheus:9090/api/v1/query?query=dora:change_failure_rate:ratio30d'
-   curl -s 'http://prometheus:9090/api/v1/query?query=dora:mttr_seconds:p50'
+   curl -s 'http://prometheus:9090/api/v1/query?query=dora:deployment_frequency:rate30d' | jq '.data.result[0].value[1] // "no data"'
+   curl -s 'http://prometheus:9090/api/v1/query?query=dora:lead_time_seconds:p50' | jq '.data.result[0].value[1] // "no data"'
+   curl -s 'http://prometheus:9090/api/v1/query?query=dora:change_failure_rate:ratio30d' | jq '.data.result[0].value[1] // "no data"'
+   curl -s 'http://prometheus:9090/api/v1/query?query=dora:mttr_seconds:p50' | jq '.data.result[0].value[1] // "no data"'
    ```
 
 2. Map each metric to Elite / High / Medium / Low using the 2023 DORA performance bands:
@@ -176,11 +186,4 @@ Reference: `references/dora.md` → Anti-pattern detection
 
 ---
 
-## Closing — Log learnings
-
-After completing any DORA mode, log findings while context is fresh:
-
-- Missing Pushgateway, broken webhook payload, or a CFR stuck at 0% → log as `ERR` in `.learnings/ERRORS.md`
-- A working instrumentation pattern, benchmark finding, or incident source integration approach → log as `LRN` in `.learnings/LEARNINGS.md`
-
-Use `/platform-skills:self-improve log` for each entry. Do not defer to end of session.
+After completing this task, log errors and learnings via `/platform-skills:self-improve log`.

--- a/commands/fluxcd.md
+++ b/commands/fluxcd.md
@@ -27,6 +27,11 @@ Determine which workflow applies from the input. If it is ambiguous, ask exactly
 
 ## Debug mode — live cluster issue
 
+> **Version check:** `flux --version` before proceeding.
+> - Flux v2.3+: use `flux bootstrap` (GitOps Toolkit) — this is the standard path.
+> - Flux Operator (v2.7+): use a `FluxInstance` CR instead. `flux bootstrap` is not used in Operator mode.
+> - If unsure: `kubectl get crd fluxinstances.fluxcd.io` — if this CRD exists, you are running Flux Operator.
+
 Use when something is broken or not reconciling on a live cluster. Invoke as `/platform-skills:gitops debug`.
 
 **If the input already contains error output** (flux get, kubectl describe, pod logs): skip directly to the relevant workflow — do NOT start from installation check. Match the error to the layer first:

--- a/commands/helmcheck.md
+++ b/commands/helmcheck.md
@@ -25,6 +25,10 @@ Enter 1–3 or mode name:
 - **review**: `Paste the chart directory listing or file content to review (or provide the chart path):`
 - **security**: `Paste the chart directory listing or file content to audit (or provide the chart path):`
 
+**Q3 — Container image?** (e.g., `myimage:1.0.0` — used to populate `image:` in the deployment template)
+
+**Q4 — Default namespace?** (default: `default` — change if this chart targets a specific namespace)
+
 Then proceed into the relevant mode below.
 
 ---
@@ -100,6 +104,17 @@ helm template myrelease <chart>/ --debug
 helm template myrelease <chart>/ | kubeconform -strict -summary
 ```
 
+**Validation:**
+```bash
+# Dry-run install to catch rendering errors
+helm install --dry-run myrelease <chart-dir>/
+
+# Validate rendered manifests against Kubernetes schemas
+helm template myrelease <chart-dir>/ | kubeconform -strict -summary
+
+# Both must pass with zero errors before committing the chart
+```
+
 ---
 
 ## Mode: review
@@ -109,7 +124,7 @@ Check the chart against this table and report findings grouped by severity:
 | Check | Severity |
 |-------|----------|
 | Missing `_helpers.tpl` | Critical |
-| No resource requests/limits | Critical |
+| No resource requests/limits | Critical | See fix below |
 | No liveness/readiness probes | High |
 | Hardcoded image tag in template | High |
 | Missing `app.kubernetes.io/*` labels | High |
@@ -120,6 +135,16 @@ Check the chart against this table and report findings grouped by severity:
 | `automountServiceAccountToken: true` | Medium |
 | Undocumented values.yaml keys | Low |
 | Deeply nested values (>3 levels) | Low |
+
+**Fix for missing resource requests/limits:** For each container missing resources, add:
+```yaml
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 256Mi  # Omit CPU limit — CPU throttling is preferable to OOMKill
+```
 
 Run validation and report:
 

--- a/commands/helmcheck.md
+++ b/commands/helmcheck.md
@@ -143,7 +143,7 @@ resources:
     cpu: 100m
     memory: 128Mi
   limits:
-    memory: 256Mi  # Omit CPU limit — CPU throttling is preferable to OOMKill
+    memory: 256Mi  # Set memory limit to prevent OOMKill; omit CPU limit to avoid throttling
 ```
 
 Run validation and report:

--- a/commands/karpenter.md
+++ b/commands/karpenter.md
@@ -6,9 +6,10 @@ argument-hint: "[generate|debug|review|audit|plan|migrate|upgrade] [description 
 
 Design, install, debug, review, plan capacity, audit, migrate, and upgrade Karpenter on EKS.
 
-# Verify current stable version before installing:
-helm search repo karpenter/karpenter --versions | head -5
-# Pin to the version from that output — do not use @latest in production
+# Verify current stable version before installing (Karpenter uses OCI, not a Helm repo):
+crane ls public.ecr.aws/karpenter/karpenter | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -5
+# Pin to the version from that output, e.g.:
+# helm upgrade --install karpenter oci://public.ecr.aws/karpenter/karpenter --version x.y.z
 
 All guidance targets the `karpenter.sh/v1` API. The v0.x `Provisioner`/`AWSNodeTemplate` API was removed in v1.0 — if you are on v0.x, use `migrate` mode first.
 

--- a/commands/karpenter.md
+++ b/commands/karpenter.md
@@ -6,7 +6,11 @@ argument-hint: "[generate|debug|review|audit|plan|migrate|upgrade] [description 
 
 Design, install, debug, review, plan capacity, audit, migrate, and upgrade Karpenter on EKS.
 
-All guidance targets **Karpenter v1.12.1** (latest stable, May 2026), `karpenter.sh/v1` API. The v0.x `Provisioner`/`AWSNodeTemplate` API was removed in v1.0 — if you are on v0.x, use `migrate` mode first.
+# Verify current stable version before installing:
+helm search repo karpenter/karpenter --versions | head -5
+# Pin to the version from that output — do not use @latest in production
+
+All guidance targets the `karpenter.sh/v1` API. The v0.x `Provisioner`/`AWSNodeTemplate` API was removed in v1.0 — if you are on v0.x, use `migrate` mode first.
 
 ---
 
@@ -62,6 +66,7 @@ Design a production-ready NodePool and EC2NodeClass from requirements.
 
 2. Generate `EC2NodeClass` with:
    - `amiSelectorTerms`: use `alias: al2023@latest` for dev/staging; use a **pinned AMI ID** (`id: ami-xxxx`) for production. Floating `@latest` in production means an untested AMI can land on fleet nodes during any scheduled SSM parameter update. Ask the user which environment this is for before choosing.
+   > Ask user: "What is your EKS cluster name?" — substitute into `karpenter.sh/discovery: <cluster-name>` before applying.
    - `subnetSelectorTerms` and `securityGroupSelectorTerms` using `karpenter.sh/discovery: <cluster-name>` tags
    - `instanceProfile` or `role` matching the Karpenter node IAM role
    - `blockDeviceMappings` with encrypted EBS and IMDSv2 enforced via `metadataOptions`
@@ -88,6 +93,8 @@ Design a production-ready NodePool and EC2NodeClass from requirements.
    ```
 
 Reference: `references/karpenter.md` → NodePool design, EC2NodeClass, IAM
+
+**Rollback:** `kubectl delete nodepool <name> && kubectl delete ec2nodeclass <name>` — Karpenter immediately stops provisioning nodes from these templates. Existing nodes remain until drained by the scheduler or TTL.
 
 ---
 
@@ -144,6 +151,8 @@ Diagnose why pods are stuck Pending or nodes are not provisioning.
 4. State the most likely root cause with the exact field or annotation to fix. Show the corrected spec section. Show the command to verify the fix worked.
 
 Reference: `references/karpenter.md` → Troubleshooting
+
+**Rollback:** If you edited NodePool/EC2NodeClass during debug: `kubectl apply -f <original-backup>.yaml` to restore. Always take a backup before editing: `kubectl get nodepool <name> -o yaml > nodepool-backup.yaml`.
 
 ---
 
@@ -404,6 +413,8 @@ Move a cluster from Cluster Autoscaler to Karpenter safely.
    - **Two scalers competing** — the window between CA scale-down and Karpenter taking over is the riskiest moment; keep CA at 0 replicas, not deleted, until Karpenter is confirmed healthy
 
 Reference: `references/karpenter.md` → Migration from Cluster Autoscaler
+
+**Rollback:** If drain was initiated: `kubectl uncordon <node>` re-admits workloads immediately. Delete the new NodePool/EC2NodeClass with `kubectl delete nodepool <name>`. Restore the original node group config in Terraform before running `terraform apply`.
 
 ---
 

--- a/commands/keda.md
+++ b/commands/keda.md
@@ -19,14 +19,14 @@ Steps:
    - `apiVersion: keda.sh/v1alpha1`
    - `scaleTargetRef.name` matching the exact Deployment/StatefulSet/Job name
    - `minReplicaCount: 0` only if the service can tolerate cold-start latency; otherwise `minReplicaCount: 1`
+
+> **Scale-to-zero warning:** Setting `minReplicaCount: 0` means the Deployment will have 0 replicas when the queue/metric is empty. Cold-start latency applies — confirm this is acceptable before enabling.
    - `pollingInterval` and `cooldownPeriod` sized to the workload pattern (see table in `references/keda.md`)
    - Trigger-specific `metadata` with `activationThreshold`/`activationQueueLength` set to avoid flapping on sparse events
    - `authenticationRef` pointing to a `TriggerAuthentication` — never inline credentials in the ScaledObject
    - For AWS: prefer IRSA (`podIdentity.provider: aws`) over static key/secret pairs
 4. Generate the companion `TriggerAuthentication` or `ClusterTriggerAuthentication`
 5. Show validation command: `kubectl describe scaledobject <name> -n <ns>` and the expected `Active: true` condition
-
-Reference: `references/keda.md` → ScaledObject, ScaledJob, TriggerAuthentication
 
 ## Mode: debug
 
@@ -57,7 +57,7 @@ Steps:
 5. State the most likely root cause with the exact field or resource to fix
 6. Show the corrected spec section and the command to verify it
 
-Reference: `references/keda.md` → Troubleshooting
+If you need deeper context on KEDA troubleshooting, scaling lifecycle, or scaler-specific behaviour, load `references/keda.md`.
 
 ## Mode: review
 
@@ -93,8 +93,6 @@ Separate findings into:
 - **Improvement** — should fix (tune cooldownPeriod, add activationThreshold)
 - **Note** — informational (consider IRSA, document cold-start expectations)
 
-Reference: `references/keda.md` → Security Patterns, Scaling Lifecycle
-
 ## Mode: scale
 
 Design the scaling strategy for a workload from requirements.
@@ -113,4 +111,4 @@ Steps:
 6. If multiple triggers are needed (e.g., queue depth + cron business hours), explain the OR-max semantics
 7. Output the complete ScaledObject, TriggerAuthentication, and IAM policy skeleton
 
-Reference: `references/keda.md` → KEDA vs HPA decision matrix, Scalers
+**Rollback:** `kubectl delete scaledobject <name> -n <namespace>` removes KEDA control and returns the Deployment to its last manual replica count (not zero — KEDA restores `spec.replicas` on deletion). Verify: `kubectl get deployment <name> -n <namespace> -o jsonpath='{.spec.replicas}'` should show the pre-KEDA replica count.

--- a/commands/keda.md
+++ b/commands/keda.md
@@ -111,4 +111,8 @@ Steps:
 6. If multiple triggers are needed (e.g., queue depth + cron business hours), explain the OR-max semantics
 7. Output the complete ScaledObject, TriggerAuthentication, and IAM policy skeleton
 
-**Rollback:** `kubectl delete scaledobject <name> -n <namespace>` removes KEDA control and returns the Deployment to its last manual replica count (not zero — KEDA restores `spec.replicas` on deletion). Verify: `kubectl get deployment <name> -n <namespace> -o jsonpath='{.spec.replicas}'` should show the pre-KEDA replica count.
+**Rollback:** `kubectl delete scaledobject <name> -n <namespace>` removes KEDA control. Replica behavior on deletion depends on configuration:
+- `advanced.restoreToOriginalReplicaCount: true` (explicit) → restores the pre-KEDA replica count
+- Default (not set) → leaves replicas at the last scaled value, which may be 0 if scale-to-zero was active
+
+Verify: `kubectl get deployment <name> -n <namespace> -o jsonpath='{.spec.replicas}'` — if replicas are 0, manually scale up: `kubectl scale deployment <name> -n <namespace> --replicas=<desired>`.

--- a/commands/linkerd.md
+++ b/commands/linkerd.md
@@ -62,7 +62,7 @@ Exact annotation, manifest change, or command. Show before/after for configurati
 
 **Validation (install/setup):** `linkerd check` — all checks must be green before proceeding. Any red check indicates a misconfiguration that will cause silent failures downstream.
 
-**Validation (mTLS / inject):** `linkerd viz edges deploy -n <namespace>` — every edge must show `tls: true`. An edge showing `tls: false` means the pod is not injected or the proxy is misconfigured.
+**Validation (mTLS / inject):** `linkerd viz edges deployment -n <namespace>` — every edge must show `tls: true`. An edge showing `tls: false` means the pod is not injected or the proxy is misconfigured.
 
 **Validation (multi-cluster):** `linkerd multicluster gateways` — each gateway must show `ALIVE: true`. Then verify cross-cluster traffic: `linkerd viz stat -n <namespace> deploy/<name> --from-namespace <remote-namespace>`.
 

--- a/commands/linkerd.md
+++ b/commands/linkerd.md
@@ -60,6 +60,12 @@ State the most likely cause. Common patterns:
 
 Exact annotation, manifest change, or command. Show before/after for configuration changes.
 
+**Validation (install/setup):** `linkerd check` — all checks must be green before proceeding. Any red check indicates a misconfiguration that will cause silent failures downstream.
+
+**Validation (mTLS / inject):** `linkerd viz edges deploy -n <namespace>` — every edge must show `tls: true`. An edge showing `tls: false` means the pod is not injected or the proxy is misconfigured.
+
+**Validation (multi-cluster):** `linkerd multicluster gateways` — each gateway must show `ALIVE: true`. Then verify cross-cluster traffic: `linkerd viz stat -n <namespace> deploy/<name> --from-namespace <remote-namespace>`.
+
 ## 5. Validation
 
 Commands to confirm the issue is resolved — specifically `linkerd viz edges` for mTLS, `linkerd check` for control plane, `linkerd multicluster gateways` for multi-cluster.

--- a/commands/linux.md
+++ b/commands/linux.md
@@ -50,6 +50,8 @@ Identify the topic from the input and apply the matching framework:
 4. For Kubernetes DNS: check CoreDNS pod health, test from inside a pod, review `ndots` and search domain behaviour
 5. Propose the fix with TTL and rollback considerations
 
+**Validation:** `dig @<resolver-ip> <domain> +short` — must return an IP. `dig @8.8.8.8 <domain> +short` confirms external resolution. Compare both; difference means split-horizon DNS or upstream issue.
+
 ### lb — Load Balancer (ALB / NLB / Ingress / Gateway API)
 1. Identify the layer (L4 vs L7) and whether the choice is correct for the protocol
 2. For health check failures: test the endpoint directly, check security group source rules, verify target registration
@@ -69,17 +71,23 @@ Identify the topic from the input and apply the matching framework:
 3. Check memory (`free -h`, `/proc/meminfo`) and CPU (`vmstat`, `mpstat`) if resource pressure is suspected
 4. Propose the fix and how to make it survive a reboot
 
+**Validation:** `ps aux --sort=-%cpu | head -10` — top CPU consumers. `cat /proc/<pid>/limits` verifies applied ulimits. `systemctl status <service>` confirms service is running after changes.
+
 ### disk — Disk and Filesystem
 1. Check both space (`df -hT`) and inodes (`df -i`) — inode exhaustion is often overlooked
 2. Find large files or directories with `du -sh` and `find`
 3. Identify the owning process if a file is deleted but space not freed (`lsof | grep deleted`)
 4. Propose cleanup or resize steps with blast radius noted
 
+**Validation:** `df -hT` — verify available space on the target filesystem. `lsblk -f` confirms mount points and filesystem types.
+
 ### network — Network Connectivity and Kernel Tuning
 1. Use the connectivity ladder: L3 (`ping`) → L4 (`nc -zv`) → L7 (`curl -v`)
 2. Check interface state (`ip addr`, `ip route`, `ss -tulnp`)
 3. For high-traffic services: review `net.core.somaxconn`, `tcp_max_syn_backlog`, and `ip_local_port_range`
 4. Provide `sysctl` commands and the `/etc/sysctl.d/` persist pattern
+
+**Validation:** `ss -tulnp | grep LISTEN` — confirms ports are listening as expected. `ip route show` verifies routing table. `ping -c3 <gateway-ip>` confirms L3 reachability.
 
 ### security-groups — Security Group / NSG Rules
 1. Map the traffic flow: source IP → SG on LB → SG on target → NACL (if any)

--- a/commands/mcp.md
+++ b/commands/mcp.md
@@ -21,6 +21,14 @@ Steps:
 8. Provide MCP Inspector test commands and expected responses
 9. Add deployment checklist (env vars, secrets, logging)
 
+**Validation:**
+```bash
+# Smoke-test the MCP server before connecting a host
+npx @modelcontextprotocol/inspector <your-server-command>
+# This opens an interactive inspector — verify: tools list, resources list, no startup errors
+# If the server is not discovered by the host, run /platform-skills:mcp debug
+```
+
 Reference: `references/mcp.md` → Protocol Fundamentals, TypeScript SDK, Python SDK
 
 ## Mode: review

--- a/commands/observability.md
+++ b/commands/observability.md
@@ -96,6 +96,10 @@ Steps:
 2. Write ramp-up → steady-state → ramp-down stages
 3. Set `thresholds` matching the SLO
 4. Add `check()` assertions on status code and response time
+
+> **Version check:** `k6 --version` — must be ≥ 1.0.0. k6 v0.x and v1.x have incompatible JavaScript API syntax.
+> Upgrade: `brew install k6` (macOS) or see https://grafana.com/docs/k6/latest/set-up/install-k6/ for other platforms.
+
 5. Run: `k6 run --out json=results.json load-test.js`
 6. Interpret results: p95/p99 latency, error rate, throughput achieved vs. thresholds
 

--- a/commands/opa.md
+++ b/commands/opa.md
@@ -52,7 +52,15 @@ Steps:
 4. Show the Conftest command to test the policy against sample input
 5. State CI placement: conftest runs **after `terraform validate`** and **before `terraform plan`** as a blocking gate — failing conftest must prevent plan from running
 
-Reference: `references/opa.md` → Rule Types, Input Shape, Rego v1 Syntax
+**Validation:** Test the policy against both a passing and a failing resource before deploying to CI:
+```bash
+# Should produce no output (policy passes)
+conftest test --policy <dir> <passing-resource.yaml>
+
+# Should produce a deny/warn message (policy fires)
+conftest test --policy <dir> <failing-resource.yaml>
+```
+Both must behave as expected. A policy that never fires on a failing resource is not enforcing anything.
 
 ## Mode: test
 
@@ -70,7 +78,12 @@ Steps:
 4. Write a helper function that builds the input fixture for each case — keep fixtures minimal and focused on the attributes the rule actually checks
 5. Run tests: `conftest verify --policy <dir>`
 
-Reference: `references/opa.md` → Unit Tests
+**Validation:** All tests must pass with zero skipped:
+```bash
+conftest verify --policy <dir>
+# Expected: PASS - X tests, 0 failures, 0 skipped
+# Skipped tests mean test fixtures are incomplete — fix before merging
+```
 
 ## Mode: validate
 
@@ -83,8 +96,6 @@ Steps:
 4. **Unit tests**: `conftest verify --policy <dir>` — all `*_test.rego` files must pass
 5. **Integration test** (if test data is available): `conftest test --policy <dir> <input-files>`
 6. Report: PASS or list each failing step with the exact error and the fix
-
-Reference: `references/opa.md` → Validation Pipeline, Regal
 
 ## Mode: explain
 
@@ -100,22 +111,26 @@ Steps:
 3. Show the input shape the rule expects — map each `input.<field>` to the resource attribute it reads
 4. Note any dependencies on `data.*` (external allow-lists or config)
 
-Reference: `references/opa.md` → Input Shape, Rego v1 Syntax
-
 ## Mode: debug
 
 Diagnose why a policy is not firing as expected.
 
 Steps:
-1. Collect: policy file, input file or `conftest parse <file>` output, and the `conftest test` or `conftest verify` output
-2. Check in order:
+1. Collect: policy file, input file, and the `conftest test` or `conftest verify` output
+2. Check input shape — extract only the paths the policy reads:
+   ```bash
+   # Extract every input.<path> reference from the policy
+   grep -oE 'input\.[a-zA-Z0-9_.[\]]+' <policy-file> | sort -u
+   # Build a targeted jq filter from those paths and run it
+   conftest parse <input-file> | jq '{field1: .<path1>, field2: .<path2>, ...}'
+   ```
+   Compare each extracted path against the parsed output. A missing or mismatched key is the most common cause of silent policy failures.
+3. Check in order:
    - **Namespace mismatch**: is the package name matching `--namespace` or `--all-namespaces`?
    - **Rule name**: does the rule start with `deny`, `warn`, or `violation`? Other names are silently ignored by Conftest
-   - **Input shape mismatch**: run `conftest parse <input-file>` and compare each `input.<path>` in the rule against the actual parsed structure
+   - **Input shape mismatch**: identified above in step 2
    - **Partial vs complete rule**: is the rule a set comprehension (`deny[msg]`) or a boolean? Conftest expects set comprehensions for message output
    - **`import rego.v1` missing**: without it, `if`, `in`, `contains` may not work as expected
    - **`some` missing**: iterating without `some` can cause unexpected behaviour in Rego v0 compatibility mode
-3. State the most likely root cause with the exact line to fix
-4. Show the corrected rule and how to verify it fires: `conftest test --policy <dir> <input>`
-
-Reference: `references/opa.md` → Troubleshooting
+4. State the most likely root cause with the exact line to fix
+5. Show the corrected rule and how to verify it fires: `conftest test --policy <dir> <input>`

--- a/commands/pr-review.md
+++ b/commands/pr-review.md
@@ -12,6 +12,28 @@ If no PR number or diff is provided, ask the user to paste the diff or provide `
 
 ---
 
+## Interactive Wizard (fires when no mode is specified)
+
+When invoked without a mode argument, ask:
+
+**Q1 — Review type?**
+```
+What type of review do you need?
+  1. cost       — estimate resource cost delta from infrastructure changes
+  2. drift      — compare values across dev / staging / prod environments
+  3. ownership  — identify ownerless or high-blast-radius resources
+  4. compliance — check against security and compliance frameworks
+  5. upgrade    — assess breaking changes and migration effort
+  6. rollback   — score reversibility and blast radius before merging
+  7. full       — run all six modes in sequence
+
+Enter 1–7 or mode name:
+```
+
+Then proceed into the selected mode.
+
+---
+
 ## Mode: cost
 
 Identify changes in the diff that will increase or decrease cloud spend.

--- a/commands/renovate.md
+++ b/commands/renovate.md
@@ -241,6 +241,22 @@ Apply `pinDigests` based on Q2:
 (remove `pinDigests` line if semver strategy chosen)
 
 `terraform`:
+
+> **WARNING — Terraform modules must never be automerged.** Module source updates change infrastructure blueprints and require human review. Add this rule to always override other automerge settings:
+> ```json
+> {
+>   "packageRules": [
+>     {
+>       "matchManagers": ["terraform"],
+>       "matchDepTypes": ["module"],
+>       "automerge": false,
+>       "labels": ["terraform-module", "requires-review"]
+>     }
+>   ]
+> }
+> ```
+> Place this rule **last** in your `packageRules` array — later rules take precedence in Renovate.
+
 ```json
 {
   "description": "Terraform providers — automerge minor/patch",

--- a/commands/runtime-security.md
+++ b/commands/runtime-security.md
@@ -72,8 +72,6 @@ EKS-specific note: if using Bottlerocket nodes, set `driver.kind: modern_ebpf` i
 
 GKE-specific note: COS nodes require `driver.kind: modern_ebpf`. GKE Autopilot does not support Falco (no DaemonSet scheduling).
 
-Reference: `references/runtime-security.md` → eBPF driver, Node OS compatibility
-
 ## Mode: rules
 
 Write and test custom Falco rules.
@@ -118,8 +116,6 @@ Steps:
          ...
    ```
 
-Reference: `references/runtime-security.md` → Rule syntax, Condition fields, Lists and macros
-
 ## Mode: alerts
 
 Configure Falcosidekick to route Falco alerts to Slack, webhooks, or other outputs.
@@ -153,9 +149,9 @@ Steps:
    ```
 4. Deduplication: set `slack.minimumpriority: warning` to suppress DEBUG/INFO noise
 
-Reference: `references/runtime-security.md` → Falcosidekick, Output types
-
 ## Mode: debug
+
+If you need deeper context on any Falco component, load `references/runtime-security.md`.
 
 Diagnose why a Falco rule is not firing.
 
@@ -185,8 +181,6 @@ Checklist (work through in order):
    kubectl exec -n falco daemonset/falco -- cat /etc/falco/falco_rules.yaml | grep -A3 "macro: <macro name>"
    kubectl exec -n falco daemonset/falco -- ls /etc/falco/rules.d/
    ```
-
-Reference: `references/runtime-security.md` → Troubleshooting
 
 ## Mode: harden
 
@@ -220,17 +214,22 @@ Steps:
          object.metadata.labels['security.platform/falco-alert'] != 'critical'
        message: "Deployment is flagged by a Falco critical alert and cannot be re-admitted. Remove the flag after remediation."
    ```
-4. Remediation workflow: fix the workload → remove the label → re-admit
+4. > **Important:** Kyverno blocks new pod admissions only — it does not terminate existing running pods that violate the policy. After applying the policy, manually identify and terminate flagged pods:
+> ```bash
+> # Find pods matching the label that triggered the alert
+> kubectl get pods -n <namespace> -l <label-key>=<label-value>
+> # Terminate with grace period to allow in-flight requests to drain
+> kubectl delete pod <name> -n <namespace> --grace-period=30
+> ```
 
-Reference: `references/runtime-security.md` → Kyverno bridge, `references/kyverno.md` → ValidatingPolicy
+5. Remediation workflow: fix the workload → remove the label → re-admit
+
+**Recovery:** If a Kyverno policy blocks a legitimate workload, remove the triggering label immediately:
+```bash
+kubectl label deployment <name> -n <namespace> security.platform/falco-alert-
+```
+The workload will be re-admitted on next rollout. Fix the underlying security issue, then re-apply the label to re-admit under policy enforcement.
 
 ---
 
-## Closing — Log learnings
-
-After completing any runtime-security mode, log findings while context is fresh:
-
-- Incorrect Falco field, wrong driver, or broken rule condition discovered → log as `ERR` in `.learnings/ERRORS.md`
-- A rule pattern, operator, or configuration approach that worked → log as `LRN` in `.learnings/LEARNINGS.md`
-
-Use `/platform-skills:self-improve log` for each entry. Do not defer to end of session.
+After completing this task, log errors and learnings via `/platform-skills:self-improve log`.

--- a/commands/self-improve.md
+++ b/commands/self-improve.md
@@ -344,6 +344,8 @@ Reference: `references/agent-self-improve.md` → Global vs project scope
 
 ---
 
+> Load this section only when the user has run `init` or explicitly enables proactive mode.
+
 ## Proactive Agent Protocols
 
 These protocols run automatically when the proactive agent pattern is active. No explicit mode is required.

--- a/commands/supply-chain.md
+++ b/commands/supply-chain.md
@@ -245,11 +245,4 @@ Reference: `references/supply-chain.md` → SLSA levels, slsa-github-generator
 
 ---
 
-## Closing — Log learnings
-
-After completing any supply-chain mode, log findings while context is fresh:
-
-- Incorrect action version, wrong flag, or broken reference discovered → log as `ERR` in `.learnings/ERRORS.md`
-- A pattern or approach that worked well → log as `LRN` in `.learnings/LEARNINGS.md`
-
-Use `/platform-skills:self-improve log` for each entry. Do not defer to end of session.
+After completing this task, log errors and learnings via `/platform-skills:self-improve log`.

--- a/commands/terraform.md
+++ b/commands/terraform.md
@@ -44,12 +44,25 @@ Walk through each gate in order. For each, state whether it would pass or fail b
 3. **`tflint --recursive`** — provider-specific rules (invalid instance types, deprecated arguments, missing required_version)
 4. **`tfsec . --minimum-severity HIGH`** or **`checkov -d . --framework terraform --compact`** — security misconfigurations
 
+   > **tfsec version note:** Flag syntax changed in v1.0+. Check with `tfsec --version`.
+   > - `< v1.0`: use `--minimum-severity HIGH`
+   > - `>= v1.0`: use `--severity HIGH`
+   > - Drop-in alternative: `trivy config . --severity HIGH`
+
 ## 2. Blast Radius
 
 - What cloud resources does this create, modify, or destroy?
 - Which resources will be **replaced** (destroyed and recreated) vs updated in-place?
 - What downstream systems depend on these resources?
 - What is the impact if this apply fails halfway?
+
+**Pre-merge validation:** Run against a test workspace before merging:
+```bash
+terraform workspace select <test-workspace>
+terraform plan -out=tfplan
+# Review the plan output for unexpected resource replacements (lines marked with -/+)
+# Any replacement of stateful resources (RDS, ElastiCache, EKS node group) requires explicit approval
+```
 
 ## 3. IAM and Security
 

--- a/commands/triage.md
+++ b/commands/triage.md
@@ -25,11 +25,10 @@ gh api repos/{owner}/{repo}/pulls/comments/<comment_id>
 # or for a PR issue comment:
 gh api repos/{owner}/{repo}/issues/comments/<comment_id>
 
-# Get the PR diff
-gh pr diff <pr_number>
-
-# Get the file the comment refers to (if it's a review comment with a path)
-# already available from the comment API response (.path field)
+# Get only the patch for the file the comment references (from .path field)
+# If the comment has no .path (issue comment), fall back to the full diff
+gh api repos/{owner}/{repo}/pulls/<pr_number>/files \
+  --jq '.[] | select(.filename == "<comment.path>") | .patch'
 ```
 
 For `--all`:
@@ -54,9 +53,22 @@ gh api graphql -f query='
 
 ---
 
-## Step 2 — Classify the comment
+## Step 2 — Verify HEAD, then classify
 
-Choose exactly one:
+**For file-scoped comments** (comment has a `.path` field): before classifying, check whether the flagged identifier still exists at HEAD:
+
+```bash
+# Get the HEAD SHA
+gh pr view <pr_number> --json headRefOid --jq '.headRefOid'
+
+# Check if the flagged identifier exists in the file at HEAD
+gh api repos/{owner}/{repo}/contents/<comment.path>?ref=<head_sha> \
+  --jq '.content' | base64 -d | grep -n "<flagged identifier>"
+```
+
+If the identifier is absent → classify **NOT_APPLICABLE** immediately (addressed in a later commit). Skip Steps 3–4 and go straight to the reply.
+
+**Then choose exactly one classification:**
 
 **ACTIONABLE_FIX** — a real problem in the changed files that must be fixed:
 - Wrong value, missing required field, broken reference or link

--- a/commands/triage.md
+++ b/commands/triage.md
@@ -26,9 +26,11 @@ gh api repos/{owner}/{repo}/pulls/comments/<comment_id>
 gh api repos/{owner}/{repo}/issues/comments/<comment_id>
 
 # Get only the patch for the file the comment references (from .path field)
-# If the comment has no .path (issue comment), fall back to the full diff
-gh api repos/{owner}/{repo}/pulls/<pr_number>/files \
-  --jq '.[] | select(.filename == "<comment.path>") | .patch'
+# --paginate handles PRs with >30 changed files
+# If the comment has no .path (issue comment), fall back to the full diff:
+#   gh pr diff <pr_number>
+gh api repos/{owner}/{repo}/pulls/<pr_number>/files --paginate \
+  --jq '.[] | select(.filename == "<comment.path>") | .patch // "binary or large diff — no patch available"'
 ```
 
 For `--all`:


### PR DESCRIPTION
## Summary

- **Token efficiency** — removed 30+ redundant per-mode `Reference:` citations across 8 files (datadog 8×, chaos 5×, runtime-security 5×, awesome-docs 6×, keda 4×); consolidated to one lazy citation in debug/explain mode per file. Scoped `conftest parse` in opa debug to policy-referenced paths only. Collapsed identical 8-line log-learnings blocks in chaos, dora, runtime-security, supply-chain to a single delegation line. Added conditional gate on self-improve proactive protocols section.

- **Safety gaps** — added rollback blocks to karpenter (generate/debug/migrate), keda (scale), and runtime-security (Kyverno admission-only warning + pod drain path). Blocked Terraform module automerge in renovate with an override `packageRules` rule. Added safe-vs-unsafe input injection example in composite-actions.

- **Missing validation** — added post-change verification to linkerd (check, viz edges, multicluster gateways), linux (dns/disk/network/process), dora (pushgateway + prometheus scrape), mcp (inspector smoke-test), opa (pass/fail conftest), helmcheck (dry-run + kubeconform), terraform (plan on test workspace).

- **Correctness** — added version guards to karpenter (helm chart), fluxcd (bootstrap vs operator), terraform (tfsec flag change v1.0+), observability (k6 ≥1.0). Added pr-review interactive mode wizard. Added helmcheck wizard Q3/Q4 (image, namespace). Fixed triage to use file-scoped diff, HEAD verification before classify, and consistent thread resolution across all comment types.

## Files changed

21 files under `commands/` — no skill metadata, examples, or references modified.

## Test plan

- [ ] Invoke each modified command in a real session and verify the new validation/rollback blocks are surfaced at the right step
- [ ] Confirm `conftest parse` in opa debug emits only scoped output (not full JSON)
- [ ] Confirm triage uses file-scoped diff for review comments with a `.path` field
- [ ] Confirm triage resolves INFORMATIONAL threads (consistent with ACTIONABLE_FIX / NOT_APPLICABLE)
- [ ] Run `bash tests/handbook-consistency.sh` to catch version/status/path check failures