### PR TITLE
feat(helmcheck): interactive chart interview, 8 modes, Helm official best practices

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
         "kubernetes",
         "helm",
         "helm-chart",
-        "helmcheck",
+        "helmchart",
         "chart-lint",
         "docker",
         "containers",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -92,7 +92,7 @@
     "./commands/linux.md",
     "./commands/product.md",
     "./commands/compliance.md",
-    "./commands/helmcheck.md",
+    "./commands/helmchart.md",
     "./commands/mcp.md",
     "./commands/observability.md",
     "./commands/document.md",

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -25,7 +25,7 @@ Commands work in any conversation — type the slash command or describe your pr
 | [/platform-skills:gitops](#platform-skillsgitops) | Flux CD / Argo CD — debug live cluster issues or audit a GitOps repo |
 | [/platform-skills:linkerd](#platform-skillslinkerd) | Linkerd mTLS, injection, policy, multi-cluster |
 | [/platform-skills:linux](#platform-skillslinux) | Linux, DNS, load balancing, VPC/VNet, networking |
-| [/platform-skills:helmcheck](#platform-skillshelmcheck) | Helm chart scaffold, review, security audit |
+| [/platform-skills:helmchart](#platform-skillshelmchart) | Helm chart scaffold, review, security audit |
 | [/platform-skills:commit](#platform-skillscommit) | Conventional commit message generation |
 | [/platform-skills:observability](#platform-skillsobservability) | Instrument, alert, dashboard, load test, capacity |
 | [/platform-skills:opa](#platform-skillsopa) | OPA/Conftest Rego policy generate, test, validate |
@@ -462,12 +462,12 @@ General-purpose structured checklist when you don't know the topic. Classifies s
 
 ---
 
-## `/platform-skills:helmcheck`
+## `/platform-skills:helmchart`
 
 **What it does:** Three modes — scaffold a production-ready chart from scratch, review an existing chart for structural issues, or run a security audit.
 
 ```
-/platform-skills:helmcheck [create <workload-type> | review | security] [chart path or description]
+/platform-skills:helmchart [create <workload-type> | review | security] [chart path or description]
 ```
 
 ---
@@ -494,13 +494,13 @@ Generates a complete, production-ready Helm chart based on workload type.
 **Examples:**
 
 ```
-/platform-skills:helmcheck create web service for a Node.js REST API — needs ingress, HPA, and network policy
+/platform-skills:helmchart create web service for a Node.js REST API — needs ingress, HPA, and network policy
 ```
 ```
-/platform-skills:helmcheck create worker for a Python background job that reads from SQS — no inbound traffic
+/platform-skills:helmchart create worker for a Python background job that reads from SQS — no inbound traffic
 ```
 ```
-/platform-skills:helmcheck create stateful for PostgreSQL with PVC and headless service
+/platform-skills:helmchart create stateful for PostgreSQL with PVC and headless service
 ```
 
 ---
@@ -512,10 +512,10 @@ Checks a chart against a severity table. Reports Critical/High/Medium/Low findin
 **Checks include:** missing `_helpers.tpl`, no resource limits, no probes, hardcoded image tags, wrong label immutability, missing NOTES.txt, `automountServiceAccountToken: true`, undocumented values.
 
 ```
-/platform-skills:helmcheck review ./charts/orders-service
+/platform-skills:helmchart review ./charts/orders-service
 ```
 ```
-/platform-skills:helmcheck review — the chart has no liveness probes and I suspect the values.yaml has secrets hardcoded
+/platform-skills:helmchart review — the chart has no liveness probes and I suspect the values.yaml has secrets hardcoded
 ```
 
 ---
@@ -531,10 +531,10 @@ Full security audit across pod security, RBAC, network, and secrets.
 - Secrets: plaintext in values.yaml defaults, missing PDB
 
 ```
-/platform-skills:helmcheck security ./charts/payments-service
+/platform-skills:helmchart security ./charts/payments-service
 ```
 ```
-/platform-skills:helmcheck security — our chart runs as root and mounts the host docker socket, help me fix it
+/platform-skills:helmchart security — our chart runs as root and mounts the host docker socket, help me fix it
 ```
 
 ---
@@ -2276,7 +2276,7 @@ Reference: `commands/composite-actions.md`, `references/composite-actions.md`, a
 |---|---|
 | Error message, `flux get` output, pod logs, "not reconciling" | `/platform-skills:gitops debug` — 5-workflow debug |
 | Repo path, "audit", "review", "before merge", "is this correct" | `/platform-skills:gitops audit` — 6-phase audit |
-| Helm chart path, `Chart.yaml`, `values.yaml`, "helm", "chart" | `/platform-skills:helmcheck` — chart review |
+| Helm chart path, `Chart.yaml`, `values.yaml`, "helm", "chart" | `/platform-skills:helmchart` — chart review |
 | A manifest to review (Kustomization, HelmRelease, FluxInstance YAML) | `/platform-skills:review` — production-readiness check |
 
 **Examples:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,7 +237,7 @@ Follow this checklist when adding a net-new domain (e.g. a new command + referen
 ### 7. CI validation
 
 - [ ] `bash tests/validate-skill.sh` — all checks pass
-- [ ] `bash tests/validate-helmcheck.sh` — all checks pass
+- [ ] `bash tests/validate-helmchart.sh` — all checks pass
 - [ ] `bash tests/handbook-consistency.sh` — all checks pass
 - [ ] `bash tests/release-consistency.sh` — all checks pass
 - [ ] `bash tests/validate-ci.sh` — all checks pass

--- a/EDITOR_INTEGRATIONS.md
+++ b/EDITOR_INTEGRATIONS.md
@@ -332,7 +332,7 @@ Argo CD application is perpetually OutOfSync despite successful manual sync. Wha
 
 ---
 
-### helmcheck — Helm chart scaffold, review, security
+### helmchart — Helm chart scaffold, review, security
 
 **Create a new chart:**
 ```

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -155,7 +155,7 @@ See [COMMANDS.md](COMMANDS.md) for every command with modes and example prompts:
 | `checkov` | Terraform static and plan scanning, multi-cloud (AWS/Azure/GCP/EKS), pre-commit, fix mode |
 | `trivy` | Container image, fs, repo, SBOM, and cluster CVE scanning; severity gates; Trivy Operator |
 | `gitops` | Flux / Argo CD — `debug` live issues or `audit` a GitOps repo |
-| `helmcheck` | Scaffold, review, or security-audit a Helm chart |
+| `helmchart` | Scaffold, review, or security-audit a Helm chart |
 | `kyverno` | Generate, test, audit, or migrate Kyverno policies |
 | `opa` | Generate, test, or debug OPA/Conftest Rego policies |
 | `compliance` | SOC 2 gap analysis, control implementation, audit evidence |
@@ -181,7 +181,7 @@ See [COMMANDS.md](COMMANDS.md) for every command with modes and example prompts:
 | `awesome-docs` | Generate any animated Markdown doc (README, architecture guide, runbook, tutorial, RFC, post-mortem, or custom), convert existing Markdown, update/diff/audit diagrams, export |
 | `aws` | Generate or review CloudFront, WAF, Lambda@Edge, CloudFront Functions, and Firewall Manager patterns |
 | `composite-actions` | Scaffold, review, secure, debug, publish, and improve composite GitHub Actions |
-| `fluxcd` | FluxCD entry point — routes to `gitops debug`, `gitops audit`, `helmcheck`, or `review` based on input |
+| `fluxcd` | FluxCD entry point — routes to `gitops debug`, `gitops audit`, `helmchart`, or `review` based on input |
 | `renovate` | Generate renovate.json covering all dep file types in the repo, or emit a GHA validation workflow |
 | `setup-agents` | Scaffold multi-agent AI configs for any repo — generate, upgrade, add, or review existing agents |
 

--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -97,7 +97,7 @@ Slash commands are predefined Claude workflows. In Codex or Cursor, ask for the 
 | `/platform-skills:debug` | You have a platform symptom and want structured diagnosis |
 | `/platform-skills:gitops debug` | Flux or Argo CD live cluster issue — structured 5-workflow debug |
 | `/platform-skills:gitops audit` | Audit a Flux CD GitOps repo — 6-phase analysis, Critical/Warning/Info report |
-| `/platform-skills:helmcheck` | You want to create, review, or security-audit a Helm chart |
+| `/platform-skills:helmchart` | You want to create, review, or security-audit a Helm chart |
 | `/platform-skills:linkerd` | mTLS, proxy injection, or traffic policy issues |
 | `/platform-skills:linux` | DNS, load balancer, VPC connectivity, or kernel issue |
 | `/platform-skills:compliance` | SOC 2 gap analysis or Checkov remediation for Terraform |
@@ -130,7 +130,7 @@ Slash commands are predefined Claude workflows. In Codex or Cursor, ask for the 
 Invoke a command by typing it at the start of your message:
 
 ```text
-/platform-skills:helmcheck review
+/platform-skills:helmchart review
 
 apiVersion: v2
 name: payments-api

--- a/SKILL.md
+++ b/SKILL.md
@@ -153,7 +153,7 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:linux` — Linux administration, DNS, load balancing, VPC/VNet, and connectivity troubleshooting
 - `/platform-skills:product` — product thinking, friction audits, DevEx, RFC/ADR, incident updates, post-mortems
 - `/platform-skills:compliance` — SOC 2 gap analysis, control implementation, evidence collection, and Checkov remediation for Terraform
-- `/platform-skills:helmcheck` — Helm chart scaffolding, structural review, and security audit with full lint/validation pipeline
+- `/platform-skills:helmchart` — Helm chart scaffolding, structural review, and security audit with full lint/validation pipeline
 - `/platform-skills:mcp` — MCP server/client scaffolding, protocol review, and integration debugging
 - `/platform-skills:aws-profile` — discover, switch, and validate AWS profiles for MCP servers across VS Code and Claude Code
 - `/platform-skills:observability` — instrument services, build dashboards, write alerts, run load tests, plan capacity

--- a/commands/fluxcd.md
+++ b/commands/fluxcd.md
@@ -1,6 +1,6 @@
 ---
 name: fluxcd
-description: FluxCD entry point — routes to the right workflow based on what you need. Live cluster issue → structured 5-workflow debug trace. Repo health check → 6-phase audit (discovery, validation, API compliance, best practices, security). Helm chart review → helmcheck. Starts by asking one question to confirm the right mode.
+description: FluxCD entry point — routes to the right workflow based on what you need. Live cluster issue → structured 5-workflow debug trace. Repo health check → 6-phase audit (discovery, validation, API compliance, best practices, security). Helm chart review → helmchart. Starts by asking one question to confirm the right mode.
 argument-hint: "[describe your situation: a symptom, a repo path, or 'audit' / 'debug' / 'helm']"
 title: "Flux CD Command"
 sidebar_label: "fluxcd"
@@ -23,7 +23,7 @@ Determine which workflow applies from the input. If it is ambiguous, ask exactly
 |---|---|
 | An error message, `flux get` output, pod logs, or "not reconciling" | **Debug** → run `/platform-skills:gitops debug` |
 | A repo path, "audit", "review", "before merge", "is this correct" | **Audit** → run `/platform-skills:gitops audit` |
-| A Helm chart path, `Chart.yaml`, `values.yaml`, "helm", "chart" | **Helm** → run `/platform-skills:helmcheck` |
+| A Helm chart path, `Chart.yaml`, `values.yaml`, "helm", "chart" | **Helm** → run `/platform-skills:helmchart` |
 | A manifest to review (Kustomization, HelmRelease, FluxInstance YAML) | **Review** → run `/platform-skills:review` |
 
 ---

--- a/commands/helmchart.md
+++ b/commands/helmchart.md
@@ -1,9 +1,9 @@
 ---
-name: helmcheck
+name: helmchart
 description: Scaffold, lint, review, security-audit, test, and upgrade-verify Helm charts. Runs an interactive interview to build production-ready charts from scratch. Covers chart structure, values design, schema validation, kubeconform, helm diff, and multi-environment scaffolding. Use when asked to "create a helm chart", "lint my chart", "review my helm chart", "check helm security", "generate values schema", "run helm diff", or "add helm tests".
 argument-hint: "[create|lint|review|security|upgrade|schema|test|deps] [chart path]"
-title: "Helm Check Command"
-sidebar_label: "helmcheck"
+title: "Helm Chart Command"
+sidebar_label: "helmchart"
 custom_edit_url: null
 ---
 

--- a/commands/helmcheck.md
+++ b/commands/helmcheck.md
@@ -1,122 +1,313 @@
 ---
 name: helmcheck
-description: Scaffold, review, lint, and security-audit Helm charts. Runs helm lint --strict, template validation, and security checks. Covers chart structure, values design, template patterns, and dependency management.
-argument-hint: "[create <workload-type> | review | security] [chart path or description]"
+description: Scaffold, lint, review, security-audit, test, and upgrade-verify Helm charts. Runs an interactive interview to build production-ready charts from scratch. Covers chart structure, values design, schema validation, kubeconform, helm diff, and multi-environment scaffolding. Use when asked to "create a helm chart", "lint my chart", "review my helm chart", "check helm security", "generate values schema", "run helm diff", or "add helm tests".
+argument-hint: "[create|lint|review|security|upgrade|schema|test|deps] [chart path]"
 title: "Helm Check Command"
 sidebar_label: "helmcheck"
 custom_edit_url: null
 ---
 
----
-
-## Interactive Wizard (fires when $ARGUMENTS is empty)
-
-When invoked with no arguments, ask before proceeding:
-
-**Q1 — Mode?**
-```
-What do you need?
-  1. create   — scaffold a new production-ready Helm chart
-  2. review   — analyse an existing chart for structural and quality issues
-  3. security — audit a chart for security misconfigurations
-
-Enter 1–3 or mode name:
-```
-
-**Q2 — Details** (after mode selected, one at a time):
-- **create**: `What type of workload? (web-service / worker / cronjob / stateful)` then `Chart name?`
-- **review**: `Paste the chart directory listing or file content to review (or provide the chart path):`
-- **security**: `Paste the chart directory listing or file content to audit (or provide the chart path):`
-
-**Q3 — Container image?** (e.g., `myimage:1.0.0` — used to populate `image:` in the deployment template)
-
-**Q4 — Default namespace?** (default: `default` — change if this chart targets a specific namespace)
-
-Then proceed into the relevant mode below.
-
----
-
 You are a senior platform engineer specialising in Helm chart development and Kubernetes packaging.
 
-The input is: $ARGUMENTS
+Input: `$ARGUMENTS`
 
-Parse the first word as the mode:
-- `create` — scaffold a production-ready chart
-- `review` — analyse an existing chart for structural and quality issues
-- `security` — audit a chart for security misconfigurations
+Parse the first word as the mode. When `$ARGUMENTS` is empty, run the interactive wizard.
 
 ---
 
-## Mode: create
+## Interactive Wizard
 
-Identify the workload type from the arguments:
+**Q1 — What do you need?**
+```
+  1. create   — scaffold a new production-ready chart from scratch
+  2. lint     — lint an existing chart (helm lint + kubeconform + ct)
+  3. review   — structural and quality review of an existing chart
+  4. security — security audit (pod security, RBAC, network, secrets)
+  5. upgrade  — verify a helm upgrade is safe (diff + breaking changes)
+  6. schema   — generate values.schema.json from values.yaml
+  7. test     — scaffold or run helm test hooks
+  8. deps     — manage chart dependencies (add, update, verify)
 
-| Type | Resources |
-|------|-----------|
-| Web service | Deployment + Service + Ingress |
-| Worker | Deployment only (no Service) |
-| CronJob | CronJob + ServiceAccount |
-| Stateful | StatefulSet + PVC + Headless Service |
+Enter 1–8 or mode name:
+```
 
-Then produce in order:
+Go to the relevant mode section. For `create`, continue with the full interview below.
 
-### 1. Chart.yaml
+---
+
+## Mode: create — Chart Interview
+
+Ask these questions **one at a time**, in order. Stop and wait for each answer before asking the next.
+
+**Stage 1 — Identity**
+
+```
+Chart name? (e.g. api-server, worker, payment-service)
+```
+```
+One-line description of what this service does?
+```
+```
+Container image? (e.g. mycompany/api-server — tag will go in values.yaml)
+```
+```
+Which workload type?
+  1. web-service  — Deployment + Service + Ingress
+  2. worker       — Deployment only, no Service
+  3. cronjob      — CronJob + ServiceAccount
+  4. stateful     — StatefulSet + PVC + Headless Service
+```
+
+**Stage 2 — Runtime**
+
+```
+Container port? (default: 8080)
+```
+```
+Default replica count? (default: 2)
+```
+```
+Default namespace? (default: default)
+```
+
+**Stage 3 — Health checks** (skip for cronjob)
+
+```
+HTTP health check path? (default: /healthz)
+  Enter a path, or press Enter for default, or type "none" to skip probes
+```
+
+If a path is given, ask:
+```
+Separate readiness path? (press Enter to use the same path)
+```
+
+**Stage 4 — Ingress** (only for web-service)
+
+```
+Do you need an Ingress? (y/N)
+```
+If yes:
+```
+Ingress class? (e.g. nginx, traefik, alb — default: nginx)
+Hostname? (e.g. api.example.com)
+Path? (default: /)
+TLS? (y/N)
+```
+
+**Stage 5 — Autoscaling**
+
+```
+Do you need a HorizontalPodAutoscaler? (y/N)
+```
+If yes:
+```
+Min replicas? (default: 2)
+Max replicas? (default: 10)
+CPU target utilisation %? (default: 70)
+```
+
+**Stage 6 — Reliability**
+
+```
+Do you need a PodDisruptionBudget? (y/N — recommended for HA workloads)
+```
+If yes:
+```
+minAvailable? (default: 1)
+```
+
+```
+Do you need a NetworkPolicy? (y/N — recommended)
+```
+
+**Stage 7 — Storage** (only for stateful)
+
+```
+PVC storage class? (leave blank for cluster default)
+PVC size? (default: 10Gi)
+Mount path inside container? (default: /data)
+Access mode? (ReadWriteOnce / ReadWriteMany — default: ReadWriteOnce)
+```
+
+**Stage 8 — Secrets and config**
+
+```
+Does this service need environment variables from a Secret? (y/N)
+```
+If yes:
+```
+Use External Secrets Operator? (y/N)
+  y → scaffold ExternalSecret CRD
+  n → scaffold a placeholder Secret template with empty values
+```
+
+```
+Does this service need a ConfigMap? (y/N)
+```
+
+**Stage 9 — Multi-environment**
+
+```
+Scaffold multi-environment values files? (y/N)
+  y → creates values.yaml (base) + values-dev.yaml + values-prod.yaml
+```
+
+**Stage 10 — Schema and docs**
+
+```
+Generate values.schema.json? (y/N — enforces type and required-field validation at install time)
+Generate NOTES.txt with post-install instructions? (y/N)
+```
+
+Once all answers are collected, produce the full chart in one pass. Do not ask further questions.
+
+---
+
+## create — Output
+
+Produce all files in order. Every file must be complete and syntactically valid.
+
+### Chart.yaml
 
 ```yaml
 apiVersion: v2
 name: <chart-name>
-description: <one-line description>
+description: <description>
 type: application
 version: 0.1.0
 appVersion: "1.0.0"
 ```
 
-### 2. _helpers.tpl
+### _helpers.tpl
 
 Include all six standard helpers: `name`, `fullname`, `chart`, `labels`, `selectorLabels`, `serviceAccountName`.
-- `selectorLabels` must NOT include `app.kubernetes.io/version` — it is immutable after creation
-- Always `trunc 63 | trimSuffix "-"` on name fields
 
-### 3. values.yaml
+**selectorLabels must contain only:**
+- `app.kubernetes.io/name`
+- `app.kubernetes.io/instance`
 
-- Every key has an inline comment explaining purpose and type
+Never add `app.kubernetes.io/version` or `helm.sh/chart` to selectorLabels — these change on upgrade and will break the Deployment selector (immutable after creation).
+
+**Required labels (all resources):**
+- `app.kubernetes.io/name: {{ include "<chart>.name" . }}`
+- `app.kubernetes.io/instance: {{ .Release.Name }}`
+- `app.kubernetes.io/managed-by: {{ .Release.Service }}`
+- `helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}`
+
+**Optional labels:**
+- `app.kubernetes.io/version: {{ .Chart.AppVersion }}` — add to `labels`, never to `selectorLabels`
+
+Always `trunc 63 | trimSuffix "-"` on name fields.
+
+### values.yaml
+
+Follow Helm official best practices:
+- All keys start with a **lowercase letter**, use **camelCase** for multi-word names (e.g., `replicaCount`, `imagePullPolicy`)
+- Every key has an inline comment that **begins with the key name**: `# replicaCount is the number of pod replicas`
 - Default values must work without any override (`helm install . --generate-name` succeeds)
 - `image.tag: ""` — falls back to `.Chart.AppVersion` in template
-- `securityContext` defaults to hardened baseline (runAsNonRoot, readOnlyRootFilesystem, drop ALL)
-- `resources.requests` and `resources.limits` always present with sensible defaults
-- No cluster-specific values (registry URL, domain, storage class)
+- Prefer **flat structures** over deeply nested ones — nested values require existence checks at every level
+- Prefer **maps over lists** for values that users will override with `--set`
+- Quote all string values explicitly to avoid YAML type ambiguity
+- `securityContext` defaults: `runAsNonRoot: true`, `runAsUser: 1000`, `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`
+- `resources.requests` and `resources.limits` always present — include memory limit, omit CPU limit to avoid throttling
+- `imagePullPolicy: IfNotPresent` — never `Always` unless the chart requires it
+- `rbac.create: true` — boolean controlling whether RBAC resources are created
+- `serviceAccount.create: true` and `serviceAccount.name: ""` — name falls back to `fullname` template when empty
+- No cluster-specific values (registry URL, domain, storageClass)
+- Reflect all interview answers as togglable blocks (`enabled: true/false`)
 
-### 4. Core templates
+### Core templates
 
-- `deployment.yaml` — uses all values, probes, securityContext, resources
-- `service.yaml` — conditioned on workload type
-- `serviceaccount.yaml` — `automountServiceAccountToken: false` by default
+Follow Helm official best practices:
+- File names use **dashed notation**: `deployment.yaml`, `service-account.yaml`, not camelCase
+- One resource per file
+- Do NOT set `namespace:` in template metadata — namespace is passed via `--namespace` at install time
+- Use `{{ include "<chart>.labels" . | nindent N }}` for labels
+- Use `{{ include "<chart>.selectorLabels" . | nindent N }}` for pod selectors
+- Condition optional blocks on `.Values.<block>.enabled`
+- Never hardcode image tags — use `{{ .Values.image.tag | default .Chart.AppVersion }}`
+- `imagePullPolicy: {{ .Values.image.pullPolicy }}` — always from values
+- Reference secrets via `secretKeyRef`, never inline values
+- All defined templates must be namespaced: `{{- define "<chart>.fullname" }}` not `{{- define "fullname" }}`
 
-### 5. Optional templates (conditioned on `enabled: true`)
+### values.schema.json (if requested)
 
-- `ingress.yaml`
-- `hpa.yaml` — `autoscaling/v2`
-- `pdb.yaml` — `policy/v1`
-- `networkpolicy.yaml` — default-deny ingress + explicit allow
+Generate a JSON Schema draft-07 document covering all keys in values.yaml with:
+- `type` for every field
+- `required` array for fields with no safe default
+- `description` matching the values.yaml comment
 
-### 6. Validation pipeline
+### NOTES.txt (if requested)
+
+Include:
+- How to get the service URL (NodePort / LoadBalancer / Ingress)
+- Upgrade command
+- How to check rollout status
+
+### Validation pipeline
+
+Run after generating:
 
 ```bash
 helm lint <chart>/ --strict
-helm template myrelease <chart>/ --debug
+helm template myrelease <chart>/ --debug 2>&1 | head -50
 helm template myrelease <chart>/ | kubeconform -strict -summary
 ```
 
-**Validation:**
+---
+
+## Mode: lint
+
+Run the full linting pipeline on the chart at the provided path.
+
+**Step 1 — Bootstrap check**
+
 ```bash
-# Dry-run install to catch rendering errors
-helm install --dry-run myrelease <chart-dir>/
-
-# Validate rendered manifests against Kubernetes schemas
-helm template myrelease <chart-dir>/ | kubeconform -strict -summary
-
-# Both must pass with zero errors before committing the chart
+# Verify required tools
+helm version --short
+kubeconform --version 2>/dev/null || echo "kubeconform not installed — brew install kubeconform"
+ct version 2>/dev/null || echo "chart-testing not installed — brew install chart-testing"
 ```
+
+**Step 2 — helm lint**
+
+```bash
+helm lint <chart>/ --strict
+```
+
+**Step 3 — Template rendering**
+
+```bash
+helm template myrelease <chart>/ --debug 2>&1
+```
+
+**Step 4 — Schema validation**
+
+```bash
+# Validate rendered manifests against Kubernetes schemas
+helm template myrelease <chart>/ | kubeconform \
+  -strict \
+  -summary \
+  -kubernetes-version 1.30.0 \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+```
+
+**Step 5 — Chart testing lint** (if `ct` is available)
+
+```bash
+ct lint --chart-dirs . --charts <chart>/
+```
+
+**Step 6 — Helm docs check** (if `helm-docs` is available)
+
+```bash
+helm-docs --dry-run <chart>/
+```
+
+Report findings grouped by tool, with severity and exact line references.
 
 ---
 
@@ -127,33 +318,49 @@ Check the chart against this table and report findings grouped by severity:
 | Check | Severity |
 |-------|----------|
 | Missing `_helpers.tpl` | Critical |
-| No resource requests/limits | Critical | See fix below |
+| No resource requests/limits | Critical |
+| `namespace:` hardcoded in template metadata | High |
 | No liveness/readiness probes | High |
-| Hardcoded image tag in template | High |
-| Missing `app.kubernetes.io/*` labels | High |
+| Hardcoded image tag in template (not via values) | High |
+| Missing required labels (`app.kubernetes.io/name`, `instance`, `managed-by`, `helm.sh/chart`) | High |
 | `app.kubernetes.io/version` in selectorLabels | High |
+| Mutable labels in selectorLabels (breaks upgrades) | High |
+| `imagePullPolicy: Always` without justification | Medium |
+| `rbac.create` not a boolean or missing | Medium |
+| `serviceAccount.create` / `serviceAccount.name` pattern missing | Medium |
 | No `NOTES.txt` | Medium |
 | No `.helmignore` | Low |
 | Missing Chart.yaml fields (description, appVersion) | Medium |
 | `automountServiceAccountToken: true` | Medium |
-| Undocumented values.yaml keys | Low |
-| Deeply nested values (>3 levels) | Low |
+| Values keys not camelCase | Low |
+| Values comments don't start with key name | Low |
+| Deeply nested values (>3 levels) — prefer flat | Low |
+| Lists in values where maps would work | Low |
+| Unquoted string values in values.yaml | Low |
+| Undocumented values.yaml keys | Medium |
+| No `values.schema.json` | Medium |
+| Default values require cluster-specific knowledge | High |
+| Optional templates not gated on `enabled:` | Medium |
+| Template file names use camelCase instead of dashes | Low |
+| Multiple resources in one template file | Low |
+| Defined templates not namespaced with chart name | High |
 
-**Fix for missing resource requests/limits:** For each container missing resources, add:
+**Fix for missing resource requests/limits:**
 ```yaml
 resources:
   requests:
     cpu: 100m
     memory: 128Mi
   limits:
-    memory: 256Mi  # Set memory limit to prevent OOMKill; omit CPU limit to avoid throttling
+    memory: 256Mi  # omit CPU limit to avoid throttling
 ```
 
-Run validation and report:
+Run and include output:
 
 ```bash
 helm lint <chart>/ --strict
 helm template myrelease <chart>/ --debug 2>&1 | head -50
+helm template myrelease <chart>/ | kubeconform -strict -summary
 ```
 
 Output format:
@@ -166,14 +373,16 @@ HIGH:     <count>
 MEDIUM:   <count>
 LOW:      <count>
 
-[Finding] Severity: description + exact fix
+[CRITICAL] Missing resource limits on container <name>
+  Fix: add resources.requests and resources.limits to deployment.yaml
+  ...
 ```
 
 ---
 
 ## Mode: security
 
-Audit using this table:
+Audit using these tables:
 
 ### Pod Security
 
@@ -191,7 +400,7 @@ Audit using this table:
 
 | Check | Severity | Fix |
 |-------|----------|-----|
-| No dedicated ServiceAccount | Medium | Create one; do not use `default` |
+| No dedicated ServiceAccount | Medium | Create one; do not use `default` SA |
 | `automountServiceAccountToken: true` | Medium | Set to `false` unless pod needs K8s API access |
 | ClusterRole instead of Role | Medium | Use namespace-scoped Role unless cluster-wide is justified |
 | Wildcard verbs or resources | Critical | Use explicit verbs and resource names |
@@ -205,6 +414,7 @@ Audit using this table:
 | No PodDisruptionBudget | Medium | Add PDB with `minAvailable: 1` for HA workloads |
 | `hostNetwork: true` | High | Remove unless required (e.g., CNI plugin) |
 | `hostPID: true` or `hostIPC: true` | Critical | Never in application charts |
+| Image tag `latest` or mutable | High | Pin to a digest or explicit version |
 
 Output format:
 
@@ -216,5 +426,175 @@ HIGH:     <count>
 MEDIUM:   <count>
 LOW:      <count>
 
-[Finding] Severity: exact problem + remediation with corrected YAML snippet
+[CRITICAL] <finding>: exact problem
+  Fix: corrected YAML snippet
 ```
+
+---
+
+## Mode: upgrade
+
+Verify a Helm upgrade is safe before applying it.
+
+**Step 1 — Check helm-diff is installed**
+
+```bash
+helm plugin list | grep diff || helm plugin install https://github.com/databus23/helm-diff
+```
+
+**Step 2 — Render diff**
+
+```bash
+helm diff upgrade <release> <chart>/ \
+  --values values.yaml \
+  --allow-unreleased
+```
+
+**Step 3 — Breaking change checks**
+
+Scan the diff output for:
+
+| Pattern | Risk | Action |
+|---------|------|--------|
+| `selector:` changed on Deployment/StatefulSet | Critical — will fail | Rename release or delete + recreate |
+| `storageClassName` changed on PVC | Critical | Manual migration required |
+| `kind:` changed (e.g. Deployment → StatefulSet) | Critical | Delete old resource first |
+| `ServiceAccount` name changed | High | Old RBAC bindings become orphaned |
+| `ConfigMap` or `Secret` removed | High | Verify no pods still reference them |
+| Resource limits decreased >50% | Medium | Risk of OOMKill on rollout |
+| Replica count → 1 | Medium | HA gap during rollout |
+
+**Step 4 — Dry run**
+
+```bash
+helm upgrade --dry-run <release> <chart>/ --values values.yaml
+```
+
+**Step 5 — Rollback plan**
+
+Always print:
+
+```bash
+# Rollback to previous revision if upgrade fails
+helm rollback <release> 0   # 0 = previous revision
+helm status <release>
+```
+
+---
+
+## Mode: schema
+
+Generate a `values.schema.json` from an existing `values.yaml`.
+
+Read the values.yaml and produce a JSON Schema draft-07 document that:
+- Infers `type` from the YAML value (`string`, `integer`, `boolean`, `object`, `array`)
+- Sets `description` from inline comments (if present)
+- Marks keys without a safe default as `required`
+- Validates enum fields where the comment lists allowed values (e.g. `# one of: debug, info, warn, error`)
+- Uses `$defs` for repeated shapes
+
+Write the file as `<chart>/values.schema.json`.
+
+Validate it immediately:
+
+```bash
+helm lint <chart>/ --strict
+# helm lint runs schema validation automatically — any mismatch is reported
+```
+
+---
+
+## Mode: test
+
+Scaffold or run Helm test hooks.
+
+**If no test files exist** — scaffold `templates/tests/test-connection.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "<chart>.fullname" . }}-test-connection"
+  labels:
+    {{- include "<chart>.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "<chart>.fullname" . }}:{{ .Values.service.port }}{{ .Values.healthCheck.path | default "/healthz" }}']
+```
+
+**If test files exist** — run them:
+
+```bash
+# Install the chart first if not already installed
+helm install myrelease <chart>/ --generate-name --wait
+
+# Run tests
+helm test <release>
+
+# Show logs on failure
+helm test <release> --logs
+```
+
+---
+
+## Mode: deps
+
+Manage chart dependencies declared in `Chart.yaml`.
+
+**List declared dependencies:**
+
+```bash
+helm dependency list <chart>/
+```
+
+**Add a dependency** — ask:
+```
+Dependency name? (e.g. postgresql, redis)
+Repository URL? (e.g. https://charts.bitnami.com/bitnami)
+Version constraint? (e.g. 13.x.x)
+Alias? (optional — useful if adding same chart twice)
+```
+
+Then add to `Chart.yaml` under `dependencies:` and run:
+
+```bash
+helm dependency update <chart>/
+helm dependency build <chart>/
+```
+
+**Verify integrity:**
+
+```bash
+helm dependency list <chart>/
+# All entries should show "ok" in the Status column
+```
+
+**Update all to latest matching constraint:**
+
+```bash
+helm dependency update <chart>/
+```
+
+After any dependency change, re-run lint:
+
+```bash
+helm lint <chart>/ --strict
+```
+
+---
+
+## Closing — Log learnings
+
+After completing any mode, log non-obvious fixes or patterns:
+
+- Unexpected breaking change found during upgrade → log as `ERR` in `.learnings/ERRORS.md`
+- Reusable pattern that saved time → log as `LRN` in `.learnings/LEARNINGS.md`
+
+Use `/platform-skills:self-improve log` for each entry worth keeping.

--- a/skills/platform-skills/SKILL.md
+++ b/skills/platform-skills/SKILL.md
@@ -153,7 +153,7 @@ For explicit, repeatable workflows use these commands:
 - `/platform-skills:linux` — Linux administration, DNS, load balancing, VPC/VNet, and connectivity troubleshooting
 - `/platform-skills:product` — product thinking, friction audits, DevEx, RFC/ADR, incident updates, post-mortems
 - `/platform-skills:compliance` — SOC 2 gap analysis, control implementation, evidence collection, and Checkov remediation for Terraform
-- `/platform-skills:helmcheck` — Helm chart scaffolding, structural review, and security audit with full lint/validation pipeline
+- `/platform-skills:helmchart` — Helm chart scaffolding, structural review, and security audit with full lint/validation pipeline
 - `/platform-skills:mcp` — MCP server/client scaffolding, protocol review, and integration debugging
 - `/platform-skills:aws-profile` — discover, switch, and validate AWS profiles for MCP servers across VS Code and Claude Code
 - `/platform-skills:observability` — instrument services, build dashboards, write alerts, run load tests, plan capacity

--- a/website/sidebars-commands.js
+++ b/website/sidebars-commands.js
@@ -8,7 +8,7 @@ const sidebars = {
       type: 'category',
       label: 'Kubernetes',
       items: [
-        { type: 'doc', id: 'helmcheck' },
+        { type: 'doc', id: 'helmchart' },
         { type: 'doc', id: 'keda' },
         { type: 'doc', id: 'karpenter' },
       ],

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -282,3 +282,206 @@
   color: var(--ifm-color-secondary-lightest);
   opacity: 0.7;
 }
+
+/* ── Problem statement section ─────────────────────────────────────── */
+.problem-section {
+  padding: 56px 24px;
+  background: rgba(239, 68, 68, 0.03);
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+[data-theme='dark'] .problem-section {
+  background: rgba(239, 68, 68, 0.04);
+}
+
+.problem-section__inner {
+  max-width: 900px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.problem-section__label {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: #ef4444;
+  margin-bottom: 16px;
+}
+
+.problem-section__heading {
+  font-size: clamp(22px, 3.5vw, 32px);
+  font-weight: 700;
+  line-height: 1.3;
+  margin-bottom: 36px;
+}
+
+.problem-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+  margin-bottom: 36px;
+  text-align: left;
+}
+
+.problem-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.problem-item__icon {
+  font-size: 20px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.problem-item__text {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--ifm-color-secondary-darkest);
+}
+
+[data-theme='dark'] .problem-item__text {
+  color: var(--ifm-color-secondary-lightest);
+  opacity: 0.75;
+}
+
+.problem-section__resolution {
+  font-size: 16px;
+  line-height: 1.6;
+  max-width: 640px;
+  margin: 0 auto;
+  opacity: 0.85;
+}
+
+/* ── STAR scenario cards ────────────────────────────────────────────── */
+.star-section {
+  padding: 64px 24px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.star-section__label {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: var(--ifm-color-primary);
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.star-section__heading {
+  font-size: 28px;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.star-section__sub {
+  text-align: center;
+  font-size: 15px;
+  opacity: 0.6;
+  margin-bottom: 40px;
+}
+
+.star-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.star-card {
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 14px;
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.star-card:hover {
+  border-color: var(--ifm-color-primary);
+  transform: translateY(-2px);
+}
+
+.star-card__tag {
+  display: inline-block;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--ifm-color-primary);
+  background: rgba(167, 139, 250, 0.1);
+  border: 1px solid rgba(167, 139, 250, 0.25);
+  border-radius: 4px;
+  padding: 3px 8px;
+  align-self: flex-start;
+}
+
+.star-card__row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.star-card__row--action {
+  align-items: center;
+  background: rgba(167, 139, 250, 0.06);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin: 2px -4px;
+}
+
+.star-card__letter {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 800;
+  width: 18px;
+  flex-shrink: 0;
+  margin-top: 2px;
+  opacity: 0.35;
+  text-transform: uppercase;
+}
+
+.star-card__letter--action {
+  color: var(--ifm-color-primary);
+  opacity: 0.9;
+  margin-top: 0;
+}
+
+.star-card__letter--result {
+  color: #059669;
+  opacity: 0.9;
+}
+
+.star-card__content {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--ifm-color-secondary-darkest);
+}
+
+[data-theme='dark'] .star-card__content {
+  color: var(--ifm-color-secondary-lightest);
+  opacity: 0.75;
+}
+
+.star-card__command {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  background: none;
+  padding: 0;
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -17,8 +17,8 @@ function Hero() {
       </div>
       <h1 className="hero-section__title">Platform Skills</h1>
       <p className="hero-section__subtitle">
-        A production-grade field handbook for platform engineers — Kubernetes, GitOps, Terraform, AWS, and more.
-        Blast radius, validation steps, and rollback plan built in.
+        Your AI agent generates config. It doesn&apos;t know what breaks.
+        Platform Skills gives it the missing context — blast radius, validation steps, and rollback plan, built in.
       </p>
       <div className="hero-section__ctas">
         <Link className="button button--primary button--lg" to="/docs/kubernetes">
@@ -38,53 +38,95 @@ function Hero() {
   );
 }
 
-function BeforeAfter() {
-  const before = `spec:
-  containers:
-    - name: api-server
-      image: mycompany/api-server:latest   # ❌ unpinned
-      env:
-        - name: DATABASE_URL
-          value: "postgres://admin:password@db:5432/prod"  # ❌ hardcoded
-      # ❌ no securityContext, no resources, no probes`;
-
-  const after = `spec:
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
-  containers:
-    - name: api-server
-      image: mycompany/api-server:v1.4.2   # ✅ pinned
-      resources:
-        requests: { cpu: 100m, memory: 128Mi }
-        limits:   { memory: 512Mi }
-      readinessProbe:
-        httpGet: { path: /healthz/ready, port: 8080 }
-      securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-      env:
-        - name: DATABASE_URL
-          valueFrom:
-            secretKeyRef: { name: api-server-secrets, key: database-url }  # ✅`;
-
+function ProblemStatement() {
   return (
-    <section className="before-after">
-      <div className="before-after__label">See it in action</div>
-      <h2 className="before-after__heading">What platform-skills catches</h2>
-      <div className="before-after__grid">
-        <div className="before-after__header before-after__header--before">
-          Before — what ships without it
+    <section className="problem-section">
+      <div className="problem-section__inner">
+        <div className="problem-section__label">The problem</div>
+        <h2 className="problem-section__heading">
+          AI agents are great at writing YAML.<br />They&apos;re not great at knowing what happens next.
+        </h2>
+        <div className="problem-grid">
+          <div className="problem-item">
+            <div className="problem-item__icon">💥</div>
+            <div className="problem-item__text">Adds a CPU limit that throttles production at peak load</div>
+          </div>
+          <div className="problem-item">
+            <div className="problem-item__icon">🔓</div>
+            <div className="problem-item__text">Writes IAM policies with wildcards because it&apos;s &quot;simpler&quot;</div>
+          </div>
+          <div className="problem-item">
+            <div className="problem-item__icon">🕳️</div>
+            <div className="problem-item__text">No mention of what breaks if the change is wrong</div>
+          </div>
+          <div className="problem-item">
+            <div className="problem-item__icon">🤷</div>
+            <div className="problem-item__text">No validation steps. No rollback plan. Ships anyway.</div>
+          </div>
         </div>
-        <div className="before-after__header before-after__header--after">
-          After — what platform-skills flags
-        </div>
-        <div className="before-after__body">
-          <pre><code>{before}</code></pre>
-        </div>
-        <div className="before-after__body">
-          <pre><code>{after}</code></pre>
-        </div>
+        <p className="problem-section__resolution">
+          Platform Skills is a plugin that teaches your agent to think like a senior platform engineer —
+          not just generate, but reason.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+const STAR_SCENARIOS = [
+  {
+    tag: 'Security',
+    situation: 'A pipeline flags a CRITICAL CVE in your base image 30 minutes before a release window.',
+    task: 'Scan the image, understand blast radius, decide whether to block or accept risk with a documented exception.',
+    command: '/platform-skills:trivy image',
+    result: 'Severity-gated scan with exploitability context, a pre-filled .trivyignore entry with expiry date, and a go/no-go recommendation with rollback path if you ship.',
+  },
+  {
+    tag: 'Code Review',
+    situation: 'Copilot left 12 unresolved review threads on your PR. Release is blocked until they\'re cleared.',
+    task: 'Classify each comment, fix the real issues, reply to every thread, and resolve them — without missing one.',
+    command: '/platform-skills:triage --all 100',
+    result: 'Every thread triaged: ACTIONABLE ones fixed and committed, INFORMATIONAL ones answered, NOT_APPLICABLE ones closed with a reason. Summary table printed.',
+  },
+  {
+    tag: 'Infrastructure',
+    situation: 'Security asks if a Terraform change is safe to apply to production. You have 20 minutes.',
+    task: 'Scan against the actual plan (not just source), surface HIGH/CRITICAL findings, map them to SOC 2 controls.',
+    command: '/platform-skills:checkov plan',
+    result: 'Deep analysis against live state values, findings grouped by control, a .checkov.baseline diff showing what\'s new vs existing, and a one-line verdict: safe / needs fix / block.',
+  },
+];
+
+function StarScenarios() {
+  return (
+    <section className="star-section">
+      <div className="star-section__label">Real usage, real results</div>
+      <h2 className="star-section__heading">See it in a real situation</h2>
+      <p className="star-section__sub">
+        Every command follows the same pattern: understand the situation, take the right action, show the result.
+      </p>
+      <div className="star-cards">
+        {STAR_SCENARIOS.map((s) => (
+          <div className="star-card" key={s.command}>
+            <div className="star-card__tag">{s.tag}</div>
+            <div className="star-card__row">
+              <span className="star-card__letter">S</span>
+              <span className="star-card__content">{s.situation}</span>
+            </div>
+            <div className="star-card__row">
+              <span className="star-card__letter">T</span>
+              <span className="star-card__content">{s.task}</span>
+            </div>
+            <div className="star-card__row star-card__row--action">
+              <span className="star-card__letter star-card__letter--action">A</span>
+              <code className="star-card__command">{s.command}</code>
+            </div>
+            <div className="star-card__row">
+              <span className="star-card__letter star-card__letter--result">R</span>
+              <span className="star-card__content">{s.result}</span>
+            </div>
+          </div>
+        ))}
       </div>
     </section>
   );
@@ -126,7 +168,7 @@ const FEATURES = [
 function FeatureStrip() {
   return (
     <section className="feature-strip">
-      <h2 className="feature-strip__heading">Everything a platform team needs</h2>
+      <h2 className="feature-strip__heading">35+ commands. Every domain a platform team touches.</h2>
       <div className="feature-grid">
         {FEATURES.map((f) => (
           <div className="feature-tile" key={f.title}>
@@ -178,47 +220,16 @@ function InstallSection() {
   );
 }
 
-const COMMANDS = [
-  {
-    name: '/platform-skills:triage',
-    desc: 'Triages a PR comment from a bot or human reviewer — fetches via gh CLI, classifies it, applies the fix, posts a reply, and resolves the thread.',
-  },
-  {
-    name: '/platform-skills:checkov',
-    desc: 'Runs Checkov static and plan-level Terraform scanning with AI-generated fix mode. Supports AWS/Azure/GCP/EKS, private modules, SARIF output.',
-  },
-  {
-    name: '/platform-skills:karpenter',
-    desc: 'Diagnoses Karpenter node provisioning failures. Covers NodePool, NodeClaim, EC2NodeClass, spot interruptions — with blast radius and rollback plan.',
-  },
-];
-
-function CommandShowcase() {
-  return (
-    <section className="command-section">
-      <h2 className="command-section__heading">Slash commands that do real work</h2>
-      <div className="command-cards">
-        {COMMANDS.map((c) => (
-          <div className="command-card" key={c.name}>
-            <div className="command-card__name">{c.name}</div>
-            <div className="command-card__desc">{c.desc}</div>
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
-
 export default function Home(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout title={siteConfig.title} description={siteConfig.tagline}>
       <main>
         <Hero />
-        <BeforeAfter />
+        <ProblemStatement />
+        <StarScenarios />
         <FeatureStrip />
         <InstallSection />
-        <CommandShowcase />
       </main>
     </Layout>
   );


### PR DESCRIPTION
## Summary

Complete rewrite of `/platform-skills:helmcheck` — from 3 modes to 8, with a full interactive interview for chart creation.

**New modes:**
- `create` — 10-stage interview (identity, runtime, health checks, ingress, HPA, PDB, storage, secrets, multi-env, schema/docs) before scaffolding
- `lint` — dedicated lint pipeline: helm lint → template render → kubeconform (with CRD schema URL) → chart-testing → helm-docs
- `upgrade` — helm-diff + breaking change detection table (selector changes, PVC storageClass, kind changes) + rollback plan
- `schema` — generate `values.schema.json` from existing values.yaml
- `test` — scaffold or run helm test hooks
- `deps` — add, update, verify chart dependencies

**Existing modes improved:**
- `review` — 27 checks (was 12), now includes official Helm best-practice violations
- `security` — added image tag mutability check

**Aligned with https://helm.sh/docs/chart_best_practices/:**
- camelCase values keys, comments start with key name
- Flat over nested, maps over lists, quoted strings
- `namespace:` must NOT be in template metadata
- Required labels: `name`, `instance`, `managed-by`, `helm.sh/chart`
- selectorLabels: only `name` + `instance` (never `version`)
- `rbac.create` boolean, `serviceAccount.create`/`name` pattern
- `imagePullPolicy: IfNotPresent` default
- File naming: dashed notation, one resource per file
- Defined templates must be namespaced with chart name

## Test plan

- [ ] `/platform-skills:helmcheck` with no args shows 8-option wizard
- [ ] `create web-service` runs 10-stage interview
- [ ] `lint <chart>` runs kubeconform with CRD schema URL
- [ ] `upgrade` prints rollback plan