### PR TITLE
fix(ci): stop the release gate drifting from the PR gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,71 +144,10 @@ jobs:
           fi
 
       - name: Validate no secrets in code
-        run: |
-          # Check for common secret patterns
-          # This exclusion list is duplicated in validate.yml ("Check for
-          # secrets in code"). Keep the two byte-identical — they have drifted
-          # before and it fails this gate, not that one.
-          # Exclude: GitHub Actions variables, terraform backend config,
-          #   examples/ (templates — sensitive values always use var.xxx),
-          #   validate.yml and release.yml (both carry these regex patterns, and
-          #     the patterns self-match, so each file must exclude both),
-          #   *.lock.yml (gh-aw generated workflows — machine-generated mega-lines
-          #     self-match, e.g. keyserver.ubuntu.com + imageTag=sha256:...; their
-          #     source .md is covered by the next step, so no coverage is lost)
-          POTENTIAL_SECRETS=$(grep -rE '(password|secret|key|token|apikey).*=.*["\x27][^"\x27]{8,}["\x27]' \
-             --exclude-dir=.git \
-             --exclude-dir=node_modules \
-             --exclude-dir=examples \
-             --exclude="*.md" \
-             --exclude="CHANGELOG.md" \
-             --exclude="QUALITY_ASSURANCE.md" \
-             --exclude="*.lock.yml" \
-             --exclude="release.yml" \
-             --exclude="validate.yml" . | \
-             grep -v 'matrix\.' | \
-             grep -v 'vars\.' | \
-             grep -v 'secrets\.' | \
-             grep -v 'backend-config=' | \
-             grep -v 'token.actions.githubusercontent.com' || true)
-
-          if [ -n "$POTENTIAL_SECRETS" ]; then
-            echo "⚠️  Potential secrets found in code:"
-            echo "$POTENTIAL_SECRETS"
-            echo "Review above matches before release"
-            exit 1
-          fi
-          echo "✅ No obvious secrets detected"
-
-      - name: Validate no secrets in agentic workflow sources
-        run: |
-          # The scan above excludes *.md (prose) and *.lock.yml (generated),
-          # which together would leave gh-aw workflow sources with no
-          # credential coverage at release time even though they are
-          # executable CI with secrets access. Tighter pattern (keyword +
-          # separator + a long literal value) so it does not self-match.
-          AW_SOURCES=$(find .github/workflows -name "*.md" 2>/dev/null || true)
-
-          if [ -z "$AW_SOURCES" ]; then
-            echo "ℹ️  No agentic workflow sources found"
-            exit 0
-          fi
-
-          FOUND=$(grep -HnE '(password|secret|key|token|apikey)[[:space:]]*[:=][[:space:]]*["]?[A-Za-z0-9/+_-]{16,}' \
-             $AW_SOURCES | \
-             grep -v 'secrets\.' | \
-             grep -v 'vars\.' | \
-             grep -v 'github\.token' || true)
-
-          if [ -n "$FOUND" ]; then
-            echo "❌ Potential hard-coded credential in agentic workflow source:"
-            echo "$FOUND"
-            echo ""
-            echo "Reference secrets as \${{ secrets.NAME }} instead of inlining values."
-            exit 1
-          fi
-
-          echo "✅ No hard-coded credentials in agentic workflow sources"
+        # Shared with validate.yml via tests/scan-secrets.sh. This step used to be
+        # an inline copy that drifted out of step with the PR gate and blocked a
+        # release on two false positives.
+        run: bash tests/scan-secrets.sh
 
   quality-checks:
     name: Quality Checks
@@ -305,26 +244,10 @@ jobs:
           terraform_version: "1.16.0"
 
       - name: Validate Terraform files (if present)
-        run: |
-          if find . -type f -name "*.tf" ! -path "./.git/*" ! -path "./examples/demo/*" | grep -q .; then
-            ERRORS=0
-            for dir in $(find . -type f -name "*.tf" ! -path "./.git/*" ! -path "./examples/demo/*" -exec dirname {} \; | sort -u); do
-              echo "Validating Terraform in: $dir"
-              if ! (cd "$dir" && terraform init -backend=false -input=false && terraform validate); then
-                echo "❌ Terraform validation failed in $dir"
-                ERRORS=$((ERRORS + 1))
-              fi
-            done
-
-            if [ $ERRORS -gt 0 ]; then
-              echo "❌ Found $ERRORS Terraform validation errors"
-              exit 1
-            fi
-
-            echo "✅ Terraform files validated"
-          else
-            echo "ℹ️  No Terraform files found"
-          fi
+        # Shared with validate.yml via tests/validate-terraform.sh, so the release
+        # gate runs exactly the checks the PR gate ran. Previously this copy was
+        # missing the fmt check that validate.yml performed.
+        run: bash tests/validate-terraform.sh
 
   create-release:
     name: Create GitHub Release

--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -1,0 +1,67 @@
+name: Terraform Drift
+
+# The PR gate's Terraform job is path-gated on changed *.tf, so it reports
+# "skipping" on any pull request that touches no Terraform. The release gate
+# sweeps every directory unconditionally. That asymmetry means a provider major
+# release can break a shipped example with no repository change at all, and
+# nothing reports it until a tag is pushed — which is how azurerm 5.0.0 blocked
+# the v1.38.0 release.
+#
+# This runs the same sweep on a schedule so that class of break surfaces within
+# a week instead of at the next release. It is detection, not prevention: the
+# prevention is `~> N.0` constraints in the examples themselves. Directories that
+# declare no required_providers block cannot be pinned, so this is their only
+# cover.
+#
+# A failing scheduled run emails the repository owner, so no write permission or
+# issue-filing step is needed here.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays, 06:00 UTC
+  workflow_dispatch:
+
+# Deny by default; the single job grants only what it needs.
+permissions: {}
+
+concurrency:
+  group: terraform-drift
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Validate all Terraform directories
+    runs-on: ubuntu-latest
+    # Scheduled workflows run on forks too, where this is just wasted minutes.
+    if: github.repository == 'nitinjain999/platform-skills'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # Nothing here talks to git after checkout, so leaving the token in
+          # .git/config would only widen what a compromised provider plugin
+          # could reach.
+          persist-credentials: false
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
+        with:
+          terraform_version: 1.16.0
+
+      - name: Validate all Terraform directories
+        # Same script the PR gate and the release gate run.
+        run: bash tests/validate-terraform.sh
+
+      - name: Explain a failure
+        if: failure()
+        run: |
+          echo "A Terraform directory stopped validating without any change to this repository."
+          echo ""
+          echo "The usual cause is a provider major release reached by a '>=' constraint."
+          echo "Check the failing directory's required_providers block and pin it to '~> N.0'"
+          echo "against the major it actually supports, then migrate any renamed arguments."
+          echo ""
+          echo "Confirm a provider's real argument set before editing:"
+          echo "  terraform providers schema -json | jq '.provider_schemas[].resource_schemas.<name>.block.attributes'"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -358,59 +358,8 @@ jobs:
           terraform_version: 1.16.0
 
       - name: Find and validate Terraform directories
-        run: |
-          # Find all directories containing .tf files
-          # Exclude examples/demo — demo dirs intentionally pair bad+fixed files that conflict as one module
-          TF_DIRS=$(find . -type f -name "*.tf" ! -path "./.git/*" ! -path "./examples/demo/*" -exec dirname {} \; | sort -u)
-
-          if [ -z "$TF_DIRS" ]; then
-            echo "ℹ️  No Terraform files found"
-            exit 0
-          fi
-
-          ERRORS=0
-          while IFS= read -r dir; do
-            echo ""
-            echo "📁 Validating Terraform in: $dir"
-            echo "─────────────────────────────────────"
-
-            (
-              cd "$dir"
-
-              # Format check
-              if ! terraform fmt -check -recursive; then
-                echo "❌ Terraform formatting issues in: $dir"
-                exit 1
-              else
-                echo "✅ Terraform formatting correct"
-              fi
-
-              # Initialize (backend=false to avoid remote state)
-              if ! terraform init -backend=false; then
-                echo "❌ Terraform init failed in: $dir"
-                exit 1
-              else
-                echo "✅ Terraform init successful"
-              fi
-
-              # Validate
-              if ! terraform validate; then
-                echo "❌ Terraform validation failed in: $dir"
-                exit 1
-              else
-                echo "✅ Terraform validation successful"
-              fi
-            ) || ERRORS=$((ERRORS + 1))
-          done <<< "$TF_DIRS"
-
-          if [ $ERRORS -gt 0 ]; then
-            echo ""
-            echo "❌ Found $ERRORS Terraform validation errors"
-            exit 1
-          fi
-
-          echo ""
-          echo "✅ All Terraform validations passed"
+        # Shared with release.yml and terraform-drift.yml.
+        run: bash tests/validate-terraform.sh
 
   validate-security:
     name: Security Checks
@@ -421,75 +370,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Check for secrets in code
-        run: |
-          # Check for common secret patterns
-          # This exclusion list is duplicated in release.yml ("Validate no
-          # secrets in code"). Keep the two byte-identical — they have drifted
-          # before and it fails the release gate, not this one.
-          # Exclude: GitHub Actions variables, terraform backend config,
-          #   examples/ (templates — sensitive values always use var.xxx),
-          #   validate.yml and release.yml (both carry these regex patterns, and
-          #     the patterns self-match, so each file must exclude both),
-          #   *.lock.yml (gh-aw generated workflows — machine-generated mega-lines
-          #     self-match, e.g. keyserver.ubuntu.com + imageTag=sha256:...; their
-          #     source .md is covered by the next step, so no coverage is lost)
-          POTENTIAL_SECRETS=$(grep -rE '(password|secret|key|token|apikey).*=.*["\x27][^"\x27]{8,}["\x27]' \
-             --exclude-dir=.git \
-             --exclude-dir=node_modules \
-             --exclude-dir=examples \
-             --exclude="*.md" \
-             --exclude="CHANGELOG.md" \
-             --exclude="QUALITY_ASSURANCE.md" \
-             --exclude="*.lock.yml" \
-             --exclude="release.yml" \
-             --exclude="validate.yml" . | \
-             grep -v 'matrix\.' | \
-             grep -v 'vars\.' | \
-             grep -v 'secrets\.' | \
-             grep -v 'backend-config=' | \
-             grep -v 'token.actions.githubusercontent.com' || true)
-
-          if [ -n "$POTENTIAL_SECRETS" ]; then
-            echo "⚠️  Potential secrets found in code:"
-            echo "$POTENTIAL_SECRETS"
-            echo ""
-            echo "Review above matches to ensure they are not real secrets"
-            exit 1
-          fi
-
-          echo "✅ No obvious secrets detected"
-
-      - name: Check for secrets in agentic workflow sources
-        run: |
-          # The scan above excludes *.md (prose) and *.lock.yml (generated —
-          # machine-generated mega-lines self-match the heuristic). Together those
-          # would leave gh-aw workflow sources with NO credential coverage, even
-          # though they are executable CI with secrets access: a hard-coded value
-          # in frontmatter or pre-steps compiles straight into the .lock.yml.
-          # So scan .github/workflows/**/*.md explicitly, with a tighter pattern
-          # (keyword + separator + a long literal value) that does not self-match.
-          AW_SOURCES=$(find .github/workflows -name "*.md" 2>/dev/null || true)
-
-          if [ -z "$AW_SOURCES" ]; then
-            echo "ℹ️  No agentic workflow sources found"
-            exit 0
-          fi
-
-          FOUND=$(grep -HnE '(password|secret|key|token|apikey)[[:space:]]*[:=][[:space:]]*["]?[A-Za-z0-9/+_-]{16,}' \
-             $AW_SOURCES | \
-             grep -v 'secrets\.' | \
-             grep -v 'vars\.' | \
-             grep -v 'github\.token' || true)
-
-          if [ -n "$FOUND" ]; then
-            echo "❌ Potential hard-coded credential in agentic workflow source:"
-            echo "$FOUND"
-            echo ""
-            echo "Reference secrets as \${{ secrets.NAME }} instead of inlining values."
-            exit 1
-          fi
-
-          echo "✅ No hard-coded credentials in agentic workflow sources"
+        # Both the repository-wide heuristic scan and the tighter agentic-source
+        # scan live in tests/scan-secrets.sh. release.yml calls the same script,
+        # so the two gates cannot drift apart again.
+        run: bash tests/scan-secrets.sh
 
       - name: Check for GitHub Actions security
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Platform Skills will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **The duplicated CI gates are now single scripts** — `tests/scan-secrets.sh` and `tests/validate-terraform.sh`, called by both `validate.yml` and `release.yml`. Four inline `run:` blocks became one call each. This closes the failure mode that blocked v1.38.0 three times over: the release gate is a second copy of the PR gate, it only executes when a tag is pushed, so any divergence is invisible until the most expensive possible moment. Both copies had already diverged in two ways at once. The secret scan's exclusion lists differed, which failed the release on false positives. And the Terraform sweep differed in what it checked at all: the PR gate ran `terraform fmt -check -recursive`, the release gate never did, so formatting was enforced on the way in but not on the way out. The scripts resolve the repository root themselves and are runnable directly, so the same gate can be run before pushing rather than discovered in CI
+- **`tests/scan-secrets.sh` scans tracked files rather than walking the working tree** — the inline `grep -r .` was equivalent in CI, where the scan runs immediately after a fresh checkout, but locally it also read gitignored build output and buried the result in minified `website/build` JavaScript. Enumerating from `git ls-files` makes a local run mean something, and "is there a credential in what we committed" is the more honest question. The one consequence is that a brand-new file needs `git add` before a local run sees it; CI is unaffected
+- **Example provider constraints pinned to a major** — 16 constraints across 15 example files moved from `>= N` to `~> N.0` (`aws` to `~> 6.0`, `azurerm` to `~> 5.0`, `tls` to `~> 4.0`, the DORA AMP example to `~> 6.28`). A `>=` constraint in a copy-paste example silently opts into every future major, which is how `azurerm 5.0.0` broke `examples/azure/workload-identity` with no commit to this repository. The repo already taught this exact lesson in `examples/pr-review/upgrade/terraform-loose-constraints.tf` while doing the opposite in 15 real examples. That demo file is deliberately left loose, since its `>= 3.0` is the anti-pattern being illustrated. Each pin targets the major that is currently validated green, so nothing changes today and the next major arrives as a Renovate pull request that runs the Terraform gate instead of as a broken release
+
+### Added
+
+- **`.github/workflows/terraform-drift.yml`** — runs the shared Terraform sweep weekly (Mondays 06:00 UTC) plus on demand. `validate.yml`'s Terraform job is path-gated on changed `*.tf`, so it reports `skipping` on any pull request touching no Terraform, while `release.yml` sweeps every directory unconditionally. That asymmetry is what let a provider major break a shipped example with nothing to review. Pinning constraints prevents it where a `required_providers` block exists; this catches it for the directories that declare none, within a week rather than at the next tag. `permissions: {}` at workflow level with `contents: read` on the single job, `persist-credentials: false` on checkout, and a `failure()` step that names the likely cause and the command to confirm a provider's real argument set
+
+### Fixed
+
+- **The Terraform sweep validated third-party module sources** — the `find` in both workflows had no `.terraform/` exclusion, so once a directory using a registry module had been initialised, downloaded module code under `.terraform/modules/` was picked up as if it were part of this repository. That put two directories of someone else's Terraform inside a gate that blocks releases here. Now excluded, taking the sweep from 24 directories to the 22 that are actually ours
+
 ## [1.38.1] - 2026-08-29
 
 Republishes the v1.38.0 content. No skill or command content changed; v1.38.0 shipped a tree that was one commit short of its own tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,12 @@ Follow this checklist when adding a net-new domain (e.g. a new command + referen
 - [ ] `bash tests/handbook-consistency.sh` — all checks pass
 - [ ] `bash tests/release-consistency.sh` — all checks pass
 - [ ] `bash tests/validate-ci.sh` — all checks pass
+- [ ] `bash tests/scan-secrets.sh` — all checks pass (stage new files first; it scans tracked files)
+- [ ] `bash tests/validate-terraform.sh` — only if you touched `*.tf`; takes a few minutes
+
+The last two are the exact scripts `validate.yml` and `release.yml` run, so a local
+pass means those gates will pass. Run them from anywhere — they resolve the repo
+root themselves.
 
 ### 8. Wiki (post-merge)
 

--- a/examples/aws/cloudfront/lambda-edge/main.tf
+++ b/examples/aws/cloudfront/lambda-edge/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/examples/aws/cloudfront/versions.tf
+++ b/examples/aws/cloudfront/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/examples/aws/firewall-manager/main.tf
+++ b/examples/aws/firewall-manager/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/aws/waf/versions.tf
+++ b/examples/aws/waf/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/azure/workload-identity/main.tf
+++ b/examples/azure/workload-identity/main.tf
@@ -1,12 +1,14 @@
 terraform {
   required_providers {
     azurerm = {
-      # 5.0.0 is a floor, not a preference: azurerm_federated_identity_credential
-      # below uses user_assigned_identity_id, which replaced parent_id +
-      # resource_group_name in 5.0.0. There is no argument set that satisfies
-      # both 4.x and 5.x, so this cannot be widened back to >= 3.87.0.
+      # Pinned to the 5.x major, both ends deliberate.
+      # Floor: azurerm_federated_identity_credential below uses
+      # user_assigned_identity_id, which replaced parent_id +
+      # resource_group_name in 5.0.0. No argument set satisfies both 4.x and 5.x.
+      # Ceiling: a ">=" constraint let 5.0.0 arrive on its own and break this
+      # file with no commit, which is only caught by the release gate.
       source  = "hashicorp/azurerm"
-      version = ">= 5.0.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/examples/compliance/backup/main.tf
+++ b/examples/compliance/backup/main.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/compliance/detection/main.tf
+++ b/examples/compliance/detection/main.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/compliance/encryption-data-services/main.tf
+++ b/examples/compliance/encryption-data-services/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/compliance/iam/main.tf
+++ b/examples/compliance/iam/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/compliance/incident-response/main.tf
+++ b/examples/compliance/incident-response/main.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/compliance/logging/main.tf
+++ b/examples/compliance/logging/main.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/compliance/network/main.tf
+++ b/examples/compliance/network/main.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/compliance/vulnerability/main.tf
+++ b/examples/compliance/vulnerability/main.tf
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/dora/amp-variant/amp-workspace.tf
+++ b/examples/dora/amp-variant/amp-workspace.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.28"
+      version = "~> 6.28"
     }
   }
 }

--- a/examples/terraform/eks-cluster/versions.tf
+++ b/examples/terraform/eks-cluster/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0"
+      version = "~> 6.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 4.0.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/tests/scan-secrets.sh
+++ b/tests/scan-secrets.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Single source of truth for the credential scan.
+#
+# This logic previously existed as four inline `run:` blocks — two in
+# validate.yml (the PR gate) and two in release.yml (the release gate). The two
+# copies drifted, and because the release gate only executes when a tag is
+# pushed, the drift was invisible until it blocked a release. Both workflows now
+# call this script instead, so there is nothing left to drift.
+#
+# The patterns and filters are carried over unchanged. Two deliberate
+# differences from the inline versions:
+#
+#   1. The file list comes from `git ls-files`, not a `grep -r` walk of the
+#      working tree. In CI these are equivalent — the scan runs immediately
+#      after a fresh checkout, so tracked files are the only files. Locally they
+#      are not: a `grep -r` walk also reads gitignored build output such as
+#      website/build, which buries the result in minified JavaScript and makes
+#      the script useless as a pre-push check. Scanning what is committed is
+#      also the more honest question to ask.
+#   2. This file excludes itself, because it carries the patterns (see below).
+#
+# One consequence of (1) worth knowing when running this locally: a brand-new
+# file is only scanned once git knows about it (`git add`, or `git add -N`). In
+# CI this never bites, because the checkout has everything already tracked.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+FAILURES=0
+
+# Path exclusions, each for a reason:
+#   node_modules/            — not source
+#   examples/                — templates; sensitive values always use var.xxx
+#   *.md                     — prose (CHANGELOG.md and QUALITY_ASSURANCE.md were
+#                              the original offenders; *.md now covers them)
+#   *.lock.yml               — gh-aw generated workflows. Machine-generated
+#                              mega-lines self-match, e.g. keyserver.ubuntu.com
+#                              supplying "key" plus an imageTag=sha256:... value.
+#                              Their .md sources are covered by check 2, so
+#                              excluding them costs no coverage.
+#   release.yml, validate.yml — retained defensively. They no longer carry the
+#                              patterns now that this script does, but if one is
+#                              ever inlined there again it would self-match,
+#                              which is exactly how this broke.
+#   scan-secrets.sh          — this file. The broad pattern matches the tighter
+#                              pattern in check 2: the keyword supplies the
+#                              keyword, [:=] supplies the "=", ["]? the opening
+#                              quote, and the pattern's own closing quote the
+#                              closing quote. Any file holding either regex must
+#                              be excluded from this one.
+EXCLUDE_RE='(^|/)node_modules/|(^|/)examples/|\.md$|\.lock\.yml$|(^|/)(release|validate)\.yml$|(^|/)scan-secrets\.sh$'
+
+# --- Check 1: broad heuristic scan across tracked files ---------------------
+scan_repository() {
+  local files matches
+  files=$(git ls-files | grep -vE "$EXCLUDE_RE" || true)
+
+  if [ -z "$files" ]; then
+    echo "ℹ️  No files to scan"
+    return 0
+  fi
+
+  # -I skips binary files rather than reporting "Binary file ... matches", which
+  # would otherwise be an unfixable finding. NUL-delimited so a path containing
+  # a space cannot split into two arguments.
+  matches=$(printf '%s\n' "$files" | tr '\n' '\0' | \
+     xargs -0 grep -IHnE '(password|secret|key|token|apikey).*=.*["\x27][^"\x27]{8,}["\x27]' | \
+     grep -v 'matrix\.' | \
+     grep -v 'vars\.' | \
+     grep -v 'secrets\.' | \
+     grep -v 'backend-config=' | \
+     grep -v 'token.actions.githubusercontent.com' || true)
+
+  if [ -n "$matches" ]; then
+    echo "⚠️  Potential secrets found in code:"
+    echo "$matches"
+    echo ""
+    echo "Review above matches to ensure they are not real secrets"
+    return 1
+  fi
+
+  echo "✅ No obvious secrets detected"
+}
+
+# --- Check 2: agentic workflow sources -------------------------------------
+#
+# Check 1 excludes *.md (prose) and *.lock.yml (generated). Together those would
+# leave gh-aw workflow sources with NO credential coverage, even though they are
+# executable CI with secrets access: a hard-coded value in frontmatter or
+# pre-steps compiles straight into the .lock.yml. So scan
+# .github/workflows/**/*.md explicitly, with a tighter pattern (keyword +
+# separator + a long literal value) that does not self-match.
+scan_agentic_sources() {
+  local sources found
+  sources=$(git ls-files -- '.github/workflows/*.md' || true)
+
+  if [ -z "$sources" ]; then
+    echo "ℹ️  No agentic workflow sources found"
+    return 0
+  fi
+
+  found=$(printf '%s\n' "$sources" | tr '\n' '\0' | \
+     xargs -0 grep -IHnE '(password|secret|key|token|apikey)[[:space:]]*[:=][[:space:]]*["]?[A-Za-z0-9/+_-]{16,}' | \
+     grep -v 'secrets\.' | \
+     grep -v 'vars\.' | \
+     grep -v 'github\.token' || true)
+
+  if [ -n "$found" ]; then
+    echo "❌ Potential hard-coded credential in agentic workflow source:"
+    echo "$found"
+    echo ""
+    echo "Reference secrets as \${{ secrets.NAME }} instead of inlining values."
+    return 1
+  fi
+
+  echo "✅ No hard-coded credentials in agentic workflow sources"
+}
+
+# Run both checks before deciding. Exiting on the first failure would hide the
+# second, which costs an extra CI round trip to discover.
+scan_repository || FAILURES=$((FAILURES + 1))
+scan_agentic_sources || FAILURES=$((FAILURES + 1))
+
+if [ "$FAILURES" -gt 0 ]; then
+  echo ""
+  echo "❌ $FAILURES credential scan(s) reported findings"
+  exit 1
+fi
+
+echo "✅ Credential scans passed"

--- a/tests/scan-secrets.sh
+++ b/tests/scan-secrets.sh
@@ -93,7 +93,7 @@ scan_repository() {
 # separator + a long literal value) that does not self-match.
 scan_agentic_sources() {
   local sources found
-  sources=$(git ls-files -- '.github/workflows/*.md' || true)
+  sources=$(git ls-files -- '.github/workflows/**/*.md' || true)
 
   if [ -z "$sources" ]; then
     echo "ℹ️  No agentic workflow sources found"

--- a/tests/validate-terraform.sh
+++ b/tests/validate-terraform.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Single source of truth for the Terraform sweep.
+#
+# This logic previously existed as two inline `run:` blocks — one in validate.yml
+# (the PR gate) and one in release.yml (the release gate) — and they had already
+# drifted: the PR gate ran `terraform fmt -check -recursive`, the release gate
+# did not. Unified here, so the release gate cannot be weaker or stronger than
+# the gate that let the change in.
+#
+# Callers: validate.yml, release.yml, terraform-drift.yml.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# examples/demo is excluded because demo dirs intentionally pair a bad file with
+# its fixed version; as a single module they declare conflicting resources.
+TF_DIRS=$(find . -type f -name "*.tf" \
+  ! -path "./.git/*" \
+  ! -path "./examples/demo/*" \
+  ! -path "*/.terraform/*" \
+  -exec dirname {} \; | sort -u)
+
+if [ -z "$TF_DIRS" ]; then
+  echo "ℹ️  No Terraform files found"
+  exit 0
+fi
+
+ERRORS=0
+CHECKED=0
+
+while IFS= read -r dir; do
+  echo ""
+  echo "📁 Validating Terraform in: $dir"
+  echo "─────────────────────────────────────"
+  CHECKED=$((CHECKED + 1))
+
+  (
+    cd "$dir"
+
+    if ! terraform fmt -check -recursive; then
+      echo "❌ Terraform formatting issues in: $dir"
+      exit 1
+    fi
+    echo "✅ Terraform formatting correct"
+
+    # -backend=false avoids touching remote state; -input=false makes a missing
+    # value a failure rather than a hang waiting on a prompt.
+    if ! terraform init -backend=false -input=false; then
+      echo "❌ Terraform init failed in: $dir"
+      exit 1
+    fi
+    echo "✅ Terraform init successful"
+
+    if ! terraform validate; then
+      echo "❌ Terraform validation failed in: $dir"
+      exit 1
+    fi
+    echo "✅ Terraform validation successful"
+  ) || ERRORS=$((ERRORS + 1))
+done <<< "$TF_DIRS"
+
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+  echo "❌ Found $ERRORS Terraform validation errors across $CHECKED directories"
+  exit 1
+fi
+
+echo "✅ All $CHECKED Terraform directories validated"


### PR DESCRIPTION
## Problem

The release gate in `release.yml` is a **second copy** of the PR gate in `validate.yml`, and it only executes when a tag is pushed. Any divergence between the two copies is therefore invisible until a release is already blocked.

Both copies had diverged, in two ways at once, and both were found the hard way while shipping v1.38.0:

| Check | PR gate | Release gate | Consequence |
|---|---|---|---|
| Secret scan exclusions | current | stale | Release failed on two false positives the PR gate had already accounted for |
| `terraform fmt -check -recursive` | present | absent | A release could be gated on a check no PR ever ran |

Separately, and looking unrelated but tracing to the same root cause: 16 provider constraints across 15 example files used `>=`. That lets a provider major arrive with **no commit at all**, and `validate-terraform` in the PR gate is path-gated on changed `*.tf`, so it reports "skipping" on every PR that touches no Terraform. The release gate sweeps unconditionally. That asymmetry is exactly how `azurerm` 5.0.0 broke `examples/azure/workload-identity` and blocked the v1.38.0 release.

## Change

**One script per gate.** Four inline `run:` blocks became `tests/scan-secrets.sh`; two became `tests/validate-terraform.sh`. `validate.yml`, `release.yml`, and the new `terraform-drift.yml` all call the same scripts. There is no second copy left to drift.

The patterns and filters are carried over unchanged. Two deliberate differences in the secret scan:

1. The file list comes from `git ls-files`, not a `grep -r` walk. In CI these are equivalent, since the scan runs immediately after a fresh checkout. Locally they are not: a `grep -r` walk also reads gitignored build output such as `website/build`, which buried the result in 8.8 MB of minified JavaScript and made the script useless as a pre-push check. Scanning what is committed is also the more honest question to ask.
2. `tests/scan-secrets.sh` excludes itself. The broad pattern matches the tighter pattern in check 2, so any file holding either regex must be excluded from the other. `release.yml` and `validate.yml` stay in the exclusion list defensively.

**Pinned 16 constraints across 15 files** to `~> N.0` against the major each file actually supports. `examples/pr-review/upgrade/terraform-loose-constraints.tf` keeps its `>= 3.0` deliberately: that file exists to teach this exact anti-pattern.

**Added `terraform-drift.yml`**, a weekly scheduled sweep. This is detection, not prevention; the prevention is the pinning above. It exists because directories that declare no `required_providers` block cannot be pinned, so a schedule is their only cover. `permissions: {}` at the top level, `contents: read` on the single job, `persist-credentials: false` on checkout, both actions SHA-pinned.

**Fixed a bug found while unifying the two sweeps:** neither excluded `*/.terraform/*`, so downloaded third-party module code was being validated as if it were repository code. The sweep goes from 24 directories to 22.

## Validation

| Check | Result |
|---|---|
| `bash tests/validate-terraform.sh` | `✅ All 22 Terraform directories validated`, after deleting every local `.terraform.lock.hcl` and `.terraform/` so resolution matches a clean runner |
| `bash tests/scan-secrets.sh` | clean, `exit=0`, with the three new files staged and therefore in scope |
| Positive control | two canary files staged via `git add -N`; both checks fired, `exit=1`, both reported in one run |
| `shellcheck` on both new scripts | clean |
| `bash -n` on both new scripts | ok |
| `actionlint` on all three workflows | no findings on `terraform-drift.yml`; only pre-existing informational findings in untouched steps |
| `tests/handbook-consistency.sh` | PASS |
| `tests/release-consistency.sh` | PASS |
| Step inventory after rewiring | `release.yml` validate job 9 steps, quality-checks 7 steps, `Setup Terraform` intact; `validate.yml` all 8 jobs intact |
| Agentic-source file list | `git ls-files -- '.github/workflows/*.md'` returns an identical set to the previous recursive `find` |

`tests/validate-ci.sh` still FAILs, with 632 errors. Proven pre-existing: `git stash -u` then re-running on a clean tree gives the identical 632. All but 3 originate inside `website/node_modules`. It is not wired into any workflow. Out of scope here, but it has the same "local run is useless because of gitignored directories" problem this PR just fixed in the secret scan, and `CONTRIBUTING.md` tells contributors to run it.

## Rollback

`git revert bb9d655`. The three new files are additive and the workflow changes are pure substitutions of a `run:` block, so reverting restores the previous inline copies verbatim, including the drift. No state, no published artifact, and no release tag is involved.

## Not in this PR

103 low-severity `artipacked` findings across 28 files, and the `ZIZMOR_FAIL_ON: medium` raise they unblock. That is a 28-file change plus a gate-policy decision and belongs on its own.