### PR TITLE
chore(release): point marketplace source.sha at the 1.39.0 content commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -188,7 +188,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "f898524b84a0c37a62095a9a7cf5ed4cec53dc75"
+        "sha": "e48230e6237c4e7190e0d86ba1fe0c37c5bd9b7b"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
## Summary

- Bumps `.claude-plugin/marketplace.json` `source.sha` from `f898524` (the 1.38.1 content commit) to `e48230e` — the squash-merge commit for #170, which landed the `/platform-skills:kingfisher` command and the v1.39.0 version bump.
- This is the second half of the two-PR release pattern established in #167/#168: content + version bump lands first (#170), then `source.sha` is bumped to that commit in a PR that touches nothing else, so the sha-bump commit itself can never exclude content (a commit cannot contain its own hash).
- **Only file changed: `.claude-plugin/marketplace.json`.**

## Validation steps

- [x] `git merge-base --is-ancestor e48230e HEAD` — passes, `e48230e` is reachable
- [x] `git diff --name-only e48230e HEAD -- . ':(exclude).claude-plugin/marketplace.json'` — empty, confirming the pin excludes nothing
- [x] `jq empty .claude-plugin/marketplace.json` — valid JSON
- [ ] Release gate (`.github/workflows/release.yml` "Validate marketplace.json source.sha ships the tagged content") will re-verify the same invariant against whatever commit gets tagged next

## Rollback plan

Revert this commit — it changes one string in one file. No functional impact until a tag is cut against this pin.

## Next step after merge

Tag `v1.39.0` on this PR's merge commit (not on #170's commit — the pin only becomes correct once this lands).