### PR TITLE
feat(website): redesign landing page with STAR usage scenarios

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -282,3 +282,206 @@
   color: var(--ifm-color-secondary-lightest);
   opacity: 0.7;
 }
+
+/* ── Problem statement section ─────────────────────────────────────── */
+.problem-section {
+  padding: 56px 24px;
+  background: rgba(239, 68, 68, 0.03);
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+[data-theme='dark'] .problem-section {
+  background: rgba(239, 68, 68, 0.04);
+}
+
+.problem-section__inner {
+  max-width: 900px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.problem-section__label {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: #ef4444;
+  margin-bottom: 16px;
+}
+
+.problem-section__heading {
+  font-size: clamp(22px, 3.5vw, 32px);
+  font-weight: 700;
+  line-height: 1.3;
+  margin-bottom: 36px;
+}
+
+.problem-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  margin-bottom: 36px;
+  text-align: left;
+}
+
+.problem-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.problem-item__icon {
+  font-size: 20px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.problem-item__text {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--ifm-color-secondary-darkest);
+}
+
+[data-theme='dark'] .problem-item__text {
+  color: var(--ifm-color-secondary-lightest);
+  opacity: 0.75;
+}
+
+.problem-section__resolution {
+  font-size: 16px;
+  line-height: 1.6;
+  max-width: 640px;
+  margin: 0 auto;
+  opacity: 0.85;
+}
+
+/* ── STAR scenario cards ────────────────────────────────────────────── */
+.star-section {
+  padding: 64px 24px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.star-section__label {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: var(--ifm-color-primary);
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.star-section__heading {
+  font-size: 28px;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.star-section__sub {
+  text-align: center;
+  font-size: 15px;
+  opacity: 0.6;
+  margin-bottom: 40px;
+}
+
+.star-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.star-card {
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 14px;
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.star-card:hover {
+  border-color: var(--ifm-color-primary);
+  transform: translateY(-2px);
+}
+
+.star-card__tag {
+  display: inline-block;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--ifm-color-primary);
+  background: rgba(167, 139, 250, 0.1);
+  border: 1px solid rgba(167, 139, 250, 0.25);
+  border-radius: 4px;
+  padding: 3px 8px;
+  align-self: flex-start;
+}
+
+.star-card__row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.star-card__row--action {
+  align-items: center;
+  background: rgba(167, 139, 250, 0.06);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin: 2px -4px;
+}
+
+.star-card__letter {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 800;
+  width: 18px;
+  flex-shrink: 0;
+  margin-top: 2px;
+  opacity: 0.35;
+  text-transform: uppercase;
+}
+
+.star-card__letter--action {
+  color: var(--ifm-color-primary);
+  opacity: 0.9;
+  margin-top: 0;
+}
+
+.star-card__letter--result {
+  color: #059669;
+  opacity: 0.9;
+}
+
+.star-card__content {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--ifm-color-secondary-darkest);
+}
+
+[data-theme='dark'] .star-card__content {
+  color: var(--ifm-color-secondary-lightest);
+  opacity: 0.75;
+}
+
+.star-card__command {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  background: none;
+  padding: 0;
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -17,8 +17,8 @@ function Hero() {
       </div>
       <h1 className="hero-section__title">Platform Skills</h1>
       <p className="hero-section__subtitle">
-        A production-grade field handbook for platform engineers — Kubernetes, GitOps, Terraform, AWS, and more.
-        Blast radius, validation steps, and rollback plan built in.
+        Your AI agent generates config. It doesn&apos;t know what breaks.
+        Platform Skills gives it the missing context — blast radius, validation steps, and rollback plan, built in.
       </p>
       <div className="hero-section__ctas">
         <Link className="button button--primary button--lg" to="/docs/kubernetes">
@@ -38,53 +38,95 @@ function Hero() {
   );
 }
 
-function BeforeAfter() {
-  const before = `spec:
-  containers:
-    - name: api-server
-      image: mycompany/api-server:latest   # ❌ unpinned
-      env:
-        - name: DATABASE_URL
-          value: "postgres://admin:password@db:5432/prod"  # ❌ hardcoded
-      # ❌ no securityContext, no resources, no probes`;
-
-  const after = `spec:
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
-  containers:
-    - name: api-server
-      image: mycompany/api-server:v1.4.2   # ✅ pinned
-      resources:
-        requests: { cpu: 100m, memory: 128Mi }
-        limits:   { memory: 512Mi }
-      readinessProbe:
-        httpGet: { path: /healthz/ready, port: 8080 }
-      securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-      env:
-        - name: DATABASE_URL
-          valueFrom:
-            secretKeyRef: { name: api-server-secrets, key: database-url }  # ✅`;
-
+function ProblemStatement() {
   return (
-    <section className="before-after">
-      <div className="before-after__label">See it in action</div>
-      <h2 className="before-after__heading">What platform-skills catches</h2>
-      <div className="before-after__grid">
-        <div className="before-after__header before-after__header--before">
-          Before — what ships without it
+    <section className="problem-section">
+      <div className="problem-section__inner">
+        <div className="problem-section__label">The problem</div>
+        <h2 className="problem-section__heading">
+          AI agents are great at writing YAML.<br />They&apos;re not great at knowing what happens next.
+        </h2>
+        <div className="problem-grid">
+          <div className="problem-item">
+            <div className="problem-item__icon">💥</div>
+            <div className="problem-item__text">Adds a CPU limit that throttles production at peak load</div>
+          </div>
+          <div className="problem-item">
+            <div className="problem-item__icon">🔓</div>
+            <div className="problem-item__text">Writes IAM policies with wildcards because it&apos;s &quot;simpler&quot;</div>
+          </div>
+          <div className="problem-item">
+            <div className="problem-item__icon">🕳️</div>
+            <div className="problem-item__text">No mention of what breaks if the change is wrong</div>
+          </div>
+          <div className="problem-item">
+            <div className="problem-item__icon">🤷</div>
+            <div className="problem-item__text">No validation steps. No rollback plan. Ships anyway.</div>
+          </div>
         </div>
-        <div className="before-after__header before-after__header--after">
-          After — what platform-skills flags
-        </div>
-        <div className="before-after__body">
-          <pre><code>{before}</code></pre>
-        </div>
-        <div className="before-after__body">
-          <pre><code>{after}</code></pre>
-        </div>
+        <p className="problem-section__resolution">
+          Platform Skills is a plugin that teaches your agent to think like a senior platform engineer —
+          not just generate, but reason.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+const STAR_SCENARIOS = [
+  {
+    tag: 'Security',
+    situation: 'A pipeline flags a CRITICAL CVE in your base image 30 minutes before a release window.',
+    task: 'Scan the image, understand blast radius, decide whether to block or accept risk with a documented exception.',
+    command: '/platform-skills:trivy image',
+    result: 'Severity-gated scan with exploitability context, a pre-filled .trivyignore entry with expiry date, and a go/no-go recommendation with rollback path if you ship.',
+  },
+  {
+    tag: 'Code Review',
+    situation: 'Copilot left 12 unresolved review threads on your PR. Release is blocked until they\'re cleared.',
+    task: 'Classify each comment, fix the real issues, reply to every thread, and resolve them — without missing one.',
+    command: '/platform-skills:triage --all 100',
+    result: 'Every thread triaged: ACTIONABLE ones fixed and committed, INFORMATIONAL ones answered, NOT_APPLICABLE ones closed with a reason. Summary table printed.',
+  },
+  {
+    tag: 'Infrastructure',
+    situation: 'Security asks if a Terraform change is safe to apply to production. You have 20 minutes.',
+    task: 'Scan against the actual plan (not just source), surface HIGH/CRITICAL findings, map them to SOC 2 controls.',
+    command: '/platform-skills:checkov plan',
+    result: 'Deep analysis against live state values, findings grouped by control, a .checkov.baseline diff showing what\'s new vs existing, and a one-line verdict: safe / needs fix / block.',
+  },
+];
+
+function StarScenarios() {
+  return (
+    <section className="star-section">
+      <div className="star-section__label">Real usage, real results</div>
+      <h2 className="star-section__heading">See it in a real situation</h2>
+      <p className="star-section__sub">
+        Every command follows the same pattern: understand the situation, take the right action, show the result.
+      </p>
+      <div className="star-cards">
+        {STAR_SCENARIOS.map((s) => (
+          <div className="star-card" key={s.command}>
+            <div className="star-card__tag">{s.tag}</div>
+            <div className="star-card__row">
+              <span className="star-card__letter">S</span>
+              <span className="star-card__content">{s.situation}</span>
+            </div>
+            <div className="star-card__row">
+              <span className="star-card__letter">T</span>
+              <span className="star-card__content">{s.task}</span>
+            </div>
+            <div className="star-card__row star-card__row--action">
+              <span className="star-card__letter star-card__letter--action">A</span>
+              <code className="star-card__command">{s.command}</code>
+            </div>
+            <div className="star-card__row">
+              <span className="star-card__letter star-card__letter--result">R</span>
+              <span className="star-card__content">{s.result}</span>
+            </div>
+          </div>
+        ))}
       </div>
     </section>
   );
@@ -126,7 +168,7 @@ const FEATURES = [
 function FeatureStrip() {
   return (
     <section className="feature-strip">
-      <h2 className="feature-strip__heading">Everything a platform team needs</h2>
+      <h2 className="feature-strip__heading">35+ commands. Every domain a platform team touches.</h2>
       <div className="feature-grid">
         {FEATURES.map((f) => (
           <div className="feature-tile" key={f.title}>
@@ -178,47 +220,16 @@ function InstallSection() {
   );
 }
 
-const COMMANDS = [
-  {
-    name: '/platform-skills:triage',
-    desc: 'Triages a PR comment from a bot or human reviewer — fetches via gh CLI, classifies it, applies the fix, posts a reply, and resolves the thread.',
-  },
-  {
-    name: '/platform-skills:checkov',
-    desc: 'Runs Checkov static and plan-level Terraform scanning with AI-generated fix mode. Supports AWS/Azure/GCP/EKS, private modules, SARIF output.',
-  },
-  {
-    name: '/platform-skills:karpenter',
-    desc: 'Diagnoses Karpenter node provisioning failures. Covers NodePool, NodeClaim, EC2NodeClass, spot interruptions — with blast radius and rollback plan.',
-  },
-];
-
-function CommandShowcase() {
-  return (
-    <section className="command-section">
-      <h2 className="command-section__heading">Slash commands that do real work</h2>
-      <div className="command-cards">
-        {COMMANDS.map((c) => (
-          <div className="command-card" key={c.name}>
-            <div className="command-card__name">{c.name}</div>
-            <div className="command-card__desc">{c.desc}</div>
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
-
 export default function Home(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout title={siteConfig.title} description={siteConfig.tagline}>
       <main>
         <Hero />
-        <BeforeAfter />
+        <ProblemStatement />
+        <StarScenarios />
         <FeatureStrip />
         <InstallSection />
-        <CommandShowcase />
       </main>
     </Layout>
   );


### PR DESCRIPTION
## Summary

- Replaces generic command cards with 3 STAR scenario cards (Security, Code Review, Infrastructure) — each card shows a real situation, the task, the exact command, and the outcome
- Adds a Problem Statement section between hero and scenarios — 4 concrete pain points AI agents cause without the plugin
- Sharpens hero subtitle to lead with the problem before the solution
- Updates feature strip heading to emphasise command count
- Removes the before/after YAML block (superseded by the richer STAR narratives)

## Test plan

- [ ] Build passes with no warnings
- [ ] STAR cards render correctly on dark mode
- [ ] Mobile: cards stack to single column