### PR TITLE
fix(ci): enforce marketplace.json description <= 1024 chars in validate.yml

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,7 +80,7 @@ jobs:
             (.plugins | type == "array" and length > 0) and
             (.plugins[0].name | type == "string" and length > 0) and
             (.plugins[0].version | type == "string" and length > 0) and
-            (.plugins[0].description | type == "string" and length > 0) and
+            (.plugins[0].description | type == "string" and length > 0 and length <= 1024) and
             (.plugins[0].author.name | type == "string" and length > 0) and
             (.plugins[0].license | type == "string" and length > 0) and
             (.plugins[0].source.url | type == "string" and length > 0) and


### PR DESCRIPTION
## Problem

CI only checked that `description` was non-empty. The Copilot marketplace enforces a 1024-character hard limit — caught during v1.35.0 release (PR #109).

## Fix

Added `and length <= 1024` to the `jq` check on `plugins[0].description` in `validate.yml`. Future PRs that exceed the limit will fail CI before reaching the release workflow.

Closes Copilot review thread on #109.