### PR TITLE
chore(release): v1.36.0 — five new slash commands, OpenShift reference expansion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -176,7 +176,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "7198f97eec2ee318ee248829ab66b27bca9305cc"
+        "sha": "41bd89a119cf5dd4689d0331c295dcc5d732c702"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
## Summary

- Updates `marketplace.json` `source.sha` to `41bd89a` — the final main HEAD after PR #112 merged
- No logic changes; this commit exists solely to point the marketplace at the correct release SHA

## What shipped in v1.36.0 (PR #112)

- **5 new slash commands**: `/platform-skills:github-actions`, `/platform-skills:kubernetes`, `/platform-skills:azure`, `/platform-skills:openshift`, `/platform-skills:secrets`
- **OpenShift reference** expanded from 52 lines to ~430 lines (SCC, Routes TLS, GitOps, cluster upgrades)
- **Sealed Secrets interview**: 5-question interview before generating any `kubeseal` commands — controller namespace and Service name are gathered upfront
- **ESO callout block**: discovery commands before ESO debug steps
- **Triage fixes** (8 Copilot threads resolved): yaml fence, controller Service vs Deployment name, secret value masking, `who-can use scc` comment accuracy, Flux CD row command pointer
- **README and website** updated: v1.36.0 badge, 40 commands, Flux CD table collapsed, new domain tiles

## Validation steps

```bash
bash tests/validate-skill.sh   # PASS
bash tests/handbook-consistency.sh  # PASS
```

## Rollback plan

Revert this commit — marketplace.json `source.sha` returns to v1.35.0 HEAD; no cluster or plugin state is affected.