### PR TITLE
fix(ci): exclude tsconfig.json from strict JSON validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Validate JSON files
         run: |
           # Validate all JSON files
-          JSON_FILES=$(find . -type f -name "*.json" ! -path "./.git/*" ! -path "./node_modules/*")
+          JSON_FILES=$(find . -type f -name "*.json" ! -path "./.git/*" ! -path "./node_modules/*" ! -name "tsconfig*.json")
 
           if [ -n "$JSON_FILES" ]; then
             while IFS= read -r file; do


### PR DESCRIPTION
## Problem

Release CI fails with `❌ Invalid JSON: ./website/tsconfig.json` because Docusaurus scaffolds `tsconfig.json` with `//` comments (JSONC format). `jq empty` rejects comments as invalid JSON.

## Fix

Add `! -name "tsconfig*.json"` to the `find` command in the "Validate JSON files" step. TypeScript config files intentionally use JSONC — they are not validated by `jq`.

## Validation

Re-run the release workflow against the v1.35.0 tag after merge.