### PR TITLE
fix(ci): validate.yml fails on multi-commit pushes to main

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -55,8 +55,12 @@ jobs:
           else
             BASE="$PUSH_BEFORE_SHA"
           fi
-          # Fall back to HEAD~1 when base SHA is all-zeros (force-push or first push)
-          if [[ -z "$BASE" || "$BASE" == "0000000000000000000000000000000000000000" ]]; then
+          # Fall back to HEAD~1 when base SHA is all-zeros (force-push or first push),
+          # or when it isn't present in this shallow clone (e.g. a multi-commit merge
+          # pushes more commits than fetch-depth covers) — verify the object exists
+          # before trusting it, rather than only checking for the all-zeros sentinel.
+          if [[ -z "$BASE" || "$BASE" == "0000000000000000000000000000000000000000" ]] \
+             || ! git cat-file -e "$BASE" 2>/dev/null; then
             BASE=$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)
           fi
           CHANGED=$(git diff --name-only "$BASE" HEAD)


### PR DESCRIPTION
## Summary

- Root cause: PR #131's merge pushed 20 commits to `main` in one push event. `detect-changes`' `actions/checkout` only fetches `fetch-depth: 2`, but `github.event.before` correctly pointed at the true pre-push SHA — 20 commits back, outside the shallow clone. `git diff` on that SHA failed with `fatal: bad object`, exiting 128 and cascading into every downstream job showing as skipped: [run 28757193779](https://github.com/nitinjain999/platform-skills/actions/runs/28757193779)
- Fix: the existing fallback only triggered on the all-zeros sentinel (force-push/first-push case). Added `git cat-file -e "$BASE"` so the `HEAD~1` fallback also covers "real SHA that just isn't fetched," which any push carrying more than ~2 commits will hit under `fetch-depth: 2`.
- Checked all other workflows for the same `event.before` pattern — `validate.yml` is the only one, no other file needs this fix.

## Validation steps

- Reproduced the exact failure locally: `git clone --depth 2 file://<repo> ...` against the real pre-fix commit, then ran the real failing `before` SHA (`fb970a6d865213397da5200067a951967d7525d2`) through the old script logic — reproduced the identical `fatal: bad object` error.
- Ran the same reproduction through the fixed script — resolves cleanly, falls back to `HEAD~1`, produces correct `has_md`/`has_yaml`/`has_tf` outputs.
- Confirmed the fix doesn't change behavior when the before-SHA *is* present (normal single/few-commit push case) — `BASE` resolves identically to before.
- YAML syntax validated with `yq`; extracted `run:` script syntax-checked with `bash -n`.

## Rollback plan

Single-file, single-hunk change to `.github/workflows/validate.yml` — revert the commit if it causes unexpected behavior. No state, no other files, no version bump.