### PR TITLE
fix(release): stop source.sha excluding the newest commit's content

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.38.0",
+      "version": "1.38.1",
       "description": "Production-grade platform engineering handbook for Claude, Codex, and Cursor. 41 slash-command workflows: Kubernetes (baseline, RBAC, workload, debug), GitHub Actions (design, security, review, debug), Azure (Workload Identity, AKS, tagging, RBAC), OpenShift (SCC, Routes, GitOps, upgrades), Secrets (ESO, Sealed Secrets, rotation, audit), Helm, Terraform, Flux CD, Argo CD, AWS, Kyverno, OPA, KEDA, Karpenter, supply chain security, Falco, chaos engineering, DORA metrics, Datadog, Dynatrace, Linkerd, AWS MCP, Renovate, Checkov, Trivy, Zizmor workflow auditing, and multi-agent scaffolding. Every answer includes blast radius, validation steps, and rollback plan.",
       "author": {
         "name": "Nitin Jain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-skills",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "description": "Practical guidance for platform engineers across Claude, Codex, Cursor, and Copilot: Kubernetes (baseline, RBAC, workload hardening, debug), GitHub Actions (design, security, review, debug), Azure (Workload Identity, tagging, AKS, RBAC), OpenShift (SCC, Routes, GitOps, upgrades), Secrets (ESO, Sealed Secrets, rotation, audit), Kyverno, Helm, Terraform, Flux CD (Flux Operator, FluxInstance, OCI delivery), Argo CD, AWS (CloudFront, WAF, Lambda@Edge, IAM, IRSA), Linkerd, Linux, networking, MCP development, observability, SOC 2 compliance, PR review, PR triage, KEDA, Karpenter, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA Metrics, LLM Observability (Datadog LLMObs), and animated docs. Every answer includes blast radius, validation steps, and rollback plan.",
   "author": {
     "name": "Nitin Jain",

--- a/.cursor/rules/platform-skills.mdc
+++ b/.cursor/rules/platform-skills.mdc
@@ -4,7 +4,7 @@ globs: []
 alwaysApply: true
 ---
 
-# Platform Skills — v1.38.0
+# Platform Skills — v1.38.1
 
 You are a senior platform engineer. Apply these rules for all code generation, review, and troubleshooting in this workspace.
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,4 +1,4 @@
-# Platform Engineering Rules — platform-skills v1.38.0
+# Platform Engineering Rules — platform-skills v1.38.1
 # Source: https://github.com/nitinjain999/platform-skills
 # Scope: project-level — applies to all Cursor AI in this workspace
 # Upgrade: git pull in the platform-skills clone → re-copy this file → commit

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 # Platform Engineering Instructions for GitHub Copilot
-# Version: 1.38.0
+# Version: 1.38.1
 # Source: https://github.com/nitinjain999/platform-skills
 # Scope: project-level — applies to every Copilot Chat session in this workspace
 # Install: ./install.sh --copilot --target /path/to/your-project

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,14 +338,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate marketplace.json source.sha is a recent ancestor of tagged commit
+      - name: Validate marketplace.json source.sha ships the tagged content
         run: |
           TAG_COMMIT=$(git rev-parse HEAD)
           STORED_SHA=$(jq -r '.plugins[0].source.sha' .claude-plugin/marketplace.json)
 
-          # Exact equality is impossible: the SHA-update PR merge always creates one
-          # new commit on top of the stored SHA. Check reachability instead — the stored
-          # SHA must be an ancestor of the tagged commit (i.e. it is reachable from it).
+          # source.sha, not the tag, selects the tree installers download. Exact
+          # equality is impossible — the sha-bump commit cannot contain its own hash —
+          # so the stored SHA must at least be reachable from the tagged commit.
           if ! git merge-base --is-ancestor "$STORED_SHA" "$TAG_COMMIT"; then
             echo "❌ marketplace.json source.sha is not reachable from the tagged commit"
             echo "  stored: ${STORED_SHA}"
@@ -355,13 +355,30 @@ jobs:
             exit 1
           fi
 
-          # Warn if the SHA is more than 1 commit behind — that suggests a stale update.
-          DISTANCE=$(git rev-list --count "${STORED_SHA}..${TAG_COMMIT}")
-          if [ "$DISTANCE" -gt 1 ]; then
-            echo "⚠️  source.sha is ${DISTANCE} commits behind the tag — consider updating it."
+          # Reachability alone is not enough: anything that differs between the stored
+          # SHA and the tag is content the release does not ship. A sha-bump commit can
+          # only ever touch marketplace.json, so every other path here is a leak.
+          #
+          # This replaces a "warn if more than 1 commit behind" heuristic that could not
+          # tell a metadata commit from a content commit. v1.38.0 sat exactly 1 commit
+          # behind and shipped the pre-azurerm-5 azure example, warning-free, because
+          # the fix commit repointed source.sha at its own parent.
+          EXCLUDED=$(git diff --name-only "$STORED_SHA" "$TAG_COMMIT" -- . ':(exclude).claude-plugin/marketplace.json')
+          if [ -n "$EXCLUDED" ]; then
+            echo "❌ source.sha excludes content that is present in the tag:"
+            while IFS= read -r excluded_path; do
+              echo "  ${excluded_path}"
+            done <<< "$EXCLUDED"
+            echo ""
+            echo "  stored: ${STORED_SHA}"
+            echo "  tagged: ${TAG_COMMIT}"
+            echo ""
+            echo "Land content first and merge it, then bump source.sha to that merge"
+            echo "commit in a PR that touches only .claude-plugin/marketplace.json, then tag."
+            exit 1
           fi
 
-          echo "✅ source.sha ${STORED_SHA} is reachable from tagged commit ${TAG_COMMIT}"
+          echo "✅ source.sha ${STORED_SHA} ships the tagged content"
 
       - name: Extract changelog for this version
         id: changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to Platform Skills will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.38.1] - 2026-08-29
+
+Republishes the v1.38.0 content. No skill or command content changed; v1.38.0 shipped a tree that was one commit short of its own tag.
+
+### Fixed
+
+- **v1.38.0 installed the pre-fix Azure Workload Identity example.** `marketplace.json` `source.sha` selects the tree installers download, and v1.38.0 pinned `ad1950c` while the `v1.38.0` tag was `bd2e06c`. The excluded commit was the azurerm 5.x migration, so anyone who installed v1.38.0 got `examples/azure/workload-identity/main.tf` with `parent_id` + `resource_group_name` under `azurerm >= 3.87.0`. That constraint is open-ended, so `terraform init` resolves azurerm 5.x, where both arguments were replaced by `user_assigned_identity_id` — the example failed `terraform validate` as shipped. The root cause was structural, not a slip: `bd2e06c` repointed `source.sha` at its own parent *in the same commit* that carried the content fix, so the pin could never include it. `ad1950c` and `27d938e` did the same thing, meaning the newest commit's content was excluded from every one of those releases
+- **The release gate could not catch this.** Its `source.sha` check hard-failed only on unreachability, then warned when the pin was more than 1 commit behind the tag. A pin exactly 1 commit behind was assumed to be the sha-bump commit, so a lone *content* commit passed silently. The distance heuristic is now replaced by a hard check on the diff: every path other than `.claude-plugin/marketplace.json` that differs between `source.sha` and the tagged commit is content the release does not ship, and the job fails and lists those paths
+
+### Changed
+
+- **A sha-bump commit must now touch nothing but `.claude-plugin/marketplace.json`.** Land content first, merge it, then bump `source.sha` to that merge commit in a marketplace.json-only PR, then tag. The release gate enforces this
+
 ## [1.38.0] - 2026-08-29
 
 Brings the count to 41 command workflows.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -168,7 +168,7 @@ claude plugin install platform-skills
 
 ```bash
 claude plugin list
-# platform-skills  v1.38.0  enabled
+# platform-skills  v1.38.1  enabled
 ```
 
 **Upgrade:**

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ platform-skills/
 
 ## Roadmap
 
-**Current release: v1.38.0** — 41 commands, 41 domain reference guides, 50+ wiki pages.
+**Current release: v1.38.1** — 41 commands, 41 domain reference guides, 50+ wiki pages.
 
 Full version history is in [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## Problem

`marketplace.json` `source.sha` selects the tree installers actually download. v1.38.0 pinned `ad1950c` while the `v1.38.0` tag was `bd2e06c`, so the release shipped one commit short of its own tag. The excluded commit was the azurerm 5.x migration.

Result: anyone who installed v1.38.0 got a broken example.

```hcl
# what v1.38.0 installs (from ad1950c)
version = ">= 3.87.0"
...
resource_group_name = var.resource_group_name
parent_id           = azurerm_user_assigned_identity.workload.id
```

```hcl
# what the v1.38.0 tag contains (bd2e06c)
version = ">= 5.0.0"
...
user_assigned_identity_id = azurerm_user_assigned_identity.workload.id
```

`>= 3.87.0` is open-ended, so `terraform init` resolves azurerm 5.x, where `parent_id` and `resource_group_name` no longer exist on `azurerm_federated_identity_credential`. The example fails `terraform validate` as shipped.

## Root cause

Structural, not a slip. `bd2e06c` repointed `source.sha` at its **own parent** in the same commit that carried the content fix, so the pin could never contain that fix. `ad1950c` and `27d938e` did the same thing, excluding their own content from those releases too.

Earlier releases got this right: `48b6261` and `14ca070` are sha bumps that touch nothing but `marketplace.json`. The convention existed; it just was not enforced.

## Why CI missed it

The release gate hard-failed only when the pin was unreachable from the tag, then *warned* when the pin was more than 1 commit behind:

```bash
DISTANCE=$(git rev-list --count "${STORED_SHA}..${TAG_COMMIT}")
if [ "$DISTANCE" -gt 1 ]; then
  echo "⚠️  source.sha is ${DISTANCE} commits behind the tag — consider updating it."
fi
```

A distance of exactly 1 was assumed to be the sha-bump commit. v1.38.0 sat at distance 1 with a *content* commit, so it passed warning-free. `tests/handbook-consistency.sh` has no `sha` check at all.

## Changes

- **`.github/workflows/release.yml`** — replaces the distance heuristic with a hard check: every path other than `.claude-plugin/marketplace.json` that differs between `source.sha` and the tagged commit is content the release does not ship. Fails and lists those paths. The ancestry check is kept.
- **1.38.0 → 1.38.1** across `plugin.json`, `marketplace.json`, `CHANGELOG.md`, `INSTALLATION.md`, `README.md`, `.cursorrules`, `.cursor/rules/platform-skills.mdc`, `.github/copilot-instructions.md`.

No skill or command content changes. `source.sha` is deliberately **not** touched here — see sequencing below.

## Why 1.38.1 instead of moving the v1.38.0 tag

The plugin cache keys on the version string (`~/.claude/plugins/cache/platform-skills/platform-skills/1.38.0`), and `claude plugin update` compares versions. Moving the tag would leave every existing 1.38.0 install broken with no upgrade path. A patch version propagates.

## Required sequencing

`source.sha` cannot be set in this PR — a commit cannot contain its own hash, and bundling the bump with content is the exact bug being fixed. Two PRs, in order:

1. **This PR** — content and version bump. Merges as `M1`.
2. **Follow-up** — sets `source.sha` to `M1`, touching only `.claude-plugin/marketplace.json`. Merges as `M2`.
3. Tag `v1.38.1` on `M2`. `diff(M1, M2)` is marketplace.json only, so the new gate passes.

Squash, merge, or rebase are all fine for this PR, since the follow-up pins whatever commit lands on `main`.

## Validation

- New gate logic simulated against the real commits: rejects `ad1950c..bd2e06c`, naming `commands/azure.md` and `examples/azure/workload-identity/main.tf`; accepts the clean bump `48b6261^..48b6261`.
- `bash tests/handbook-consistency.sh` passes, including `editor-version-consistency.sh` at 1.38.1.
- `actionlint .github/workflows/release.yml`: 9 findings on this branch, 9 on `main`, none inside the modified step. No new findings.
- `release.yml` parses as YAML; both JSON manifests validate under `jq`.

## Conflict note

`chore/dedupe-ci-gates` has uncommitted `release.yml` edits at lines 147-212 and 308-328. The step changed here starts at 341, so the hunks do not overlap, but that branch will need a rebase.

## Rollback

Revert the merge commit. Nothing here is applied at runtime; the gate only runs on tag push, and the version strings are metadata. A revert restores the previous gate and 1.38.0 strings, leaving the broken 1.38.0 artifact published as it is today.