### PR TITLE
chore(release): bump version to 1.40.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "platform-skills",
-      "version": "1.39.0",
+      "version": "1.40.0",
       "description": "Production-grade platform engineering handbook for Claude, Codex, and Cursor. 43 slash-command workflows: Kubernetes (baseline, RBAC, workload, debug), GitHub Actions (design, security, review, debug), Azure (Workload Identity, AKS, tagging, RBAC), OpenShift (SCC, Routes, GitOps, upgrades), Secrets (ESO, Sealed Secrets, rotation, audit), Helm, Terraform, Flux CD, Argo CD, AWS, Kyverno, OPA, KEDA, Karpenter, supply chain security, Falco, chaos engineering, DORA metrics, Datadog, Dynatrace, Linkerd, AWS MCP, Renovate, Checkov, Trivy, Zizmor workflow auditing, Kingfisher secret scanning and revocation, and multi-agent scaffolding. Every answer includes blast radius, validation steps, and rollback plan.",
       "author": {
         "name": "Nitin Jain"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "platform-skills",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "description": "Practical guidance for platform engineers across Claude, Codex, Cursor, and Copilot: Kubernetes (baseline, RBAC, workload hardening, debug), GitHub Actions (design, security, review, debug), Azure (Workload Identity, tagging, AKS, RBAC), OpenShift (SCC, Routes, GitOps, upgrades), Secrets (ESO, Sealed Secrets, rotation, audit), Kyverno, Helm, Terraform, Flux CD (Flux Operator, FluxInstance, OCI delivery), Argo CD, AWS (CloudFront, WAF, Lambda@Edge, IAM, IRSA), Linkerd, Linux, networking, MCP development, observability, SOC 2 compliance, PR review, PR triage, KEDA, Karpenter, supply chain security (Cosign, SBOM, SLSA), Falco runtime security, Chaos Engineering, DORA Metrics, LLM Observability (Datadog LLMObs), and animated docs. Every answer includes blast radius, validation steps, and rollback plan.",
   "author": {
     "name": "Nitin Jain",

--- a/.cursor/rules/platform-skills.mdc
+++ b/.cursor/rules/platform-skills.mdc
@@ -4,7 +4,7 @@ globs: []
 alwaysApply: true
 ---
 
-# Platform Skills — v1.39.0
+# Platform Skills — v1.40.0
 
 You are a senior platform engineer. Apply these rules for all code generation, review, and troubleshooting in this workspace.
 

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,4 +1,4 @@
-# Platform Engineering Rules — platform-skills v1.39.0
+# Platform Engineering Rules — platform-skills v1.40.0
 # Source: https://github.com/nitinjain999/platform-skills
 # Scope: project-level — applies to all Cursor AI in this workspace
 # Upgrade: git pull in the platform-skills clone → re-copy this file → commit

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 # Platform Engineering Instructions for GitHub Copilot
-# Version: 1.39.0
+# Version: 1.40.0
 # Source: https://github.com/nitinjain999/platform-skills
 # Scope: project-level — applies to every Copilot Chat session in this workspace
 # Install: ./install.sh --copilot --target /path/to/your-project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to Platform Skills will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.40.0] - 2026-08-30
 
-Adds the `/platform-skills:ai-governance` command (43 total) — Phase 1 of a policy gate for AI coding agents, with zero infrastructure dependency.
+Adds the `/platform-skills:ai-governance` command (43 commands total) — Phase 1 of a policy gate for AI coding agents, with zero infrastructure dependency.
 
 ### Added
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -168,7 +168,7 @@ claude plugin install platform-skills
 
 ```bash
 claude plugin list
-# platform-skills  v1.39.0  enabled
+# platform-skills  v1.40.0  enabled
 ```
 
 **Upgrade:**


### PR DESCRIPTION
## Summary

Bumps the plugin version from 1.39.0 to 1.40.0. Content for `/platform-skills:ai-governance` already merged in #172 (43 total commands) without a version bump — this closes that out.

Follows the two-step release pattern already established in this repo's history (#170 content → #171 sha-pin, for the kingfisher release): **this PR does not touch `marketplace.json`'s `source.sha`.** That's a deliberate, separate follow-up — it must point at a commit that already exists on `main`, so it can only be created once this PR itself has merged.

## Type of change

- [x] Tooling / CI change

## Checklist

- [x] Technically accurate and tested in a real environment
- [x] Follows the writing principles
- [x] Security-conscious — n/a, version metadata only
- [x] Includes rollback plan for any risky operation — revert this commit; nothing else depends on it existing
- [x] `CHANGELOG.md` updated — `## [Unreleased]` converted to `## [1.40.0] - 2026-08-30`
- [x] `README.md` badge counts updated — already correct from #172, verified unchanged
- [x] `bash tests/handbook-consistency.sh` passes locally

## Validation steps

- `bash tests/release-consistency.sh` → all checks pass, prints "safe to tag v1.40.0"
- `bash tests/handbook-consistency.sh` → clean, evaluator suite 115/115
- Confirmed every version-string reference this repo tracks was updated: `plugin.json`, `marketplace.json` (version field only), `CHANGELOG.md`, `INSTALLATION.md`, `.cursorrules`, `.cursor/rules/platform-skills.mdc`, `.github/copilot-instructions.md`

## Follow-up (after this merges)

A second, `marketplace.json`-only PR will point `source.sha` at this PR's merge commit — do not bundle that into this PR or any future content PR, per the "marketplace pin excludes its own commit" pattern already established in this repo.

## Related issues

N/A