### PR TITLE
ci: scope workflow triggers to avoid unnecessary runs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -176,7 +176,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "7198f97eec2ee318ee248829ab66b27bca9305cc"
+        "sha": "41bd89a119cf5dd4689d0331c295dcc5d732c702"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,13 @@ name: Deploy GitHub Pages
 on:
   push:
     branches: [main]
+    paths:
+      - 'website/**'
+      - 'references/**'
+      - 'commands/**'
+      - 'examples/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,21 +42,30 @@ jobs:
       terraform: ${{ steps.filter.outputs.terraform }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 2
       - id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
         run: |
-          BASE=${{ github.event.pull_request.base.sha || github.event.before }}
-          HEAD=${{ github.sha }}
-          # Fall back to HEAD~1 on push when before is all-zeros (first push)
-          if [[ "$BASE" == "0000000000000000000000000000000000000000" ]]; then
-            BASE=$(git rev-parse HEAD~1 2>/dev/null || echo "$HEAD")
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            BASE="$PR_BASE_SHA"
+          else
+            BASE="$PUSH_BEFORE_SHA"
           fi
-          CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
-          has_md=$(echo "$CHANGED"    | grep -qE '\.md$'          && echo true || echo false)
-          has_yaml=$(echo "$CHANGED"  | grep -qE '\.(yml|yaml)$'  && echo true || echo false)
-          has_tf=$(echo "$CHANGED"    | grep -qE '\.tf$'          && echo true || echo false)
-          echo "markdown=$has_md"   >> "$GITHUB_OUTPUT"
-          echo "yaml=$has_yaml"     >> "$GITHUB_OUTPUT"
-          echo "terraform=$has_tf"  >> "$GITHUB_OUTPUT"
+          # Fall back to HEAD~1 when base SHA is all-zeros (force-push or first push)
+          if [[ -z "$BASE" || "$BASE" == "0000000000000000000000000000000000000000" ]]; then
+            BASE=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
+          fi
+          CHANGED=$(git diff --name-only "$BASE" HEAD)
+          has_md=$(echo "$CHANGED"   | grep -qE '\.md$'         && echo true || echo false)
+          has_yaml=$(echo "$CHANGED" | grep -qE '\.(yml|yaml)$' && echo true || echo false)
+          has_tf=$(echo "$CHANGED"   | grep -qE '\.tf$'         && echo true || echo false)
+          echo "markdown=$has_md"  >> "$GITHUB_OUTPUT"
+          echo "yaml=$has_yaml"    >> "$GITHUB_OUTPUT"
+          echo "terraform=$has_tf" >> "$GITHUB_OUTPUT"
 
   validate-structure:
     name: Validate Repository Structure

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '**.md'
+      - '**.yml'
+      - '**.yaml'
+      - '**.tf'
+      - '**.json'
+      - '**.sh'
+      - '.github/workflows/**'
   push:
     branches:
       - main
@@ -16,14 +24,44 @@ on:
       - '**.sh'
       - '.github/workflows/**'
 
+concurrency:
+  group: validate-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
+  detect-changes:
+    name: Detect Changed File Types
+    runs-on: ubuntu-latest
+    outputs:
+      markdown: ${{ steps.filter.outputs.markdown }}
+      yaml: ${{ steps.filter.outputs.yaml }}
+      terraform: ${{ steps.filter.outputs.terraform }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - id: filter
+        run: |
+          BASE=${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD=${{ github.sha }}
+          # Fall back to HEAD~1 on push when before is all-zeros (first push)
+          if [[ "$BASE" == "0000000000000000000000000000000000000000" ]]; then
+            BASE=$(git rev-parse HEAD~1 2>/dev/null || echo "$HEAD")
+          fi
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+          has_md=$(echo "$CHANGED"    | grep -qE '\.md$'          && echo true || echo false)
+          has_yaml=$(echo "$CHANGED"  | grep -qE '\.(yml|yaml)$'  && echo true || echo false)
+          has_tf=$(echo "$CHANGED"    | grep -qE '\.tf$'          && echo true || echo false)
+          echo "markdown=$has_md"   >> "$GITHUB_OUTPUT"
+          echo "yaml=$has_yaml"     >> "$GITHUB_OUTPUT"
+          echo "terraform=$has_tf"  >> "$GITHUB_OUTPUT"
+
   validate-structure:
     name: Validate Repository Structure
     runs-on: ubuntu-latest
+    needs: detect-changes
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -150,6 +188,8 @@ jobs:
   validate-markdown:
     name: Validate Markdown
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.markdown == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -195,6 +235,8 @@ jobs:
   validate-yaml:
     name: Validate YAML Files
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.yaml == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -274,6 +316,8 @@ jobs:
   validate-terraform:
     name: Validate Terraform
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.terraform == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -341,6 +385,7 @@ jobs:
   validate-security:
     name: Security Checks
     runs-on: ubuntu-latest
+    needs: detect-changes
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -423,6 +468,7 @@ jobs:
   validate-skill-structure:
     name: Skill Structure Checks
     runs-on: ubuntu-latest
+    needs: detect-changes
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -436,35 +482,36 @@ jobs:
   summary:
     name: Validation Summary
     runs-on: ubuntu-latest
-    needs: [validate-structure, validate-markdown, validate-yaml, validate-terraform, validate-security, validate-skill-structure]
+    needs: [detect-changes, validate-structure, validate-markdown, validate-yaml, validate-terraform, validate-security, validate-skill-structure]
     if: always()
     steps:
       - name: Generate summary
         run: |
+          pass_or_skip() { [[ "$1" == "success" || "$1" == "skipped" ]] && echo "✅ Passed" || echo "❌ Failed"; }
           cat << EOF >> $GITHUB_STEP_SUMMARY
           ## Validation Results
 
           | Check | Status |
           |-------|--------|
-          | Repository Structure | ${{ needs.validate-structure.result == 'success' && '✅ Passed' || '❌ Failed' }} |
-          | Markdown Validation | ${{ needs.validate-markdown.result == 'success' && '✅ Passed' || '❌ Failed' }} |
-          | YAML Validation | ${{ needs.validate-yaml.result == 'success' && '✅ Passed' || '❌ Failed' }} |
-          | Terraform Validation | ${{ needs.validate-terraform.result == 'success' && '✅ Passed' || '❌ Failed' }} |
-          | Security Checks | ${{ needs.validate-security.result == 'success' && '✅ Passed' || '❌ Failed' }} |
-          | Skill Structure | ${{ needs.validate-skill-structure.result == 'success' && '✅ Passed' || '❌ Failed' }} |
+          | Repository Structure | $(pass_or_skip "${{ needs.validate-structure.result }}") |
+          | Markdown Validation  | $(pass_or_skip "${{ needs.validate-markdown.result }}") |
+          | YAML Validation      | $(pass_or_skip "${{ needs.validate-yaml.result }}") |
+          | Terraform Validation | $(pass_or_skip "${{ needs.validate-terraform.result }}") |
+          | Security Checks      | $(pass_or_skip "${{ needs.validate-security.result }}") |
+          | Skill Structure      | $(pass_or_skip "${{ needs.validate-skill-structure.result }}") |
 
           EOF
 
       - name: Check overall status
         run: |
-          if [[ "${{ needs.validate-structure.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-markdown.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-yaml.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-terraform.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-security.result }}" != "success" ]] || \
-             [[ "${{ needs.validate-skill-structure.result }}" != "success" ]]; then
+          fail() { [[ "$1" != "success" && "$1" != "skipped" ]]; }
+          if fail "${{ needs.validate-structure.result }}" || \
+             fail "${{ needs.validate-markdown.result }}"  || \
+             fail "${{ needs.validate-yaml.result }}"      || \
+             fail "${{ needs.validate-terraform.result }}" || \
+             fail "${{ needs.validate-security.result }}"  || \
+             fail "${{ needs.validate-skill-structure.result }}"; then
             echo "❌ Some validation checks failed"
             exit 1
           fi
-
           echo "✅ All validation checks passed"


### PR DESCRIPTION
## Problem

Two workflows were triggering on every push/PR regardless of what changed:

- `validate.yml` had a `paths` filter on `push` but not on `pull_request`, so all 6 validation jobs ran on every PR (including release SHA-bump PRs that touch only `marketplace.json`)
- `pages.yml` rebuilt the Docusaurus site on every merge to main, including `.tf` and `.sh` only changes

## Changes

**validate.yml**
- Add `paths` filter to `pull_request` trigger — now matches the existing `push` filter
- Add `concurrency` group so stale runs on the same branch/PR are cancelled
- New `detect-changes` job diffs the touched files and outputs `markdown`, `yaml`, `terraform` flags
- `validate-markdown`, `validate-yaml`, `validate-terraform` gated on those flags — a PR touching only `.md` skips the YAML and Terraform jobs; a pure `marketplace.json` bump skips all three
- `summary` treats `skipped` as a pass so the required status check stays green on partially-skipped runs

**pages.yml**
- Add `paths` to push trigger — rebuilds only when `website/`, `references/`, `commands/`, `examples/`, `README.md`, or `CHANGELOG.md` change
- Terraform, shell script, or JSON-only merges no longer kick off a full npm build and Pages deploy

## What does NOT change

- `release.yml` — already only fires on `v*.*.*` tags, no change needed
- `tessl-publish.yml` — `workflow_dispatch` only, no change needed
- `test-composite-actions.yml` — already scoped to `examples/github-actions/composite-actions/**`, no change needed
- `validate-renovate.yml` — already scoped to `renovate.json`, no change needed

## Validation

```bash
npx js-yaml .github/workflows/validate.yml  # OK
npx js-yaml .github/workflows/pages.yml     # OK
```