### PR TITLE
chore(release): update source.sha for v1.35.0 final

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -176,7 +176,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "9f35deee5ae1aad4e356181718752b73e39d9329"
+        "sha": "7198f97eec2ee318ee248829ab66b27bca9305cc"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
Updates marketplace.json source.sha to current main HEAD (7198f97) after all v1.35.0 fixes landed.