### PR TITLE
chore(release): point marketplace source.sha at the 1.40.0 content commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -194,7 +194,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "e48230e6237c4e7190e0d86ba1fe0c37c5bd9b7b"
+        "sha": "386426911098ac0640f35146d0173f721a7e5e1f"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
## Summary

Second step of the two-PR release pattern for 1.40.0 (mirrors #170 → #171 for the kingfisher release). #174 (the version bump) merged as commit `3864269`; this points `marketplace.json`'s `source.sha` at it so installers actually receive 1.40.0 rather than whatever `e48230e` (the prior, 1.39.0-era commit) contained.

`marketplace.json`-only diff, deliberately — nothing else is bundled into this commit, so there's no risk of the sha pointing at a commit whose own changes it doesn't yet include.

## Type of change

- [x] Tooling / CI change

## Checklist

- [x] Technically accurate and tested in a real environment
- [x] Security-conscious — n/a, metadata only
- [x] Includes rollback plan — revert this commit; installers fall back to the previous pinned sha
- [ ] `CHANGELOG.md` updated — not needed, this doesn't change any shipped content, only which commit the marketplace installs from
- [ ] `README.md` badge counts updated — n/a
- [x] `bash tests/handbook-consistency.sh` passes locally

## Validation steps

- `bash tests/release-consistency.sh` → `PASS: marketplace.json source.sha is a full 40-char SHA` and `PASS: marketplace.json source.sha exists in git history`
- `git diff --stat` confirms exactly one file changed: `.claude-plugin/marketplace.json`

## Related issues

Follow-up to #174.