### PR TITLE
chore(release): repoint marketplace source.sha at main for v1.38.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -182,7 +182,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "f3e7abd6660347e993fb8e0fcd09797d83afeac3"
+        "sha": "48b626168eb782482798082dbb862f53a7224c6c"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
PR #159 was merged with a rebase, so the `source.sha` it set (`f3e7abd`) exists only on the `feat/zizmor` branch — it is not an ancestor of `main`. Once that branch is deleted the object becomes unreachable and a marketplace install from this manifest breaks.

This repoints `source.sha` at `48b6261`, the current `main` HEAD, which carries the complete 1.38.0 content. That matches the shape of v1.37.0, where `source.sha` named the tag commit’s parent — a commit cannot contain its own SHA, so the manifest always names its ancestor.

This is the last step before tagging v1.38.0.

## Validation

- `tests/release-consistency.sh` — all checks pass, including `source.sha` is a full 40-char SHA and exists in git history; ends with "safe to tag v1.38.0"
- `tests/handbook-consistency.sh` — passes
- Version sync: `plugin.json` 1.38.0, `marketplace.json` 1.38.0, `INSTALLATION.md` 1.38.0
- `marketplace.json` description 665 chars, under the 1024 limit
- `CHANGELOG.md` has `## [1.38.0] - 2026-08-29`

## Rollback

`git revert` this commit. It changes one JSON string and no runtime behaviour; nothing is published until a `v*.*.*` tag is pushed.