### PR TITLE
chore(release): point marketplace source.sha at the 1.38.1 content commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -182,7 +182,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "ad1950c13c53e00fd8ea0767e5f55dd613d6fb82"
+        "sha": "f898524b84a0c37a62095a9a7cf5ed4cec53dc75"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
Step 2 of 3 for the v1.38.1 release. Follows #167.

## Change

One line. `source.sha` moves from `ad1950c` to `f898524` (#167's merge commit on `main`).

```diff
-        "sha": "ad1950c13c53e00fd8ea0767e5f55dd613d6fb82"
+        "sha": "f898524b84a0c37a62095a9a7cf5ed4cec53dc75"
```

`source.sha` selects the tree installers download. `f898524` is the first commit that carries **both** the azurerm 5.x example fix and the 1.38.1 version strings, so pinning it is what actually gets the fix to users. The old pin `ad1950c` predates the fix entirely, which is what shipped broken as v1.38.0.

## Why this is a separate PR

This deliberately touches nothing but `.claude-plugin/marketplace.json`. Bundling a pin bump with content is the exact defect #167 fixed: a commit cannot contain its own hash, so the pin always names an earlier commit, and any content in the same commit is silently excluded from the published plugin.

The gate added in #167 now enforces that, so this PR is also the first real exercise of it.

## Verification

Simulated the #167 gate against this commit:

```
ancestry: OK
✅ source.sha ships the tagged content
```

- `git diff --name-only origin/main HEAD` → `.claude-plugin/marketplace.json`, nothing else.
- Pinned tree `f898524` confirmed to contain `user_assigned_identity_id = azurerm_user_assigned_identity.workload.id` and `plugin.json` version `1.38.1`.
- `marketplace.json` validates under `jq`.

## Remaining step

After this merges as `M2`, tag `v1.38.1` on `M2`. `diff(f898524, M2)` is marketplace.json only, so the release gate passes. Nothing else should land on `main` between this merge and the tag.

## Rollback

Revert the merge commit. The pin returns to `ad1950c` and no release is affected, since nothing is published until the tag is pushed.