### PR TITLE
fix(website): force dark mode — disable respectPrefersColorScheme

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -79,7 +79,7 @@ const config = {
       colorMode: {
         defaultMode: 'dark',
         disableSwitch: false,
-        respectPrefersColorScheme: true,
+        respectPrefersColorScheme: false,
       },
       navbar: {
         title: 'Platform Skills',


### PR DESCRIPTION
## Summary

- Sets `respectPrefersColorScheme: false` so dark mode is always the default regardless of the user's OS setting
- `defaultMode: 'dark'` was already set but `respectPrefersColorScheme: true` was overriding it for light-mode OS users

## Test plan

- [ ] Open site in a browser with OS set to light mode — should load dark