### PR TITLE
chore(release): update source.sha to v1.37.0 final main HEAD

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -176,7 +176,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "fb970a6d865213397da5200067a951967d7525d2"
+        "sha": "bfd8ee104aca6df1f1ae92fc155eaf2e699891ca"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
## Summary

- Updates `.claude-plugin/marketplace.json` `plugins[0].source.sha` from `fb970a6` (21 commits stale — predates all of #129/#131/#132) to `bfd8ee1`, current `main` HEAD at the time of this PR.
- Prerequisite for tagging `v1.37.0` — `release.yml`'s `create-release` job requires `source.sha` to be a reachable ancestor of the tagged commit, and warns if it's more than 1 commit behind.
- Matches this repo's existing two-step release convention (bump PR → separate `source.sha` PR → tag), same pattern as `e66a00e` (v1.36.0) and `b63492e` (v1.35.0).

## Validation steps

- `jq empty .claude-plugin/marketplace.json` — valid JSON
- `git merge-base --is-ancestor bfd8ee1 <post-merge-HEAD>` will hold once merged (this commit becomes the new ancestor)

## Rollback plan

Single-field JSON change. Revert the commit if needed — no functional/runtime impact, this field is only read by `release.yml`'s reachability check.