### PR TITLE
fix(website): derive the homepage version from plugin.json instead of hardcoding

### DIFF
--- a/tests/release-consistency.sh
+++ b/tests/release-consistency.sh
@@ -324,6 +324,28 @@ fi
 
 # ---------------------------------------------------------------------------
 echo ""
+echo "=== Docs site version is derived, not hardcoded ==="
+
+# The homepage hero showed v1.38.0 through the 1.39.0, 1.40.0 and 1.41.0
+# releases: it was a hardcoded string and no gate covered website/. The version
+# is now read from customFields, which docusaurus.config.js derives from
+# .claude-plugin/plugin.json. These two checks keep it that way — asserting the
+# derivation exists is what prevents the drift, since asserting a literal
+# version would just move the stale string into this file.
+if grep -q "require('../.claude-plugin/plugin.json')" website/docusaurus.config.js 2>/dev/null; then
+  pass "website/docusaurus.config.js derives the version from plugin.json"
+else
+  fail "website/docusaurus.config.js must derive the version from .claude-plugin/plugin.json"
+fi
+
+if grep -qE '^\s*v1\.[0-9]+\.[0-9]+|>v1\.[0-9]+\.[0-9]+' website/src/pages/index.tsx 2>/dev/null; then
+  fail "website/src/pages/index.tsx hardcodes a version — read siteConfig.customFields.pluginVersion instead"
+else
+  pass "website/src/pages/index.tsx does not hardcode a version"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
 echo "=== Example maturity labels ==="
 
 while IFS= read -r readme; do

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,11 +1,22 @@
 // @ts-check
 const { themes: prismThemes } = require('prism-react-renderer');
 
+// Single source of truth for the version shown on the site. Derived from the
+// plugin manifest rather than hardcoded, because a hardcoded string in
+// src/pages/index.tsx sat at v1.38.0 through the 1.39.0, 1.40.0 and 1.41.0
+// releases — no release gate covered website/, so nothing caught it. Reading it
+// here means the homepage cannot go stale again.
+const pluginManifest = require('../.claude-plugin/plugin.json');
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Platform Skills',
   tagline: 'A production-grade field handbook for platform engineers',
   favicon: 'img/favicon.ico',
+
+  customFields: {
+    pluginVersion: pluginManifest.version,
+  },
 
   url: 'https://nitinjain999.github.io',
   baseUrl: '/platform-skills/',

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -7,10 +7,16 @@ import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 
 function Hero() {
+  // Read from customFields, which docusaurus.config.js derives from
+  // .claude-plugin/plugin.json. Do not hardcode a version here: the previous
+  // hardcoded string sat at v1.38.0 across three releases because no gate
+  // covered website/.
+  const {siteConfig} = useDocusaurusContext();
+  const version = siteConfig.customFields?.pluginVersion as string;
   return (
     <div className="hero-section">
       <div className="hero-section__eyebrow">
-        v1.38.0 &mdash;{' '}
+        v{version} &mdash;{' '}
         <a href="https://github.com/nitinjain999/platform-skills/blob/main/CHANGELOG.md">
           What&apos;s new
         </a>


### PR DESCRIPTION
## The symptom

The docs site homepage shows **v1.38.0**. Live check against the deployed page confirms it:

```
$ curl -sL https://nitinjain999.github.io/platform-skills/ | grep -oE 'v1\.[0-9]+\.[0-9]+'
v1.38.0
```

## The cause is not the deploy

`pages.yml` has run and **succeeded** on every merge, including the v1.41.0 merge commit:

```
2026-09-11T05:02  completed/success  main  feat(token-optimizer): ... (#181)
2026-08-30T11:51  completed/success  main  chore(release): bump version to 1.40.0 (#174)
```

It was publishing a stale literal, faithfully. `website/src/pages/index.tsx:13` hardcoded:

```tsx
v1.38.0 &mdash;{' '}
```

So the homepage sat at 1.38.0 across the 1.39.0, 1.40.0 and 1.41.0 releases.

## Why three releases passed over it

No release gate looked at `website/` at all. Between them, `release-consistency.sh` and `editor-version-consistency.sh` assert the version in `plugin.json`, `marketplace.json`, `INSTALLATION.md`, `.cursorrules`, `.cursor/rules/platform-skills.mdc`, `.github/copilot-instructions.md`, the README badge, `EDITOR_INTEGRATIONS.md`, `GETTING_STARTED.md`, `QUICKSTART.md` and `CHANGELOG.md`. The site was simply outside the net, and `grep -rln website tests/*.sh` returns only `scan-secrets.sh`.

## The fix

Derive it rather than duplicate it. `docusaurus.config.js` reads the plugin manifest and exposes the version through `customFields`:

```js
const pluginManifest = require('../.claude-plugin/plugin.json');
// ...
customFields: {
  pluginVersion: pluginManifest.version,
},
```

and the hero reads it from context, which `index.tsx` was already importing for another component:

```tsx
const {siteConfig} = useDocusaurusContext();
const version = siteConfig.customFields?.pluginVersion as string;
```

## Verified by building, not by reading

```
$ npx tsc --noEmit          # clean
$ npx docusaurus build      # [SUCCESS] Generated static files in "build"
$ grep -c '1\.41\.0' build/index.html   # 1
$ grep -c '1\.38\.0' build/index.html   # 0
```

Rendered hero: `hero-section__eyebrow">v<!-- -->1.41.0`

## Guarding the derivation, not a literal

Two assertions added to `release-consistency.sh`. Both check the *mechanism*, deliberately — asserting a version string here would just relocate the stale value into the gate:

- `docusaurus.config.js` must require `../.claude-plugin/plugin.json`
- `index.tsx` must not contain a hardcoded `v1.x.y`

Confirmed the second one fails when a literal is reintroduced:

```
FAIL: website/src/pages/index.tsx hardcodes a version — read siteConfig.customFields.pluginVersion instead
```

## Validation

```bash
bash tests/release-consistency.sh        # PASS, including the two new checks
bash tests/editor-version-consistency.sh # PASS
shellcheck -S warning tests/release-consistency.sh
cd website && npx tsc --noEmit && npx docusaurus build
```

## Rollback

Three files, no runtime or plugin behaviour touched. Reverting restores the hardcoded string and the site returns to whatever literal it carries.

## Not ready for review yet

Draft. `main`'s ruleset requires an approving review.
