### PR TITLE
chore(release): update marketplace.json source.sha for v1.35.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -176,7 +176,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "2aadec98b35cc99d42fcdeff217f678c3d24b9c7"
+        "sha": "9f35deee5ae1aad4e356181718752b73e39d9329"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
## Summary

- Updates `source.sha` in `.claude-plugin/marketplace.json` to the current main HEAD (`9f35deee`) after the v1.35.0 merge

## Validation

```bash
bash tests/handbook-consistency.sh
```

## Rollback

Revert the SHA back to the previous value if the release is rolled back.