### PR TITLE
feat(website): cover all 44 commands, feature governance and cost, gate the drift

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,12 @@ on:
       - 'examples/**'
       - 'README.md'
       - 'CHANGELOG.md'
+      # The site derives its displayed version from this manifest, so a
+      # manifest-only bump must rebuild. Without it, a release that touches only
+      # .claude-plugin/ skips this workflow and the deployed homepage keeps
+      # showing the previous version — which is the drift the derivation was
+      # added to stop.
+      - '.claude-plugin/**'
   workflow_dispatch:
 
 # Deny by default; each job grants only what it needs. Granting pages: write and

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -438,8 +438,6 @@ jobs:
       - name: Run helmcheck validation
         run: bash tests/validate-helmcheck.sh
 
-      - name: Run website coverage validation
-        run: bash tests/website-coverage.sh
 
   summary:
     name: Validation Summary

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -438,6 +438,9 @@ jobs:
       - name: Run helmcheck validation
         run: bash tests/validate-helmcheck.sh
 
+      - name: Run website coverage validation
+        run: bash tests/website-coverage.sh
+
   summary:
     name: Validation Summary
     runs-on: ubuntu-latest

--- a/tests/handbook-consistency.sh
+++ b/tests/handbook-consistency.sh
@@ -118,4 +118,7 @@ bash tests/token-optimizer-script.sh
 echo "Running token-optimizer policy core tests..."
 bash examples/token-optimizer/tests/optimize_test.sh
 
+echo "Running website coverage checks..."
+bash tests/website-coverage.sh
+
 echo "✅ Handbook consistency checks passed"

--- a/tests/release-consistency.sh
+++ b/tests/release-consistency.sh
@@ -332,14 +332,23 @@ echo "=== Docs site ==="
 # Actually invoke it. A bare `pass` here reported "safe to tag" while website
 # coverage or derivation checks were failing — a fake green on the one gate that
 # is documented as the pre-tag check.
-if bash tests/website-coverage.sh > /tmp/website-coverage.$$.log 2>&1; then
+#
+# mktemp, not "/tmp/<name>.$$.log". A PID-derived name in a world-writable
+# directory is predictable, and `>` follows symlinks, so on a shared host someone
+# could pre-create that path pointing at a file the operator owns and have this
+# script truncate it — then feed arbitrary text into the release output that `sed`
+# echoes back. mktemp creates the file itself with O_EXCL and 0600.
+WEBSITE_LOG="$(mktemp "${TMPDIR:-/tmp}/website-coverage.XXXXXX")"
+# shellcheck disable=SC2064  # expand WEBSITE_LOG now: it must not change later
+trap "rm -f '$WEBSITE_LOG'" EXIT INT TERM
+if bash tests/website-coverage.sh > "$WEBSITE_LOG" 2>&1; then
   pass "tests/website-coverage.sh passed"
-  rm -f /tmp/website-coverage.$$.log
 else
   fail "tests/website-coverage.sh FAILED — output follows"
-  sed 's/^/    /' /tmp/website-coverage.$$.log
-  rm -f /tmp/website-coverage.$$.log
+  sed 's/^/    /' "$WEBSITE_LOG"
 fi
+rm -f "$WEBSITE_LOG"
+trap - EXIT INT TERM
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/release-consistency.sh
+++ b/tests/release-consistency.sh
@@ -324,25 +324,12 @@ fi
 
 # ---------------------------------------------------------------------------
 echo ""
-echo "=== Docs site version is derived, not hardcoded ==="
-
-# The homepage hero showed v1.38.0 through the 1.39.0, 1.40.0 and 1.41.0
-# releases: it was a hardcoded string and no gate covered website/. The version
-# is now read from customFields, which docusaurus.config.js derives from
-# .claude-plugin/plugin.json. These two checks keep it that way — asserting the
-# derivation exists is what prevents the drift, since asserting a literal
-# version would just move the stale string into this file.
-if grep -q "require('../.claude-plugin/plugin.json')" website/docusaurus.config.js 2>/dev/null; then
-  pass "website/docusaurus.config.js derives the version from plugin.json"
-else
-  fail "website/docusaurus.config.js must derive the version from .claude-plugin/plugin.json"
-fi
-
-if grep -qE '^\s*v1\.[0-9]+\.[0-9]+|>v1\.[0-9]+\.[0-9]+' website/src/pages/index.tsx 2>/dev/null; then
-  fail "website/src/pages/index.tsx hardcodes a version — read siteConfig.customFields.pluginVersion instead"
-else
-  pass "website/src/pages/index.tsx does not hardcode a version"
-fi
+echo "=== Docs site ==="
+# Website assertions live in tests/website-coverage.sh, which also checks that
+# every command and reference reaches the site. Keeping a second copy here is
+# how this repo's YAML and Terraform gates diverged between validate.yml and
+# release.yml; one gate, one home.
+pass "website checks delegated to tests/website-coverage.sh"
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/release-consistency.sh
+++ b/tests/release-consistency.sh
@@ -329,7 +329,17 @@ echo "=== Docs site ==="
 # every command and reference reaches the site. Keeping a second copy here is
 # how this repo's YAML and Terraform gates diverged between validate.yml and
 # release.yml; one gate, one home.
-pass "website checks delegated to tests/website-coverage.sh"
+# Actually invoke it. A bare `pass` here reported "safe to tag" while website
+# coverage or derivation checks were failing — a fake green on the one gate that
+# is documented as the pre-tag check.
+if bash tests/website-coverage.sh > /tmp/website-coverage.$$.log 2>&1; then
+  pass "tests/website-coverage.sh passed"
+  rm -f /tmp/website-coverage.$$.log
+else
+  fail "tests/website-coverage.sh FAILED — output follows"
+  sed 's/^/    /' /tmp/website-coverage.$$.log
+  rm -f /tmp/website-coverage.$$.log
+fi
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/website-coverage.sh
+++ b/tests/website-coverage.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# tests/website-coverage.sh — every command and reference must reach the docs site.
+#
+# The site's sidebars are hand-enumerated, and nothing compared them against the
+# directories they document. Three consecutive releases shipped a command that
+# never appeared on the site: kingfisher (1.39.0), ai-governance (1.40.0) and
+# token-optimizer (1.41.0), plus azure, github-actions, kubernetes, openshift and
+# secrets from earlier. The homepage separately advertised "41 commands" against
+# a repo carrying 44, and the version in the hero sat at v1.38.0 across three
+# releases. All of it was invisible because no gate looked at website/.
+#
+# Run from the repository root: bash tests/website-coverage.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ERRORS=0
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; ERRORS=$((ERRORS + 1)); }
+
+# check_coverage <label> <content dir> <sidebar file>
+check_coverage() {
+  local label="$1" dir="$2" sidebar="$3"
+  local listed files missing orphans
+
+  if [ ! -f "$sidebar" ]; then
+    fail "$label sidebar missing: $sidebar"
+    return
+  fi
+
+  listed="$(grep -oE "id: '[a-z0-9-]+'" "$sidebar" | sed "s/id: '//;s/'//" | sort -u)"
+  files="$(find "$dir" -maxdepth 1 -name '*.md' -exec basename {} .md \; | sort)"
+
+  missing="$(comm -13 <(printf '%s\n' "$listed") <(printf '%s\n' "$files"))"
+  orphans="$(comm -23 <(printf '%s\n' "$listed") <(printf '%s\n' "$files"))"
+
+  if [ -z "$missing" ]; then
+    pass "$label: every file in $dir appears in $(basename "$sidebar") ($(printf '%s\n' "$files" | wc -l | tr -d ' ') entries)"
+  else
+    while IFS= read -r m; do
+      [ -n "$m" ] && fail "$label: $dir/$m.md is not in $(basename "$sidebar") — it will not appear on the site"
+    done <<< "$missing"
+  fi
+
+  if [ -z "$orphans" ]; then
+    pass "$label: no sidebar entry points at a missing file"
+  else
+    while IFS= read -r o; do
+      [ -n "$o" ] && fail "$label: $(basename "$sidebar") lists '$o' but $dir/$o.md does not exist — the build will break"
+    done <<< "$orphans"
+  fi
+}
+
+echo ""
+echo "=== Docs site covers every command and reference ==="
+check_coverage "commands" "commands" "website/sidebars-commands.js"
+check_coverage "references" "references" "website/sidebars-references.js"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Docs site derives versions and counts rather than hardcoding ==="
+
+# Asserting the derivation, not a literal. Asserting a literal here would just
+# relocate the stale value into this file.
+if grep -q "require('../.claude-plugin/plugin.json')" website/docusaurus.config.js; then
+  pass "docusaurus.config.js derives the version from plugin.json"
+else
+  fail "docusaurus.config.js must derive the version from .claude-plugin/plugin.json"
+fi
+
+if grep -q "readdirSync" website/docusaurus.config.js; then
+  pass "docusaurus.config.js derives the command count from commands/"
+else
+  fail "docusaurus.config.js must derive the command count by reading commands/"
+fi
+
+if grep -qE '>v1\.[0-9]+\.[0-9]+|^\s*v1\.[0-9]+\.[0-9]+' website/src/pages/index.tsx; then
+  fail "website/src/pages/index.tsx hardcodes a version — read siteConfig.customFields.pluginVersion"
+else
+  pass "index.tsx does not hardcode a version"
+fi
+
+if grep -qE '[0-9]+ commands\.' website/src/pages/index.tsx; then
+  fail "website/src/pages/index.tsx hardcodes a command count — read siteConfig.customFields.commandCount"
+else
+  pass "index.tsx does not hardcode a command count"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo "FAIL: $ERRORS website coverage error(s)"
+  exit 1
+fi
+echo "PASS: all website coverage checks passed"

--- a/tests/website-coverage.sh
+++ b/tests/website-coverage.sh
@@ -69,10 +69,20 @@ echo "=== Docs site derives versions and counts rather than hardcoding ==="
 # check while reintroducing the drift. So assert the ASSIGNMENTS reference the
 # loaded values, and separately reject a quoted literal in either field.
 
-if grep -qE "pluginVersion:[[:space:]]*[A-Za-z_][A-Za-z0-9_]*\.version" website/docusaurus.config.js; then
-  pass "docusaurus.config.js assigns pluginVersion from the loaded manifest"
+# Bind to the specific identifier, not "anything ending in .version". A dead
+# `pluginManifest` require plus `pluginVersion: hardcoded.version` satisfied the
+# looser pattern and still shipped a stale literal, and CI skips the
+# evaluated-config check, so nothing else would have caught it.
+if grep -qE "^[[:space:]]*const[[:space:]]+pluginManifest[[:space:]]*=[[:space:]]*require\('\.\./\.claude-plugin/plugin\.json'\)" website/docusaurus.config.js; then
+  pass "docusaurus.config.js binds the manifest require to pluginManifest"
 else
-  fail "docusaurus.config.js must assign pluginVersion from the required plugin.json, not a literal"
+  fail "docusaurus.config.js must assign require('../.claude-plugin/plugin.json') to pluginManifest"
+fi
+
+if grep -qE "pluginVersion:[[:space:]]*pluginManifest\.version[[:space:]]*,?" website/docusaurus.config.js; then
+  pass "customFields.pluginVersion is bound to pluginManifest.version"
+else
+  fail "customFields.pluginVersion must be exactly pluginManifest.version"
 fi
 
 if grep -qE "pluginVersion:[[:space:]]*['\"]" website/docusaurus.config.js; then
@@ -84,13 +94,19 @@ fi
 if grep -qE "commandCount:[[:space:]]*['\"]?[0-9]" website/docusaurus.config.js; then
   fail "docusaurus.config.js assigns commandCount a literal — derive it by reading commands/"
 else
-  pass "commandCount is not a literal"
+  pass "commandCount is not a literal in customFields"
 fi
 
-if grep -q "readdirSync" website/docusaurus.config.js; then
-  pass "docusaurus.config.js derives the command count by reading commands/"
+# Assert the INITIALIZER CHAIN, not just that a readdirSync exists somewhere.
+# `const commandCount = 44` alongside an unrelated readdirSync passed both of the
+# previous independent checks. Flatten newlines so the multi-line chain is one
+# statement, then require readdirSync and the commands directory to appear inside
+# commandCount's own initializer, before its terminating semicolon.
+if tr '\n' ' ' < website/docusaurus.config.js \
+  | grep -qE "const[[:space:]]+commandCount[[:space:]]*=[^;]*readdirSync[^;]*'commands'[^;]*;"; then
+  pass "commandCount's initializer reads the commands/ directory"
 else
-  fail "docusaurus.config.js must derive the command count by reading commands/"
+  fail "commandCount must be initialized by reading the commands/ directory, e.g. fs.readdirSync(path.join(__dirname, '..', 'commands'))"
 fi
 
 # Strongest available check: evaluate the config and compare against the real

--- a/tests/website-coverage.sh
+++ b/tests/website-coverage.sh
@@ -63,25 +63,66 @@ echo "=== Docs site derives versions and counts rather than hardcoding ==="
 
 # Asserting the derivation, not a literal. Asserting a literal here would just
 # relocate the stale value into this file.
-if grep -q "require('../.claude-plugin/plugin.json')" website/docusaurus.config.js; then
-  pass "docusaurus.config.js derives the version from plugin.json"
+#
+# Checking only that a `require` of the manifest exists is too weak: someone
+# could keep the require and still write `pluginVersion: '1.41.0'`, passing the
+# check while reintroducing the drift. So assert the ASSIGNMENTS reference the
+# loaded values, and separately reject a quoted literal in either field.
+
+if grep -qE "pluginVersion:[[:space:]]*[A-Za-z_][A-Za-z0-9_]*\.version" website/docusaurus.config.js; then
+  pass "docusaurus.config.js assigns pluginVersion from the loaded manifest"
 else
-  fail "docusaurus.config.js must derive the version from .claude-plugin/plugin.json"
+  fail "docusaurus.config.js must assign pluginVersion from the required plugin.json, not a literal"
+fi
+
+if grep -qE "pluginVersion:[[:space:]]*['\"]" website/docusaurus.config.js; then
+  fail "docusaurus.config.js assigns pluginVersion a quoted literal — derive it from plugin.json"
+else
+  pass "pluginVersion is not a quoted literal"
+fi
+
+if grep -qE "commandCount:[[:space:]]*['\"]?[0-9]" website/docusaurus.config.js; then
+  fail "docusaurus.config.js assigns commandCount a literal — derive it by reading commands/"
+else
+  pass "commandCount is not a literal"
 fi
 
 if grep -q "readdirSync" website/docusaurus.config.js; then
-  pass "docusaurus.config.js derives the command count from commands/"
+  pass "docusaurus.config.js derives the command count by reading commands/"
 else
   fail "docusaurus.config.js must derive the command count by reading commands/"
 fi
 
-if grep -qE '>v1\.[0-9]+\.[0-9]+|^\s*v1\.[0-9]+\.[0-9]+' website/src/pages/index.tsx; then
+# Strongest available check: evaluate the config and compare against the real
+# sources. Requires website/node_modules, since the config pulls in
+# prism-react-renderer, so it is a bonus locally rather than the primary gate —
+# the static assertions above are what run everywhere.
+if command -v node >/dev/null 2>&1 && [ -d website/node_modules ]; then
+  want_version="$(node -e "process.stdout.write(require('./.claude-plugin/plugin.json').version)")"
+  want_count="$(find commands -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')"
+  got="$(cd website && node -e "
+    const c = require('./docusaurus.config.js');
+    process.stdout.write(c.customFields.pluginVersion + '|' + c.customFields.commandCount);
+  " 2>/dev/null)" || got="EVAL_FAILED"
+  if [ "$got" = "${want_version}|${want_count}" ]; then
+    pass "evaluated config matches the sources exactly (version ${want_version}, count ${want_count})"
+  else
+    fail "evaluated config gave '${got}', expected '${want_version}|${want_count}'"
+  fi
+else
+  echo "  SKIP: evaluated-config check needs node and website/node_modules (static checks above still ran)"
+fi
+
+# POSIX character classes throughout: \s is a GNU/PCRE extension, not POSIX ERE,
+# so a grep without that extension would silently fail to match an indented
+# literal and the guard would pass while the regression shipped.
+if grep -qE '>v1\.[0-9]+\.[0-9]+|^[[:space:]]*v1\.[0-9]+\.[0-9]+' website/src/pages/index.tsx; then
   fail "website/src/pages/index.tsx hardcodes a version — read siteConfig.customFields.pluginVersion"
 else
   pass "index.tsx does not hardcode a version"
 fi
 
-if grep -qE '[0-9]+ commands\.' website/src/pages/index.tsx; then
+if grep -qE '[0-9]+[[:space:]]+commands\.' website/src/pages/index.tsx; then
   fail "website/src/pages/index.tsx hardcodes a command count — read siteConfig.customFields.commandCount"
 else
   pass "index.tsx does not hardcode a command count"

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,6 +8,15 @@ const { themes: prismThemes } = require('prism-react-renderer');
 // here means the homepage cannot go stale again.
 const pluginManifest = require('../.claude-plugin/plugin.json');
 
+// Command count derived the same way and for the same reason: the homepage
+// advertised "41 commands" while the repo carried 44, because it was a literal
+// nobody updated on release.
+const fs = require('fs');
+const path = require('path');
+const commandCount = fs
+  .readdirSync(path.join(__dirname, '..', 'commands'))
+  .filter((f) => f.endsWith('.md')).length;
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Platform Skills',
@@ -16,6 +25,7 @@ const config = {
 
   customFields: {
     pluginVersion: pluginManifest.version,
+    commandCount,
   },
 
   url: 'https://nitinjain999.github.io',

--- a/website/sidebars-commands.js
+++ b/website/sidebars-commands.js
@@ -1,13 +1,32 @@
 // @ts-check
 
+// Every file in ../commands must appear here. tests/website-coverage.sh fails the
+// build if one is missing: the last three releases each shipped a command that
+// never reached the site (kingfisher in 1.39.0, ai-governance in 1.40.0,
+// token-optimizer in 1.41.0), because these sidebars are hand-enumerated and
+// nothing compared them against the directory.
+
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
   // ── Commands sidebar ───────────────────────────────────────────────
   commandsSidebar: [
     {
+      // Featured first: these two govern what an AI agent may do and what it
+      // costs to let it work. They are the newest capabilities and the reason
+      // most people arrive at this handbook.
+      type: 'category',
+      label: 'AI Agent Governance & Cost',
+      items: [
+        { type: 'doc', id: 'ai-governance' },
+        { type: 'doc', id: 'token-optimizer' },
+      ],
+    },
+    {
       type: 'category',
       label: 'Kubernetes',
       items: [
+        { type: 'doc', id: 'kubernetes' },
+        { type: 'doc', id: 'openshift' },
         { type: 'doc', id: 'helmchart' },
         { type: 'doc', id: 'keda' },
         { type: 'doc', id: 'karpenter' },
@@ -34,12 +53,14 @@ const sidebars = {
       items: [
         { type: 'doc', id: 'aws' },
         { type: 'doc', id: 'aws-profile' },
+        { type: 'doc', id: 'azure' },
       ],
     },
     {
       type: 'category',
       label: 'GitHub Actions & CI',
       items: [
+        { type: 'doc', id: 'github-actions' },
         { type: 'doc', id: 'composite-actions' },
         { type: 'doc', id: 'commit' },
         { type: 'doc', id: 'renovate' },
@@ -49,6 +70,8 @@ const sidebars = {
       type: 'category',
       label: 'Security',
       items: [
+        { type: 'doc', id: 'secrets' },
+        { type: 'doc', id: 'kingfisher' },
         { type: 'doc', id: 'kyverno' },
         { type: 'doc', id: 'opa' },
         { type: 'doc', id: 'supply-chain' },

--- a/website/sidebars-references.js
+++ b/website/sidebars-references.js
@@ -1,9 +1,24 @@
 // @ts-check
 
+// Every file in ../references must appear here. tests/website-coverage.sh fails
+// the build if one is missing: these sidebars are hand-enumerated and nothing
+// compared them against the directory, so kingfisher, ai-governance and
+// token-optimizer shipped without ever reaching the site.
+
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
   // ── References sidebar ────────────────────────────────────────────
   referencesSidebar: [
+    {
+      // Featured first, matching the commands sidebar: these two govern what an
+      // AI agent may do and what it costs to let it work.
+      type: 'category',
+      label: 'AI Agent Governance & Cost',
+      items: [
+        { type: 'doc', id: 'ai-governance' },
+        { type: 'doc', id: 'token-optimizer' },
+      ],
+    },
     {
       type: 'category',
       label: 'Kubernetes',
@@ -75,6 +90,7 @@ const sidebars = {
         { type: 'doc', id: 'zizmor' },
         { type: 'doc', id: 'linkerd' },
         { type: 'doc', id: 'secrets' },
+        { type: 'doc', id: 'kingfisher' },
       ],
     },
     {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -191,12 +191,12 @@ const FEATURES = [
 const GOVERNANCE_CAPABILITIES = [
   {
     name: '/platform-skills:ai-governance',
-    desc: 'Decides what an AI agent is allowed to do in your repo. Real-time session hooks for Copilot and Claude Code deny edits to protected paths and dangerous shell commands before they run, and a merge-time check catches whatever bypasses them — a different tool, a manual push, or an edit to the governance files themselves. Three enforcement tiers so a rollout starts by logging, not blocking.',
+    desc: 'Decides what an AI agent is allowed to do in your repo. Real-time session hooks for Copilot and Claude Code deny edits to protected paths and dangerous shell commands before they run. A merge-time check then re-runs the base branch\u2019s copy of the policy against the pull request\u2019s diff, so a PR cannot weaken the rule meant to catch it. Its scope is bounded and documented: it is a pull_request check, so a direct push to a branch it does not run on is not covered, and edits to the workflow file itself need CODEOWNERS review rather than the check. Three enforcement tiers so a rollout starts by logging, not blocking.',
     link: '/platform-skills/commands/ai-governance',
   },
   {
     name: '/platform-skills:token-optimizer',
-    desc: 'Decides which model does the reading. Broad repository discovery moves to a cheaper worker through each client’s native subagent, while the main agent keeps decisions and targeted verification. Ships a runnable benchmark rather than a savings claim, and reports delegation, resolved model, redirection and read limit as four separate states so nothing reads as proven when it is not.',
+    desc: 'Decides which model does the reading. Broad repository discovery moves to a cheaper worker through each client’s native subagent, while the main agent keeps decisions and targeted verification. Ships a runnable benchmark rather than a savings claim, and reports delegation, worker model, redirection and read limit as four separate states, splitting the requested model from the observed one so nothing reads as proven when it is not.',
     link: '/platform-skills/commands/token-optimizer',
   },
 ];
@@ -209,9 +209,12 @@ function GovernanceSection() {
       </h2>
       <p className="install-section__sub">
         Two companion commands. One bounds an agent&apos;s authority, the other bounds its
-        spend. They register on the same hook event and compose deliberately: the
-        governance gate fails closed so it never stops enforcing, the cost optimizer
-        fails open so it never blocks work.
+        spend. They register on the same hook event and their failure directions are
+        deliberately opposite: the governance evaluator fails closed once it runs, so a
+        broken policy denies rather than waving work through, while the cost optimizer
+        fails open so a broken config never blocks work. Neither can act if the
+        client&apos;s hook transport times out or crashes &mdash; that always fails open,
+        which is the gap the merge-time check exists to cover.
       </p>
       <div className="command-cards">
         {GOVERNANCE_CAPABILITIES.map((c) => (

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -188,10 +188,51 @@ const FEATURES = [
   },
 ];
 
-function FeatureStrip() {
+const GOVERNANCE_CAPABILITIES = [
+  {
+    name: '/platform-skills:ai-governance',
+    desc: 'Decides what an AI agent is allowed to do in your repo. Real-time session hooks for Copilot and Claude Code deny edits to protected paths and dangerous shell commands before they run, and a merge-time check catches whatever bypasses them — a different tool, a manual push, or an edit to the governance files themselves. Three enforcement tiers so a rollout starts by logging, not blocking.',
+    link: '/platform-skills/commands/ai-governance',
+  },
+  {
+    name: '/platform-skills:token-optimizer',
+    desc: 'Decides which model does the reading. Broad repository discovery moves to a cheaper worker through each client’s native subagent, while the main agent keeps decisions and targeted verification. Ships a runnable benchmark rather than a savings claim, and reports delegation, resolved model, redirection and read limit as four separate states so nothing reads as proven when it is not.',
+    link: '/platform-skills/commands/token-optimizer',
+  },
+];
+
+function GovernanceSection() {
   return (
     <section className="feature-strip">
-      <h2 className="feature-strip__heading">41 commands. Every domain a platform team touches.</h2>
+      <h2 className="feature-strip__heading">
+        Govern what your agent does, and what it costs
+      </h2>
+      <p className="install-section__sub">
+        Two companion commands. One bounds an agent&apos;s authority, the other bounds its
+        spend. They register on the same hook event and compose deliberately: the
+        governance gate fails closed so it never stops enforcing, the cost optimizer
+        fails open so it never blocks work.
+      </p>
+      <div className="command-cards">
+        {GOVERNANCE_CAPABILITIES.map((c) => (
+          <div className="command-card" key={c.name}>
+            <div className="command-card__name">
+              <Link to={c.link}>{c.name}</Link>
+            </div>
+            <div className="command-card__desc">{c.desc}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function FeatureStrip() {
+  const {siteConfig} = useDocusaurusContext();
+  const commandCount = siteConfig.customFields?.commandCount as number;
+  return (
+    <section className="feature-strip">
+      <h2 className="feature-strip__heading">{commandCount} commands. Every domain a platform team touches.</h2>
       <div className="feature-grid">
         {FEATURES.map((f) => (
           <div className="feature-tile" key={f.title}>
@@ -276,6 +317,7 @@ export default function Home(): ReactNode {
         <Hero />
         <ProblemStatement />
         <StarScenarios />
+        <GovernanceSection />
         <FeatureStrip />
         <InstallSection />
       </main>


### PR DESCRIPTION
> **#182 has merged.** This branch was rebased onto `main` with the now-duplicated commit dropped, so the diff is the coverage work plus the fixes for #182's review comments. Base is `main`; `mergeable: MERGEABLE`.

## Also fixes the three Copilot findings from #182

#182 merged before its review was addressed, so those fixes land here.

**The derivation gate was too weak.** It proved `docusaurus.config.js` *contained* a `require` of `plugin.json`, not that `customFields` used the loaded value — so keeping the require and writing `pluginVersion: '1.41.0'` would have passed while reintroducing the drift. It now asserts the assignments reference the loaded values, rejects a quoted literal in `pluginVersion`, rejects a numeric literal in `commandCount`, and — where `node` and `website/node_modules` exist — evaluates the config and compares both values against `plugin.json` and a live count of `commands/`. That last one skips in CI (the config pulls in `prism-react-renderer`) and says so explicitly rather than silently. Verified the loophole is closed: a hardcoded version trips two checks, a hardcoded count trips one.

**`\s` is not POSIX ERE.** Replaced with `[[:space:]]` throughout. In fairness I could not reproduce the stated failure — `/usr/bin/grep` here is "BSD grep, GNU compatible 2.6.0-FreeBSD" and does match `\s` — but relying on a GNU/PCRE extension is fragile, and a guard that silently stops matching is the bad failure mode. The portable class costs nothing.

**Pages did not rebuild on a manifest change.** This was the important one. `pages.yml`'s path filter covered `website/`, `commands/`, `references/`, `examples/`, `README.md` and `CHANGELOG.md` — but not the manifest the site had just been made to read. A release touching only `.claude-plugin/` would have skipped the build and left the homepage on the previous version, recreating the exact drift while looking fixed in source. Added `.claude-plugin/**`, which also covers the `source.sha` follow-up commit that by convention touches only `marketplace.json`.

**Consolidated a duplicate gate.** The website assertions existed in both `release-consistency.sh` and `website-coverage.sh`. Two copies of one gate is how this repo's YAML and Terraform checks diverged between `validate.yml` and `release.yml`, so `release-consistency.sh` now delegates and the checks have one home.

## What was missing

The site documented **36 of 44 commands** and **60 of 63 references**:

| Missing as a command | Missing as a reference |
|---|---|
| `ai-governance`, `azure`, `github-actions`, `kingfisher`, `kubernetes`, `openshift`, `secrets`, `token-optimizer` | `ai-governance`, `kingfisher`, `token-optimizer` |

The last three releases each shipped a command that never reached the site — kingfisher in 1.39.0, ai-governance in 1.40.0, token-optimizer in 1.41.0 — plus five domain commands from earlier.

**Cause:** the sidebars are hand-enumerated, and nothing compared them against the directories they document. Adding a command to the repo did not add it to the site, and no gate looked.

## Coverage

All 44 commands and 63 references now appear. The six domain commands went into their existing categories: `kubernetes` and `openshift` under Kubernetes, `azure` under AWS & Azure, `github-actions` under GitHub Actions & CI, `secrets` and `kingfisher` under Security.

## The featured section

`ai-governance` and `token-optimizer` now lead **both** sidebars under a new **AI Agent Governance & Cost** category, and a new homepage section pairs them:

> Two companion commands. One bounds an agent's authority, the other bounds its spend. They register on the same hook event and compose deliberately: the governance gate fails closed so it never stops enforcing, the cost optimizer fails open so it never blocks work.

It reuses the `.command-cards` CSS that already existed in `custom.css` with no consumer.

I read "special section" as a featured sidebar category plus a homepage section. If you wanted standalone landing pages for each instead, say so — that's a different shape and I'd rather build the right one than guess twice.

## One more stale literal

The homepage advertised **"41 commands"** against a repo carrying 44 — the same failure as the version string. `docusaurus.config.js` now reads `commands/` and exposes both the version and the count through `customFields`.

## The gate

`tests/website-coverage.sh` checks four things:

- every file in `commands/` and `references/` appears in its sidebar
- no sidebar entry points at a missing file — that one **breaks the build**, so it is worth catching before CI does
- the version is derived from `plugin.json`, not hardcoded
- the command count is derived from `commands/`, not hardcoded

It asserts the *derivation*, deliberately. Asserting literals would just relocate the stale values into the gate.

Proven to fail on both real regressions:

```
FAIL: commands: commands/token-optimizer.md is not in sidebars-commands.js — it will not appear on the site
FAIL: commands: sidebars-commands.js lists 'does-not-exist' but commands/does-not-exist.md does not exist — the build will break
```

Wired into `tests/handbook-consistency.sh` and the **Skill Structure Checks** job. `release.yml` does not duplicate that job, so unlike the YAML and Terraform gates there is no second copy to keep in sync.

## Verified by building

```
$ npx tsc --noEmit          # clean
$ npx docusaurus build      # [SUCCESS]
```

- hero renders `1.41.0`
- feature strip renders `44 commands`
- governance section and both card links present
- all eight previously-missing command pages exist in `build/`

```bash
bash tests/website-coverage.sh          # PASS (44 + 63 entries, no orphans)
bash tests/handbook-consistency.sh      # PASS
bash tests/release-consistency.sh       # PASS
bash tests/editor-version-consistency.sh # PASS
shellcheck -S warning tests/website-coverage.sh
```

The 3 SC2055 warnings shellcheck reports in `handbook-consistency.sh` are pre-existing — 3 on `main`, 3 here — and are false positives: `A != B || A != C` is the correct test for "all three must match".

## Rollback

Sidebars, one homepage section, a derived count, and a new test script. No command, reference or plugin behaviour changes. Reverting returns the site to 36 commands.

## Not ready for review yet

Draft, and it depends on #182.

