### PR TITLE
fix(token-optimizer): size searches by output, parse string args, protect user edits

### DIFF
--- a/commands/token-optimizer.md
+++ b/commands/token-optimizer.md
@@ -287,7 +287,7 @@ Steps:
     ```
     This is what `remove` uses to identify assets safe to delete.
 
-11b. **Record what was installed.** Write `.token-optimizer/installed.sha256` as the very last step of setup — after the config is written, after the model rewrite in 8b, and after every ownership marker is injected. The manifest must hash each file **exactly as it now sits on disk**, or `remove` will read a mismatch for a file nobody touched and refuse to uninstall it.
+11b. **Record what was installed.** Write `.token-optimizer/installed.sha256` as the very last step of setup — after the config is written, after the model rewrite in 10b, and after every ownership marker is injected. The manifest must hash each file **exactly as it now sits on disk**, or `remove` will read a mismatch for a file nobody touched and refuse to uninstall it.
 
    ```bash
    # Run LAST. Every path this setup installed, hashed as-written.
@@ -617,22 +617,14 @@ Steps:
    - `.token-optimizer.yaml`
    - `.token-optimizer/optimize.sh`
    - `.token-optimizer/probe/run-probe.sh` and `.token-optimizer/probe/fixture.json`
-
-   For the **shared** files setup edited rather than created — `.claude/settings.json`, `.github/hooks/preToolUse.json`, the repository-root `settings.json` `hooks` key, `~/.copilot/config.json` — remove only this command's own entry with `jq`, matching on the command string. Never delete the file. It may hold `ai-governance`'s hooks or the user's own, and a whole-file hash cannot tell you otherwise.
-
-   Finally, remove `.token-optimizer/` **only if it is empty** after the steps above:
-
-   ```bash
-   # rmdir, never rm -rf: a preserved locally-modified file must survive
-   # uninstall, and a recursive delete of the parent would take it with it.
-   rmdir .token-optimizer/probe .token-optimizer/state .token-optimizer 2>/dev/null || true
-   ```
-
-   If `rmdir` refuses because something is still there, that is the intended outcome — report the directory as retained and name what is in it.
    - `.claude/agents/platform-bulk-reader.md` and `~/.claude/agents/platform-bulk-reader.md`
    - `.github/agents/platform-bulk-reader.agent.md` and `.github/agents/platform-coordinator.agent.md` (Copilot CLI and VS Code)
    - `~/.copilot/agents/platform-bulk-reader.agent.md` and `~/.copilot/agents/platform-coordinator.agent.md` (user-scoped)
    - Hook entries in `.claude/settings.json`, `.github/hooks/*.json`, repository root `settings.json` `hooks` key, `~/.copilot/config.json`
+
+   For the **shared** files setup edited rather than created — `.claude/settings.json`, `.github/hooks/preToolUse.json`, the repository-root `settings.json` `hooks` key, `~/.copilot/config.json` — remove only this command's own entry with `jq`, matching on the command string. Never delete the file. It may hold `ai-governance`'s hooks or the user's own, and a whole-file hash cannot tell you otherwise.
+
+   This step only **lists**. It deletes nothing and it removes no directory. Directory cleanup is step 8, because it cannot run before every hash comparison below has finished.
 
 3. For each asset carrying the ownership marker:
    Check before mutating. In this order, and never delete before the comparison:
@@ -658,10 +650,36 @@ Steps:
 
 7. Remove `.token-optimizer/` entries from `.gitignore` if they were added by `setup`.
 
+8. **Last: drop the manifest, then the directories.** This is the final step for a reason. `.token-optimizer/installed.sha256` is the input to every comparison in step 3, so deleting it earlier would strip the evidence the later assets are judged against. Remove it only once no asset still needs to be checked, and only then attempt the directories:
+
+   ```bash
+   # rmdir, never rm -rf: a preserved locally-modified file must survive
+   # uninstall, and a recursive delete of the parent would take it with it.
+   rm -f .token-optimizer/installed.sha256
+   rmdir .token-optimizer/probe .token-optimizer/state .token-optimizer 2>/dev/null || true
+   ```
+
+   `rmdir` refusing is a normal outcome, not a failure — report the directory as retained and name what is still in it. Two cases are expected:
+   - `decisions.log` is preserved by default (step 5), so **a clean uninstall normally does keep `.token-optimizer/`**. Say so, rather than reporting it as leftover junk.
+   - Anything preserved in step 3 as `locally modified` or `no manifest entry` is still there by design.
+
+   Only report full removal when `rmdir` actually succeeded.
+
 **Validation:**
 ```bash
-[[ ! -f .token-optimizer.yaml ]] && echo "config: removed"
-[[ ! -f .token-optimizer/optimize.sh ]] && echo "core script: removed"
-[[ ! -d .token-optimizer/state ]] && echo "state directory: removed"
+[[ ! -f .token-optimizer.yaml ]]            && echo "config: removed"
+[[ ! -f .token-optimizer/optimize.sh ]]     && echo "core script: removed"
+[[ ! -d .token-optimizer/state ]]           && echo "state directory: removed"
+[[ ! -f .token-optimizer/installed.sha256 ]] && echo "manifest: removed"
+
+# .token-optimizer/ itself is EXPECTED to survive when decisions.log was kept.
+# Absence is not the success condition here — what remains must be explainable.
+if [[ -d .token-optimizer ]]; then
+  echo "retained .token-optimizer/, contents:"
+  find .token-optimizer -mindepth 1 | sed 's/^/  /'
+else
+  echo ".token-optimizer/: fully removed"
+fi
+
 git status --short
 ```

--- a/commands/token-optimizer.md
+++ b/commands/token-optimizer.md
@@ -199,24 +199,6 @@ Steps:
    ```
    The probe script resolves its output path relative to its own location, so running `.token-optimizer/probe/run-probe.sh` updates `.token-optimizer/probe/fixture.json`.
 
-8b. **Wire the chosen worker model into the installed agent.** The shipped templates carry a fixed `model:` (`haiku` for Claude Code, `claude-haiku-4.5` for the Copilot CLI and VS Code readers). Copying them verbatim leaves the agent pinned to that value while `.token-optimizer.yaml` claims whatever the user picked — so a user who chose `gpt-5-mini` gets a reader still running `claude-haiku-4.5`, and on Copilot, where the mode is capped to audit, the redirect reason that would have carried the chosen model is never emitted either. Nothing else in setup corrects this.
-
-   After copying each agent template, rewrite its frontmatter `model:` to the selected value:
-   ```bash
-   # $AGENT_FILE is the INSTALLED copy, $WORKER_MODEL the value written to
-   # .token-optimizer.yaml. Only the first `model:` line, which is in frontmatter.
-   awk -v m="$WORKER_MODEL" '
-     BEGIN { done = 0 }
-     /^model:/ && !done { print "model: " m; done = 1; next }
-     { print }
-   ' "$AGENT_FILE" > "$AGENT_FILE.tmp" && mv "$AGENT_FILE.tmp" "$AGENT_FILE"
-   ```
-   Then confirm it took, and say what was set:
-   ```bash
-   awk '/^---$/{n++; next} n==1 && /^model:/{print; exit}' "$AGENT_FILE"
-   ```
-   Apply this to the reader on every client. Do **not** apply it to a coordinator: the Copilot CLI coordinator deliberately sets no `model:` and inherits the session's, and the VS Code coordinator pins `claude-sonnet-4.6` as the *decision* model, which is not the worker model the user chose.
-
 9. Register the PreToolUse hook by **appending**, never overwriting. Existing hooks for other features (e.g., `ai-governance`) must remain intact.
 
    **For Claude Code**, use the three-level matcher-group structure and the `jq` idiom from `commands/ai-governance.md:142-151`:
@@ -270,7 +252,9 @@ Steps:
 
    > Installed: reader and coordinator agent definitions in `.github/agents/`. **No hook was installed**, so nothing is classified or logged on this client — the optimizer here is routing guidance only. Agent-scoped hooks are a preview feature gated on `chat.useCustomAgentHooks`; enabling that setting will not change anything until a hook exists to load. `doctor` will report `read redirection active: no (unsupported on this client)`, which is accurate rather than a misconfiguration.
 
-   If you want classification on VS Code, install the repository-scoped Copilot surface instead — `.github/hooks/preToolUse.json` is read by Copilot CLI, and VS Code shares `.github/agents/` but not that hook path. Say which you did.
+   Be precise about which kind of gap this is. **This feature does not implement a VS Code hook** — that is a limitation of this command, not a statement about the client. Do not claim VS Code cannot discover `.github/hooks/*.json`; that has not been verified either way here, and asserting it would be inventing a client limitation to explain a missing feature.
+
+   If you want classification on this repository, install the `copilot-cli` surface, which registers `.github/hooks/preToolUse.json` and is exercised by the shipped tests. Whether VS Code also loads that file is unverified; if it does, classification may work there as a side effect rather than by design. Before advertising VS Code support, validate the registration format against the installed build and confirm the adapter round-trips a real payload.
 
 10. Copy the client's agent templates. The optimizer's own config, state directory and hook command are repository-scoped, but agent definitions can additionally be installed user-wide, so both destinations are listed where a client supports them:
    - **Claude Code** (repository): copy `examples/token-optimizer/claude/platform-bulk-reader.md` to `.claude/agents/platform-bulk-reader.md`
@@ -279,11 +263,43 @@ Steps:
    - **Copilot CLI** (user): copy both to `~/.copilot/agents/`
    - **VS Code** (repository): copy both `examples/token-optimizer/vscode/platform-bulk-reader.agent.md` and `examples/token-optimizer/vscode/platform-coordinator.agent.md` to `.github/agents/`
 
+10b. **Wire the chosen worker model into the installed agent.** This has to run *after* step 10 — the file it rewrites does not exist until the template is copied. The shipped templates carry a fixed `model:` (`haiku` for Claude Code, `claude-haiku-4.5` for the Copilot CLI and VS Code readers). Copying them verbatim leaves the agent pinned to that value while `.token-optimizer.yaml` claims whatever the user picked — so a user who chose `gpt-5-mini` gets a reader still running `claude-haiku-4.5`, and on Copilot, where the mode is capped to audit, the redirect reason that would have carried the chosen model is never emitted either. Nothing else in setup corrects this.
+
+   After copying each agent template, rewrite its frontmatter `model:` to the selected value:
+   ```bash
+   # $AGENT_FILE is the INSTALLED copy, $WORKER_MODEL the value written to
+   # .token-optimizer.yaml. Only the first `model:` line, which is in frontmatter.
+   awk -v m="$WORKER_MODEL" '
+     BEGIN { done = 0 }
+     /^model:/ && !done { print "model: " m; done = 1; next }
+     { print }
+   ' "$AGENT_FILE" > "$AGENT_FILE.tmp" && mv "$AGENT_FILE.tmp" "$AGENT_FILE"
+   ```
+   Then confirm it took, and say what was set:
+   ```bash
+   awk '/^---$/{n++; next} n==1 && /^model:/{print; exit}' "$AGENT_FILE"
+   ```
+   Apply this to the reader on every client. Do **not** apply it to a coordinator: the Copilot CLI coordinator deliberately sets no `model:` and inherits the session's, and the VS Code coordinator pins `claude-sonnet-4.6` as the *decision* model, which is not the worker model the user chose.
+
 11. Add an ownership marker to every generated asset (YAML, JSON, agent templates) as a comment or frontmatter field:
     ```
     # OWNERSHIP MARKER: platform-skills token-optimizer v1.41.0
     ```
     This is what `remove` uses to identify assets safe to delete.
+
+11b. **Record what was installed.** Write `.token-optimizer/installed.sha256` as the very last step of setup — after the config is written, after the model rewrite in 8b, and after every ownership marker is injected. The manifest must hash each file **exactly as it now sits on disk**, or `remove` will read a mismatch for a file nobody touched and refuse to uninstall it.
+
+   ```bash
+   # Run LAST. Every path this setup installed, hashed as-written.
+   : > .token-optimizer/installed.sha256
+   for f in "${INSTALLED_ASSETS[@]}"; do
+     [ -f "$f" ] || continue
+     printf '%s  %s\n' "$(shasum -a 256 "$f" | cut -d' ' -f1)" "$f" \
+       >> .token-optimizer/installed.sha256
+   done
+   ```
+
+   `INSTALLED_ASSETS` is every file setup created or generated: `.token-optimizer.yaml`, `.token-optimizer/optimize.sh`, the probe script, and each installed agent definition. Do **not** list shared files that setup only *edited* — `.claude/settings.json`, `.github/hooks/preToolUse.json`, `settings.json`, `~/.copilot/config.json`. A whole-file hash of a shared file proves only that it has not changed since setup; it does not prove this command owns it, and deleting it would take another feature's hooks with it. Those are handled surgically in `remove`.
 
 12. Add runtime state to `.gitignore`, but explicitly do not ignore the script itself (the committed hook invokes it):
     ```bash
@@ -352,12 +368,14 @@ Steps:
 
    When resolution cannot be observed from static files (e.g., Bedrock mapping is account-specific), print `unverified` and make **no** cheaper-routing claim:
    ```
-   worker model resolved:    unverified (Bedrock mapping is account-specific)
+   worker model requested:   haiku (config; frontmatter agrees)
+   worker model observed:    unverified (Bedrock resolution is account-specific and no probe run recorded)
    ```
 
    When resolution is known:
    ```
-   worker model resolved:    claude-haiku-4.5 (source: config)
+   worker model requested:   claude-haiku-4.5 (config; frontmatter agrees)
+   worker model observed:    unverified (no probe run recorded)
    ```
 
 3. **read redirection active** — check the effective mode and platform caps, passing the actual client being inspected:
@@ -393,7 +411,8 @@ Steps:
 **Validation:**
 ```
 delegation verified:      yes | no (runtime fixture required) | no (unsupported)
-worker model resolved:    <resolved> (source: <how>) | unverified
+worker model requested:   <config value> (config; frontmatter agrees | FRONTMATTER DISAGREES: <value>)
+worker model observed:    <observed> (probe <client_version>) | unverified (no probe run recorded)
 read redirection active:  yes | no (audit only) | no (unsupported on this client)
 default read limit:       <n> (measured) | <n> (assumed) | unknown
 ```
@@ -598,14 +617,33 @@ Steps:
    - `.token-optimizer.yaml`
    - `.token-optimizer/optimize.sh`
    - `.token-optimizer/probe/run-probe.sh` and `.token-optimizer/probe/fixture.json`
+
+   For the **shared** files setup edited rather than created — `.claude/settings.json`, `.github/hooks/preToolUse.json`, the repository-root `settings.json` `hooks` key, `~/.copilot/config.json` — remove only this command's own entry with `jq`, matching on the command string. Never delete the file. It may hold `ai-governance`'s hooks or the user's own, and a whole-file hash cannot tell you otherwise.
+
+   Finally, remove `.token-optimizer/` **only if it is empty** after the steps above:
+
+   ```bash
+   # rmdir, never rm -rf: a preserved locally-modified file must survive
+   # uninstall, and a recursive delete of the parent would take it with it.
+   rmdir .token-optimizer/probe .token-optimizer/state .token-optimizer 2>/dev/null || true
+   ```
+
+   If `rmdir` refuses because something is still there, that is the intended outcome — report the directory as retained and name what is in it.
    - `.claude/agents/platform-bulk-reader.md` and `~/.claude/agents/platform-bulk-reader.md`
    - `.github/agents/platform-bulk-reader.agent.md` and `.github/agents/platform-coordinator.agent.md` (Copilot CLI and VS Code)
    - `~/.copilot/agents/platform-bulk-reader.agent.md` and `~/.copilot/agents/platform-coordinator.agent.md` (user-scoped)
    - Hook entries in `.claude/settings.json`, `.github/hooks/*.json`, repository root `settings.json` `hooks` key, `~/.copilot/config.json`
 
 3. For each asset carrying the ownership marker:
-   - Remove it immediately
-   - If the recomputed SHA-256 does not match the line in `.token-optimizer/installed.sha256`, the user has edited it: **do not delete it**. Report `preserved (locally modified): <path>` and continue with the rest.
+   Check before mutating. In this order, and never delete before the comparison:
+
+   1. Look up the asset's recorded hash in `.token-optimizer/installed.sha256`.
+   2. **No entry** — this command did not record installing it. Do not delete. Report `preserved (no manifest entry): <path>`.
+   3. **Entry found** — recompute the file's SHA-256 and compare.
+      - **Match**: this command wrote it and nobody has edited it since. Delete it.
+      - **Mismatch**: the user has edited it. **Do not delete.** Report `preserved (locally modified): <path>` and move on.
+
+   Deleting first and comparing afterwards is not a variant of this — it destroys the file the comparison exists to protect.
    - The ownership marker is authoritative because `setup` injects it, so no shipped-file hash can match a generated asset
    
    For assets with no ownership marker:

--- a/commands/token-optimizer.md
+++ b/commands/token-optimizer.md
@@ -199,6 +199,24 @@ Steps:
    ```
    The probe script resolves its output path relative to its own location, so running `.token-optimizer/probe/run-probe.sh` updates `.token-optimizer/probe/fixture.json`.
 
+8b. **Wire the chosen worker model into the installed agent.** The shipped templates carry a fixed `model:` (`haiku` for Claude Code, `claude-haiku-4.5` for the Copilot CLI and VS Code readers). Copying them verbatim leaves the agent pinned to that value while `.token-optimizer.yaml` claims whatever the user picked — so a user who chose `gpt-5-mini` gets a reader still running `claude-haiku-4.5`, and on Copilot, where the mode is capped to audit, the redirect reason that would have carried the chosen model is never emitted either. Nothing else in setup corrects this.
+
+   After copying each agent template, rewrite its frontmatter `model:` to the selected value:
+   ```bash
+   # $AGENT_FILE is the INSTALLED copy, $WORKER_MODEL the value written to
+   # .token-optimizer.yaml. Only the first `model:` line, which is in frontmatter.
+   awk -v m="$WORKER_MODEL" '
+     BEGIN { done = 0 }
+     /^model:/ && !done { print "model: " m; done = 1; next }
+     { print }
+   ' "$AGENT_FILE" > "$AGENT_FILE.tmp" && mv "$AGENT_FILE.tmp" "$AGENT_FILE"
+   ```
+   Then confirm it took, and say what was set:
+   ```bash
+   awk '/^---$/{n++; next} n==1 && /^model:/{print; exit}' "$AGENT_FILE"
+   ```
+   Apply this to the reader on every client. Do **not** apply it to a coordinator: the Copilot CLI coordinator deliberately sets no `model:` and inherits the session's, and the VS Code coordinator pins `claude-sonnet-4.6` as the *decision* model, which is not the worker model the user chose.
+
 9. Register the PreToolUse hook by **appending**, never overwriting. Existing hooks for other features (e.g., `ai-governance`) must remain intact.
 
    **For Claude Code**, use the three-level matcher-group structure and the `jq` idiom from `commands/ai-governance.md:142-151`:
@@ -246,7 +264,13 @@ Steps:
 
    c. User `~/.copilot/config.json` `hooks` key (only if the user wants the optimizer active across all their repositories, and only alongside a repository-scoped install in each) — merge using `jq`.
 
-   **For VS Code**, note that agent-scoped hooks are a preview feature gated on `chat.useCustomAgentHooks`. If that setting is not enabled, the hooks will not fire. Report this as a post-setup instruction.
+   **For VS Code**, there is nothing to register, and setup must say that plainly rather than implying otherwise. The shipped VS Code templates are agent definitions only — neither carries a `hooks` field, and this command installs no hook file for VS Code. Telling a user to enable `chat.useCustomAgentHooks` while installing nothing for it to load leaves them believing audit logging is active when no hook exists to write it.
+
+   Report exactly this after a VS Code install:
+
+   > Installed: reader and coordinator agent definitions in `.github/agents/`. **No hook was installed**, so nothing is classified or logged on this client — the optimizer here is routing guidance only. Agent-scoped hooks are a preview feature gated on `chat.useCustomAgentHooks`; enabling that setting will not change anything until a hook exists to load. `doctor` will report `read redirection active: no (unsupported on this client)`, which is accurate rather than a misconfiguration.
+
+   If you want classification on VS Code, install the repository-scoped Copilot surface instead — `.github/hooks/preToolUse.json` is read by Copilot CLI, and VS Code shares `.github/agents/` but not that hook path. Say which you did.
 
 10. Copy the client's agent templates. The optimizer's own config, state directory and hook command are repository-scoped, but agent definitions can additionally be installed user-wide, so both destinations are listed where a client supports them:
    - **Claude Code** (repository): copy `examples/token-optimizer/claude/platform-bulk-reader.md` to `.claude/agents/platform-bulk-reader.md`
@@ -319,7 +343,12 @@ Steps:
    fi
    ```
 
-2. **worker model resolved** — read the config's `worker_model` and report what the client would resolve it to. On Claude Code, the agent definition's frontmatter `model:` field is the request, and the resolved model depends on the provider. On Copilot CLI, the requested model is directly in the config.
+2. **worker model** — report the **requested** and the **observed** model as two separate values, and never present a configuration value as a resolved one.
+
+   - **requested**: the config's `worker_model`, cross-checked against the installed agent's frontmatter `model:`. If those two disagree, say so — it means `setup` did not finish wiring the model, and the agent will run something other than what the config claims.
+   - **observed**: only from a recorded probe run. If no probe has run, print `observed: unverified (run .token-optimizer/probe/run-probe.sh)` and make no claim about what the worker actually used.
+
+   A requested model is not evidence. An invocation-time override, a cost-tier cap, or an `Auto` session can all resolve something else, so reporting the config value as "resolved" would assert exactly what has not been checked.
 
    When resolution cannot be observed from static files (e.g., Bedrock mapping is account-specific), print `unverified` and make **no** cheaper-routing claim:
    ```
@@ -359,7 +388,7 @@ Steps:
    - Whether `.token-optimizer/state/` exists (without it recovery cannot bound and the core will not redirect)
    - Whether `chat.useCustomAgentHooks` is set on VS Code (required for agent-scoped hooks)
    - Whether `disableAllHooks` is set in Copilot's config (if true, no hooks fire at all)
-   - Whether each worker budget is natively enforced or instruction-only (on Claude Code, agent-level `max_tokens`, `timeout`, and `max_iterations` are natively enforced; on other clients, budgets are instruction-only)
+   - Report `max_delegations_per_task`, `max_worker_retries` and `max_worker_seconds` as **instruction-only on every client**. They are carried to the worker in the redirect reason and nothing enforces them. Do not claim otherwise: `max_tokens`, `timeout` and `max_iterations` are not documented Claude subagent frontmatter fields, and the shipped worker sets no limit of any kind. If a client gains an enforceable control, name that control and report it separately from these three.
 
 **Validation:**
 ```
@@ -548,7 +577,18 @@ yq eval '.enabled' .token-optimizer.yaml
 
 ## Mode: remove
 
-Remove assets carrying the ownership marker. The marker is authoritative: `setup` injects it, so no shipped-file hash can ever match a generated asset, and gating deletion on a hash match would make uninstall silently inert. A marked asset whose content differs from what `setup` would generate is still removed, and reported as locally modified. An asset with no marker is never touched, only listed for manual review.
+Remove only assets this command installed and the user has not since edited.
+
+Two properties have to hold at once, and an earlier revision traded one away for the other. Gating deletion on a hash of the *shipped* file made uninstall inert, because `setup` injects an ownership marker and that changes the content. Dropping the hash entirely fixed uninstall but started deleting files the user had edited — losing their work to a command whose own wizard promises "owned, unmodified assets".
+
+Both hold if `setup` records the hash of what it actually **generated**, marker included. So:
+
+- `setup` writes a manifest at `.token-optimizer/installed.sha256`, one line per installed asset: the SHA-256 of the file **as written**, and its path.
+- `remove` recomputes each hash. Match means this command wrote it and nobody has touched it since — delete.
+- Mismatch means the user edited it. **Preserve it**, and report it as modified with its path so they can decide.
+- No marker and no manifest entry means it is not ours. Never touch it; list it for manual review.
+
+The marker proves ownership. It does not prove deletion is safe.
 
 Steps:
 
@@ -565,7 +605,7 @@ Steps:
 
 3. For each asset carrying the ownership marker:
    - Remove it immediately
-   - If the asset's content differs from what `setup` would generate (compare against `examples/token-optimizer/`), report it as "removed (locally modified)"
+   - If the recomputed SHA-256 does not match the line in `.token-optimizer/installed.sha256`, the user has edited it: **do not delete it**. Report `preserved (locally modified): <path>` and continue with the rest.
    - The ownership marker is authoritative because `setup` injects it, so no shipped-file hash can match a generated asset
    
    For assets with no ownership marker:

--- a/examples/token-optimizer/claude/probe/fixture.json
+++ b/examples/token-optimizer/claude/probe/fixture.json
@@ -7,7 +7,8 @@
   "independent_context": null,
   "returned_to_parent": null,
   "delegation_verified": false,
-  "worker_model_requested": "haiku",
+  "worker_model_requested": null,
+  "worker_model_requested_source": null,
   "worker_model_resolved": null,
   "model_verification_source": null
 }

--- a/examples/token-optimizer/claude/probe/run-probe.sh
+++ b/examples/token-optimizer/claude/probe/run-probe.sh
@@ -10,9 +10,69 @@ OUT="$HERE/fixture.json"
 CLIENT_VERSION="$(claude --version 2>/dev/null | head -1)"
 [[ -n "$CLIENT_VERSION" ]] || { echo "claude CLI not found on PATH"; exit 1; }
 
+# The requested model has to be read from THIS installation, not hardcoded.
+# A literal "haiku" here made the fixture assert a model the user may never have
+# chosen: setup rewrites the installed agent's `model:` to whatever was picked,
+# so a user on gpt-5-mini got a fixture claiming haiku was requested. That
+# defeats the whole point of separating "requested" from "observed".
+find_up() {
+  # find_up <relative-path> -> absolute path on stdout, or non-zero
+  local rel="${1:?}" dir="$PWD"
+  while :; do
+    if [[ -e "$dir/$rel" ]]; then printf '%s' "$dir/$rel"; return 0; fi
+    if [[ "$dir" == "/" || -z "$dir" ]]; then return 1; fi
+    dir="$(dirname "$dir")"
+  done
+}
+
+CONFIG_FILE="${TOKEN_OPTIMIZER_CONFIG:-}"
+if [[ -z "$CONFIG_FILE" ]]; then
+  CONFIG_FILE="$(find_up .token-optimizer.yaml)" || CONFIG_FILE=""
+fi
+AGENT_FILE="${TOKEN_OPTIMIZER_AGENT:-}"
+if [[ -z "$AGENT_FILE" ]]; then
+  AGENT_FILE="$(find_up .claude/agents/platform-bulk-reader.md)" || AGENT_FILE=""
+fi
+
+MODEL_CONFIG=""
+if [[ -n "$CONFIG_FILE" && -r "$CONFIG_FILE" ]]; then
+  MODEL_CONFIG="$(awk '/^[[:space:]]*worker_model:[[:space:]]*/ {
+      sub(/^[[:space:]]*worker_model:[[:space:]]*/, "")
+      sub(/[[:space:]]*(#.*)?$/, ""); gsub(/^["'\'']|["'\'']$/, "")
+      print; exit }' "$CONFIG_FILE")"
+fi
+
+MODEL_FRONTMATTER=""
+if [[ -n "$AGENT_FILE" && -r "$AGENT_FILE" ]]; then
+  # Only the first frontmatter block, so a `model:` mentioned in prose below it
+  # cannot be mistaken for the declaration.
+  MODEL_FRONTMATTER="$(awk '
+      /^---[[:space:]]*$/ { n++; if (n >= 2) exit; next }
+      n == 1 && /^model:[[:space:]]*/ {
+        sub(/^model:[[:space:]]*/, ""); sub(/[[:space:]]*$/, "")
+        gsub(/^["'\'']|["'\'']$/, ""); print; exit }' "$AGENT_FILE")"
+fi
+
+# Config is what the user asked for, so it wins. Frontmatter is the fallback for
+# an install where the config is gone but the agent is still in place.
+MODEL_SOURCE="none"
+MODEL_REQUESTED="unknown"
+if [[ -n "$MODEL_CONFIG" ]]; then
+  MODEL_REQUESTED="$MODEL_CONFIG"; MODEL_SOURCE="config:$CONFIG_FILE"
+elif [[ -n "$MODEL_FRONTMATTER" ]]; then
+  MODEL_REQUESTED="$MODEL_FRONTMATTER"; MODEL_SOURCE="frontmatter:$AGENT_FILE"
+fi
+
+# A disagreement means setup's rewrite did not land. Record it rather than
+# quietly preferring one value.
+if [[ -n "$MODEL_CONFIG" && -n "$MODEL_FRONTMATTER" && "$MODEL_CONFIG" != "$MODEL_FRONTMATTER" ]]; then
+  MODEL_SOURCE="$MODEL_SOURCE (FRONTMATTER DISAGREES: $MODEL_FRONTMATTER)"
+fi
+
 cat <<EOF
 Probe: Claude Code delegation
-Client: $CLIENT_VERSION
+Client:           $CLIENT_VERSION
+Requested model:  $MODEL_REQUESTED ($MODEL_SOURCE)
 
 This probe cannot be fully automated — questions 1 and 2 need a human to read a
 real session transcript. Run the three checks below, then record the answers.
@@ -32,9 +92,9 @@ real session transcript. Run the three checks below, then record the answers.
      parent continued the original task.
 
   4. RESOLVED MODEL
-     Confirm which model the worker actually ran. Frontmatter says 'haiku'; an
-     Auto session or a provider override can resolve something else. Record the
-     resolved id and how you observed it.
+     Confirm which model the worker actually ran. This installation requests
+     '$MODEL_REQUESTED'; an Auto session or a provider override can resolve
+     something else. Record the resolved id and how you observed it.
 EOF
 
 read -r -p "1. Worker invoked?         (yes/no) " Q1
@@ -56,7 +116,8 @@ cat > "$OUT" <<EOF
   "independent_context": $([[ "$Q2" == "yes" ]] && echo true || echo false),
   "returned_to_parent": $([[ "$Q3" == "yes" ]] && echo true || echo false),
   "delegation_verified": $VERIFIED,
-  "worker_model_requested": "haiku",
+  "worker_model_requested": "$MODEL_REQUESTED",
+  "worker_model_requested_source": "$MODEL_SOURCE",
   "worker_model_resolved": "$Q4",
   "model_verification_source": "$Q4SRC"
 }

--- a/examples/token-optimizer/copilot-cli/platform-bulk-reader.agent.md
+++ b/examples/token-optimizer/copilot-cli/platform-bulk-reader.agent.md
@@ -62,3 +62,5 @@ regardless of what `.token-optimizer.yaml` says.
 Until a runtime fixture proves worker invocation, independent context, and a
 bounded return to the parent, treat this as routing guidance only and make no
 cost claim. Run `/platform-skills:token-optimizer doctor` for current status.
+
+**Unverified means not demonstrated — not proven absent.** GitHub documents an `agent` tool alias, and its absence from a given CLI build's `--help` output is not evidence that delegation is unavailable. Check tool availability against the installed client version and the official documentation before concluding anything. Equally, `handoffs` on its own does not demonstrate the opposite: it does not prove a separate worker context or a return to the parent. Neither reading is settled here, which is exactly why nothing claims working delegation or a saving until an authenticated runtime test shows both.

--- a/examples/token-optimizer/copilot-cli/platform-coordinator.agent.md
+++ b/examples/token-optimizer/copilot-cli/platform-coordinator.agent.md
@@ -49,3 +49,5 @@ regardless of what `.token-optimizer.yaml` says.
 Until a runtime fixture proves worker invocation, independent context, and a
 bounded return to the parent, treat this as routing guidance only and make no
 cost claim. Run `/platform-skills:token-optimizer doctor` for current status.
+
+**Unverified means not demonstrated — not proven absent.** GitHub documents an `agent` tool alias, and its absence from a given CLI build's `--help` output is not evidence that delegation is unavailable. Check tool availability against the installed client version and the official documentation before concluding anything. Equally, `handoffs` on its own does not demonstrate the opposite: it does not prove a separate worker context or a return to the parent. Neither reading is settled here, which is exactly why nothing claims working delegation or a saving until an authenticated runtime test shows both.

--- a/examples/token-optimizer/optimize.sh
+++ b/examples/token-optimizer/optimize.sh
@@ -51,6 +51,8 @@ P_COMMAND=""
 P_AGENT_TYPE=""
 P_AGENT_ID=""
 P_SESSION=""
+P_OUTPUT_MODE=""
+P_HEAD_LIMIT=0
 
 usage() {
   cat <<'EOF'
@@ -253,6 +255,7 @@ normalize_payload() {
   local raw="${1:-}"
   P_TOOL=""; P_PATH=""; P_OFFSET=0; P_LIMIT=0
   P_COMMAND=""; P_AGENT_TYPE=""; P_AGENT_ID=""; P_SESSION=""
+  P_OUTPUT_MODE=""; P_HEAD_LIMIT=0
 
   command -v jq >/dev/null 2>&1 || { degrade "jq not installed"; return 1; }
 
@@ -260,8 +263,19 @@ normalize_payload() {
   local item
   while IFS= read -r -d '' item; do f+=("$item"); done < <(
     printf '%s' "$raw" | jq -j '
-      def obj(g): (g | if type == "object" then . else {} end);
-      (obj(.tool_input) + obj(.toolArgs)) as $a
+      # A client may send tool arguments as an object OR as a JSON-encoded
+      # STRING. Coercing a string to {} silently discarded the path, so every
+      # read arrived unclassified and unlogged. Parse the string; if it is not
+      # valid JSON, report malformed rather than swallowing it.
+      def parsed(g):
+        g | if   type == "object" then {ok: true,  v: .}
+            elif type == "null"   then {ok: true,  v: {}}
+            elif type == "string" then (try {ok: true, v: fromjson} catch {ok: false, v: {}})
+            else {ok: false, v: {}} end;
+      parsed(.tool_input) as $ti
+      | parsed(.toolArgs) as $ta
+      | (($ti.v | if type == "object" then . else {} end)
+         + ($ta.v | if type == "object" then . else {} end)) as $a
       | [ (.tool_name // .toolName // "")
         , ($a.file_path // $a.path // $a.notebook_path // "")
         , (($a.offset // 0) | tostring)
@@ -270,21 +284,34 @@ normalize_payload() {
         , (.agent_type // .agentType // "")
         , (.agent_id // .agentId // "")
         , (.session_id // .sessionId // "")
+        , ($a.output_mode // "")
+        , (($a.head_limit // 0) | tostring)
+        , (if ($ti.ok and $ta.ok) then "ok" else "malformed" end)
         ] | map(. + "\u0000") | join("")
     ' 2>/dev/null
   )
 
   # Exactly eight fields, or the parse failed. This also catches malformed JSON,
   # where jq emits nothing at all.
-  if [[ "${#f[@]}" -ne 8 ]]; then
-    degrade "payload parse failed (${#f[@]} of 8 fields)"
+  if [[ "${#f[@]}" -ne 11 ]]; then
+    degrade "payload parse failed (${#f[@]} of 11 fields)"
     return 1
   fi
 
   P_TOOL="${f[0]}"; P_PATH="${f[1]}"; P_OFFSET="${f[2]}"; P_LIMIT="${f[3]}"
   P_COMMAND="${f[4]}"; P_AGENT_TYPE="${f[5]}"; P_AGENT_ID="${f[6]}"; P_SESSION="${f[7]}"
+  P_OUTPUT_MODE="${f[8]}"; P_HEAD_LIMIT="${f[9]}"
   is_uint "$P_OFFSET" || P_OFFSET=0
   is_uint "$P_LIMIT"  || P_LIMIT=0
+  is_uint "$P_HEAD_LIMIT" || P_HEAD_LIMIT=0
+
+  # Malformed tool arguments must not pass as an empty read. Fail open as
+  # always, but say so, so an unclassifiable payload is visible in the log
+  # instead of looking like a small read.
+  if [[ "${f[10]}" != "ok" ]]; then
+    degrade "tool arguments were neither an object nor valid JSON"
+    return 1
+  fi
   return 0
 }
 
@@ -312,14 +339,45 @@ range_bytes() {
   printf '%s' "$(( n ))"
 }
 
-is_read_tool() {
+# Tools whose output IS the file's content, so the file's size predicts the
+# cost of the call.
+is_content_read_tool() {
   local name
   name="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
   case "$name" in
-    read|view|cat|glob|grep|search|find|ls|list|notebookread|readfile|str_replace_editor_view)
-      return 0 ;;
+    read|view|cat|notebookread|readfile|str_replace_editor_view) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+# Tools whose output is DERIVED from the file — a count, a list of paths, the
+# matching lines. The file's size says nothing about the size of that output.
+# Classifying these by file size denied a `Grep` with output_mode=count against a
+# 1000-line file, which returns a single number: a false positive that makes the
+# optimizer look broken and costs a delegation for nothing.
+is_search_tool() {
+  local name
+  name="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  case "$name" in
+    grep|search|glob|find|ls|list|codebase|usages) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# A search is in scope only when the payload states a bound we can size. A
+# content-mode search with an explicit head_limit requests that many lines; a
+# count or a filenames-only search returns effectively nothing; an unbounded
+# content search cannot be predicted from the file at all.
+search_requested_lines() {
+  # search_requested_lines <output_mode> <head_limit>  -> lines, or empty if unsizable
+  local mode head
+  mode="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  head="${2:-0}"
+  case "$mode" in
+    count|files_with_matches|files-with-matches) printf '0' ; return 0 ;;
+  esac
+  if is_uint "$head" && [[ "$head" -gt 0 ]]; then printf '%s' "$head"; return 0; fi
+  return 1
 }
 
 REQ_LINES=0
@@ -620,12 +678,33 @@ run_hook_mode() {
     return 0
   fi
 
-  is_read_tool "$P_TOOL" || return 0
   [[ -n "$P_PATH" ]] || return 0
+
+  local eff_limit="$P_LIMIT" eff_offset="$P_OFFSET"
+  if is_content_read_tool "$P_TOOL"; then
+    : # the file's size is the cost; classify it as given
+  elif is_search_tool "$P_TOOL"; then
+    # Size the SEARCH OUTPUT, never the underlying file.
+    local slines
+    if ! slines="$(search_requested_lines "$P_OUTPUT_MODE" "$P_HEAD_LIMIT")"; then
+      # Unbounded content search: its output cannot be derived from the file, so
+      # there is nothing honest to classify. Pass.
+      log_line "audit" "search_unsizable" "${P_TOOL} mode=${P_OUTPUT_MODE:-unset}" "$P_PATH"
+      return 0
+    fi
+    if [[ "$slines" -eq 0 ]]; then
+      # count / files_with_matches: the result is a number or a path list.
+      return 0
+    fi
+    eff_limit="$slines"
+    eff_offset=0
+  else
+    return 0
+  fi
 
   # Direct call, not $( ) — see classify_size's comment. REQ_LINES/REQ_BYTES
   # must survive for cumulative_add and the log.
-  classify_size "$P_PATH" "$P_OFFSET" "$P_LIMIT" >/dev/null
+  classify_size "$P_PATH" "$eff_offset" "$eff_limit" >/dev/null
   class="$CLASS_RESULT"
   cumulative_add "$REQ_LINES" "$REQ_BYTES"
   decision="$(resolve_decision "$class")"

--- a/examples/token-optimizer/optimize.sh
+++ b/examples/token-optimizer/optimize.sh
@@ -53,6 +53,12 @@ P_AGENT_ID=""
 P_SESSION=""
 P_OUTPUT_MODE=""
 P_HEAD_LIMIT=0
+# Context expansion is part of the requested size. head_limit bounds the number
+# of MATCHES, not emitted lines, so 100 matches with -C 10 can emit ~2100 lines
+# and used to sail through a 350-line gate as "100".
+P_CTX_BEFORE=0
+P_CTX_AFTER=0
+P_MULTILINE="false"
 
 usage() {
   cat <<'EOF'
@@ -256,6 +262,7 @@ normalize_payload() {
   P_TOOL=""; P_PATH=""; P_OFFSET=0; P_LIMIT=0
   P_COMMAND=""; P_AGENT_TYPE=""; P_AGENT_ID=""; P_SESSION=""
   P_OUTPUT_MODE=""; P_HEAD_LIMIT=0
+  P_CTX_BEFORE=0; P_CTX_AFTER=0; P_MULTILINE="false"
 
   command -v jq >/dev/null 2>&1 || { degrade "jq not installed"; return 1; }
 
@@ -293,29 +300,39 @@ normalize_payload() {
         , (.session_id // .sessionId // "")
         , ($a.output_mode // "")
         , (($a.head_limit // 0) | tostring)
+        # Context flags are named exactly "-A" / "-B" / "-C" in the tool schema,
+        # so they need bracket lookup. -C sets both sides when the one-sided
+        # flags are absent.
+        , ((($a["-B"] // $a["-C"]) // 0) | tostring)
+        , ((($a["-A"] // $a["-C"]) // 0) | tostring)
+        , (($a.multiline // false) | tostring)
         , (if ($ti.ok and $ta.ok) then "ok" else "malformed" end)
         ] | map(. + "\u0000") | join("")
     ' 2>/dev/null
   )
 
-  # Exactly eight fields, or the parse failed. This also catches malformed JSON,
-  # where jq emits nothing at all.
-  if [[ "${#f[@]}" -ne 11 ]]; then
-    degrade "payload parse failed (${#f[@]} of 11 fields)"
+  # Exactly fourteen fields, or the parse failed. This also catches malformed
+  # JSON, where jq emits nothing at all.
+  if [[ "${#f[@]}" -ne 14 ]]; then
+    degrade "payload parse failed (${#f[@]} of 14 fields)"
     return 1
   fi
 
   P_TOOL="${f[0]}"; P_PATH="${f[1]}"; P_OFFSET="${f[2]}"; P_LIMIT="${f[3]}"
   P_COMMAND="${f[4]}"; P_AGENT_TYPE="${f[5]}"; P_AGENT_ID="${f[6]}"; P_SESSION="${f[7]}"
   P_OUTPUT_MODE="${f[8]}"; P_HEAD_LIMIT="${f[9]}"
+  P_CTX_BEFORE="${f[10]}"; P_CTX_AFTER="${f[11]}"; P_MULTILINE="${f[12]}"
   is_uint "$P_OFFSET" || P_OFFSET=0
   is_uint "$P_LIMIT"  || P_LIMIT=0
   is_uint "$P_HEAD_LIMIT" || P_HEAD_LIMIT=0
+  is_uint "$P_CTX_BEFORE" || P_CTX_BEFORE=0
+  is_uint "$P_CTX_AFTER"  || P_CTX_AFTER=0
+  [[ "$P_MULTILINE" == "true" ]] || P_MULTILINE="false"
 
   # Malformed tool arguments must not pass as an empty read. Fail open as
   # always, but say so, so an unclassifiable payload is visible in the log
   # instead of looking like a small read.
-  if [[ "${f[10]}" != "ok" ]]; then
+  if [[ "${f[13]}" != "ok" ]]; then
     degrade "tool arguments were neither an object nor valid JSON"
     return 1
   fi
@@ -376,15 +393,33 @@ is_search_tool() {
 # count or a filenames-only search returns effectively nothing; an unbounded
 # content search cannot be predicted from the file at all.
 search_requested_lines() {
-  # search_requested_lines <output_mode> <head_limit>  -> lines, or empty if unsizable
-  local mode head
+  # search_requested_lines <output_mode> <head_limit> <before> <after> <multiline>
+  #   -> an upper bound on OUTPUT LINES, or return 1 when the request does not
+  #      bound its own output.
+  #
+  # Every number here comes from the REQUEST. The file is never opened: sizing a
+  # search from its source bytes is what made a `head_limit: 10` grep that
+  # returns 7 bytes look like a 40 KiB read.
+  local mode head before after multiline span bound
   mode="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
-  head="${2:-0}"
+  head="${2:-0}"; before="${3:-0}"; after="${4:-0}"; multiline="${5:-false}"
   case "$mode" in
     count|files_with_matches|files-with-matches) printf '0' ; return 0 ;;
   esac
-  if is_uint "$head" && [[ "$head" -gt 0 ]]; then printf '%s' "$head"; return 0; fi
-  return 1
+  is_uint "$head" && [[ "$head" -gt 0 ]] || return 1
+  is_uint "$before" || before=0
+  is_uint "$after"  || after=0
+
+  # multiline lets ONE match span arbitrarily many lines, and nothing in the
+  # request caps that. Unsizable — say so rather than claim head_limit bounds it.
+  [[ "$multiline" == "true" ]] && return 1
+
+  # head_limit counts MATCHES. Each match emits at most 1 + before + after lines,
+  # and grep adds a `--` separator between non-contiguous groups.
+  span=$(( 1 + before + after ))
+  bound=$(( head * span ))
+  [[ "$span" -gt 1 ]] && bound=$(( bound + head ))
+  printf '%s' "$bound"
 }
 
 REQ_LINES=0
@@ -703,43 +738,55 @@ run_hook_mode() {
     return 0
   fi
 
-  [[ -n "$P_PATH" ]] || return 0
-
   local eff_limit="$P_LIMIT" eff_offset="$P_OFFSET"
   if is_content_read_tool "$P_TOOL"; then
+    # A content read reads ONE named file, so without a path there is nothing to
+    # size. This requirement belongs here and nowhere earlier.
+    [[ -n "$P_PATH" ]] || return 0
     : # the file's size is the cost; classify it as given
   elif is_search_tool "$P_TOOL"; then
+    # A search does NOT need a path. glob / list / codebase / usages routinely
+    # omit one, and a repository-wide grep does too. A blanket path requirement
+    # ABOVE this branch meant a pathless request with head_limit: 900 returned
+    # before the line gate and before the search_unsizable audit — it logged
+    # nothing at all, so the bypass was invisible. Searches key on their scope
+    # instead, so bounded recovery and the log always have a stable identifier.
+    local skey="${P_PATH:-search-scope:${P_TOOL}}"
     # Size the SEARCH OUTPUT, never the underlying file.
     local slines
-    if ! slines="$(search_requested_lines "$P_OUTPUT_MODE" "$P_HEAD_LIMIT")"; then
-      # Unbounded content search: its output cannot be derived from the file, so
-      # there is nothing honest to classify. Pass.
-      log_line "audit" "search_unsizable" "${P_TOOL} mode=${P_OUTPUT_MODE:-unset}" "$P_PATH"
+    if ! slines="$(search_requested_lines "$P_OUTPUT_MODE" "$P_HEAD_LIMIT" \
+                     "$P_CTX_BEFORE" "$P_CTX_AFTER" "$P_MULTILINE")"; then
+      # The request does not bound its own output (no head_limit, or multiline
+      # where one match spans arbitrarily many lines). Nothing honest to
+      # classify, so pass — but leave the reason in the log.
+      log_line "audit" "search_unsizable" \
+        "${P_TOOL} mode=${P_OUTPUT_MODE:-unset} multiline=${P_MULTILINE}" "$skey"
       return 0
     fi
     if [[ "$slines" -eq 0 ]]; then
       # count / files_with_matches: the result is a number or a path list.
       return 0
     fi
-    # head_limit is an UPPER BOUND on output lines. Size it on that alone and
-    # never touch the source file — see classify_lines_only.
+    # slines is an upper bound on output lines derived purely from the request —
+    # head_limit expanded by any -A/-B/-C context. Never touches the source
+    # file; see classify_lines_only.
     classify_lines_only "$slines" >/dev/null
     class="$CLASS_RESULT"
     cumulative_add "$REQ_LINES" "$REQ_BYTES"
     decision="$(resolve_decision "$class")"
     case "$decision" in
       redirect)
-        if [[ "$(redirect_attempts "$P_PATH")" -ge 1 ]]; then
-          log_line "redirect_exhausted" "recovery_bound" "$P_TOOL" "$P_PATH"; return 0
+        if [[ "$(redirect_attempts "$skey")" -ge 1 ]]; then
+          log_line "redirect_exhausted" "recovery_bound" "$P_TOOL" "$skey"; return 0
         fi
-        if ! record_redirect_attempt "$P_PATH"; then
-          log_line "recovery_unavailable" "state_write_failed" "$P_TOOL" "$P_PATH"; return 0
+        if ! record_redirect_attempt "$skey"; then
+          log_line "recovery_unavailable" "state_write_failed" "$P_TOOL" "$skey"; return 0
         fi
-        log_line "redirect" "search_head_limit" "$P_TOOL" "$P_PATH"
-        emit_redirect "$(redirect_reason "$P_PATH")"
+        log_line "redirect" "search_head_limit" "$P_TOOL" "$skey"
+        emit_redirect "$(redirect_reason "$skey")"
         exit $?
         ;;
-      audit) log_line "would_redirect" "search_head_limit" "$P_TOOL" "$P_PATH"; return 0 ;;
+      audit) log_line "would_redirect" "search_head_limit" "$P_TOOL" "$skey"; return 0 ;;
       *) return 0 ;;
     esac
   else

--- a/examples/token-optimizer/optimize.sh
+++ b/examples/token-optimizer/optimize.sh
@@ -270,7 +270,14 @@ normalize_payload() {
       def parsed(g):
         g | if   type == "object" then {ok: true,  v: .}
             elif type == "null"   then {ok: true,  v: {}}
-            elif type == "string" then (try {ok: true, v: fromjson} catch {ok: false, v: {}})
+            elif type == "string" then
+              # Must decode to an OBJECT. `try {ok: true, v: fromjson}` accepted
+              # a scalar or an array, so toolArgs: "null" / "[]" / "42" decoded
+              # "successfully", collapsed to {}, and passed with an empty path and
+              # no degradation — the same silent hole as the unparsed string.
+              (try (fromjson | if type == "object" then {ok: true, v: .}
+                               else {ok: false, v: {}} end)
+               catch {ok: false, v: {}})
             else {ok: false, v: {}} end;
       parsed(.tool_input) as $ti
       | parsed(.toolArgs) as $ta

--- a/examples/token-optimizer/optimize.sh
+++ b/examples/token-optimizer/optimize.sh
@@ -432,6 +432,24 @@ classify_size() {
   echo "pass"
 }
 
+# Classify by a REQUESTED LINE COUNT alone, with no reference to any file.
+# Search output is not a prefix of the source: a content search for a pattern on
+# the last line of a 40 KiB single-line file returns 7 bytes, while the first
+# `head_limit` source lines are the whole 40 KiB. Measuring source bytes to size
+# search output denied that search. Bytes are unknowable before the search runs,
+# so they are not guessed — REQ_BYTES stays 0 and only the line bound applies.
+classify_lines_only() {
+  # classify_lines_only <requested_lines>  ->  "pass" | "oversized"
+  local requested="${1:-0}"
+  REQ_LINES=0; REQ_BYTES=0; TOTAL_LINES=0
+  is_uint "$requested" || { CLASS_RESULT="pass"; echo "pass"; return 0; }
+  REQ_LINES="$requested"
+  if [[ "$REQ_LINES" -gt "$MAX_LINES" ]]; then
+    CLASS_RESULT="oversized"; echo "oversized"; return 0
+  fi
+  CLASS_RESULT="pass"; echo "pass"
+}
+
 is_whole_file_read() {
   # Reporting only. Never affects the pass/fail outcome.
   local total="${1:-0}" requested="${2:-0}" ratio
@@ -696,8 +714,27 @@ run_hook_mode() {
       # count / files_with_matches: the result is a number or a path list.
       return 0
     fi
-    eff_limit="$slines"
-    eff_offset=0
+    # head_limit is an UPPER BOUND on output lines. Size it on that alone and
+    # never touch the source file — see classify_lines_only.
+    classify_lines_only "$slines" >/dev/null
+    class="$CLASS_RESULT"
+    cumulative_add "$REQ_LINES" "$REQ_BYTES"
+    decision="$(resolve_decision "$class")"
+    case "$decision" in
+      redirect)
+        if [[ "$(redirect_attempts "$P_PATH")" -ge 1 ]]; then
+          log_line "redirect_exhausted" "recovery_bound" "$P_TOOL" "$P_PATH"; return 0
+        fi
+        if ! record_redirect_attempt "$P_PATH"; then
+          log_line "recovery_unavailable" "state_write_failed" "$P_TOOL" "$P_PATH"; return 0
+        fi
+        log_line "redirect" "search_head_limit" "$P_TOOL" "$P_PATH"
+        emit_redirect "$(redirect_reason "$P_PATH")"
+        exit $?
+        ;;
+      audit) log_line "would_redirect" "search_head_limit" "$P_TOOL" "$P_PATH"; return 0 ;;
+      *) return 0 ;;
+    esac
   else
     return 0
   fi

--- a/examples/token-optimizer/tests/optimize_test.sh
+++ b/examples/token-optimizer/tests/optimize_test.sh
@@ -307,6 +307,48 @@ case "$big_hay" in *'"permissionDecision":"deny"'*) ok "head_limit above max_lin
 rm -f .token-optimizer/state/*
 hay_read="$(hook "{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$W/hay.txt\"},\"session_id\":\"S-H\"}" claude redirect.yaml)"
 case "$hay_read" in *'"permissionDecision":"deny"'*) ok "a whole-file Read of the same file is denied on real bytes" ;; *) no "whole-file Read denied" "deny envelope" "$hay_read" ;; esac
+
+echo "=== a search without a path is still classified ==="
+# `[[ -n "$P_PATH" ]] || return 0` used to sit ABOVE the search branch. glob, list,
+# codebase and usages routinely omit a path, and a repo-wide grep does too, so a
+# pathless head_limit:900 returned before the line gate AND before the
+# search_unsizable audit — it logged nothing at all, making the bypass invisible.
+nopath() { printf '{"tool_name":"%s","tool_input":{"pattern":"x"%s},"session_id":"S-NP"}' "$1" "$2"; }
+rm -f .token-optimizer/state/*
+np_grep="$(hook "$(nopath Grep ',"output_mode":"content","head_limit":900')" claude redirect.yaml)"
+case "$np_grep" in *'"permissionDecision":"deny"'*) ok "pathless grep with head_limit=900 IS denied" ;; *) no "pathless grep denied" "deny envelope" "$np_grep" ;; esac
+rm -f .token-optimizer/state/*
+np_glob="$(hook "$(nopath Glob ',"head_limit":900')" claude redirect.yaml)"
+case "$np_glob" in *'"permissionDecision":"deny"'*) ok "pathless glob with head_limit=900 IS denied" ;; *) no "pathless glob denied" "deny envelope" "$np_glob" ;; esac
+rm -f .token-optimizer/state/*
+eq "pathless grep under max_lines is not denied" "" "$(hook "$(nopath Grep ',"output_mode":"content","head_limit":10')" claude redirect.yaml)"
+eq "pathless unbounded grep is not denied"       "" "$(hook "$(nopath Grep ',"output_mode":"content"')" claude redirect.yaml)"
+# a content read still needs a path — that requirement moved, it did not vanish
+eq "a Read with no path is still a no-op" "" "$(hook '{"tool_name":"Read","tool_input":{},"session_id":"S-NP"}' claude redirect.yaml)"
+
+echo "=== head_limit counts matches, so -A/-B/-C expansion counts too ==="
+# head_limit bounds MATCHES, not emitted lines. 100 matches with -C 10 can emit
+# ~2100 lines, which sailed through a max_lines:350 gate classified as "100".
+ctx() { printf '{"tool_name":"Grep","tool_input":{"path":"%s/large.tf","pattern":"line","output_mode":"content","head_limit":100%s},"session_id":"S-CTX"}' "$W" "$1"; }
+rm -f .token-optimizer/state/*
+eq "head_limit=100 with no context is not denied" "" "$(hook "$(ctx '')" claude redirect.yaml)"
+rm -f .token-optimizer/state/*
+ctx_c="$(hook "$(ctx ',"-C":10')" claude redirect.yaml)"
+case "$ctx_c" in *'"permissionDecision":"deny"'*) ok "head_limit=100 with -C 10 (bound 2200) IS denied" ;; *) no "-C 10 denied" "deny envelope" "$ctx_c" ;; esac
+rm -f .token-optimizer/state/*
+ctx_a="$(hook "$(ctx ',"-A":2')" claude redirect.yaml)"
+case "$ctx_a" in *'"permissionDecision":"deny"'*) ok "head_limit=100 with -A 2 (bound 400) IS denied" ;; *) no "-A 2 denied" "deny envelope" "$ctx_a" ;; esac
+# multiline lets ONE match span arbitrarily many lines and nothing in the request
+# caps that, so it is unsizable: pass and audit rather than claim a bound.
+rm -f .token-optimizer/state/*
+eq "multiline search is unsizable, so not denied" "" "$(hook "$(printf '{"tool_name":"Grep","tool_input":{"path":"%s/large.tf","pattern":"line","output_mode":"content","head_limit":10,"multiline":true},"session_id":"S-CTX"}' "$W")" claude redirect.yaml)"
+# the derivation is purely request-side: assert the arithmetic directly
+ctx_bound="$(bash -c 'source '"$OPT"' --source-only; search_requested_lines content 100 10 10 false')"
+eq "search_requested_lines expands 100 matches with -C 10 to 2200" "2200" "$ctx_bound"
+ctx_plain="$(bash -c 'source '"$OPT"' --source-only; search_requested_lines content 100 0 0 false')"
+eq "search_requested_lines leaves 100 matches with no context at 100" "100" "$ctx_plain"
+ml_rc="$(bash -c 'source '"$OPT"' --source-only; search_requested_lines content 10 0 0 true >/dev/null; echo $?')"
+eq "search_requested_lines reports multiline as unsizable" "1" "$ml_rc"
 # and the line-only classifier must never report source bytes
 lineonly="$(bash -c 'source '"$OPT"' --source-only; MAX_LINES=350; MAX_BYTES=32768
   classify_lines_only 10 >/dev/null; printf "%s|%s" "$REQ_LINES" "$REQ_BYTES"')"

--- a/examples/token-optimizer/tests/optimize_test.sh
+++ b/examples/token-optimizer/tests/optimize_test.sh
@@ -264,6 +264,34 @@ cmd_out="$(bash -c 'source '"$OPT"' --source-only
   printf "%s" "$P_SESSION"')"
 eq "multiline shell command does not shift the session id" "S-CMD" "$cmd_out"
 
+echo "=== searches are sized by their output, never by the underlying file ==="
+# A Grep with output_mode=count against a 1000-line file returns one number.
+# Classifying it by file size denied it — a false positive that spends a
+# delegation on nothing and makes the optimizer look broken.
+grep_payload() { printf '{"tool_name":"Grep","tool_input":{"path":"%s/large.tf","pattern":"line"%s},"session_id":"S-G"}' "$W" "$1"; }
+rm -f .token-optimizer/state/*
+eq "grep output_mode=count is not denied"            "" "$(hook "$(grep_payload ',"output_mode":"count"')" claude redirect.yaml)"
+eq "grep files_with_matches is not denied"           "" "$(hook "$(grep_payload ',"output_mode":"files_with_matches"')" claude redirect.yaml)"
+eq "grep content with small head_limit is not denied" "" "$(hook "$(grep_payload ',"output_mode":"content","head_limit":10')" claude redirect.yaml)"
+eq "unbounded content grep is not denied"            "" "$(hook "$(grep_payload ',"output_mode":"content"')" claude redirect.yaml)"
+rm -f .token-optimizer/state/*
+big_grep="$(hook "$(grep_payload ',"output_mode":"content","head_limit":900')" claude redirect.yaml)"
+case "$big_grep" in *'"permissionDecision":"deny"'*) ok "grep content with head_limit above max_lines IS denied" ;; *) no "grep head_limit=900 denied" "deny envelope" "$big_grep" ;; esac
+# control: the same file read wholesale must still be denied
+rm -f .token-optimizer/state/*
+whole="$(hook "$BIG" claude redirect.yaml)"
+case "$whole" in *'"permissionDecision":"deny"'*) ok "control: a whole-file Read is still denied" ;; *) no "control: whole-file Read denied" "deny envelope" "$whole" ;; esac
+
+echo "=== tool arguments sent as a JSON string are parsed, not discarded ==="
+argstr="$(bash -c 'source '"$OPT"' --source-only
+  normalize_payload "{\"toolName\":\"view\",\"toolArgs\":\"{\\\"path\\\":\\\"/x/large.tf\\\"}\"}"
+  printf "%s" "$P_PATH"')"
+eq "JSON-string toolArgs yields the path" "/x/large.tf" "$argstr"
+malformed="$(bash -c 'source '"$OPT"' --source-only
+  DEGRADED=0; normalize_payload "{\"toolName\":\"view\",\"toolArgs\":\"cat main.tf\"}" >/dev/null 2>&1
+  printf "%s" "$DEGRADED"')"
+eq "non-JSON string toolArgs degrades rather than passing silently" "1" "$malformed"
+
 echo
 echo "PASS: $PASS   FAIL: $FAIL"
 [[ "$FAIL" -eq 0 ]] || exit 1

--- a/examples/token-optimizer/tests/optimize_test.sh
+++ b/examples/token-optimizer/tests/optimize_test.sh
@@ -312,6 +312,22 @@ lineonly="$(bash -c 'source '"$OPT"' --source-only; MAX_LINES=350; MAX_BYTES=327
   classify_lines_only 10 >/dev/null; printf "%s|%s" "$REQ_LINES" "$REQ_BYTES"')"
 eq "classify_lines_only reports no bytes at all" "10|0" "$lineonly"
 
+echo "=== string tool arguments must decode to an OBJECT, not any JSON value ==="
+# `try {ok:true, v:fromjson}` accepted a scalar or an array, so toolArgs "null",
+# "[]" or "42" decoded "successfully", collapsed to {}, and passed with an empty
+# path and no degradation — the same silent hole as an unparsed string.
+for bad in 'null' '[]' '42' '"just a string"'; do
+  d="$(bash -c 'source '"$OPT"' --source-only
+    DEGRADED=0
+    normalize_payload "{\"toolName\":\"view\",\"toolArgs\":\"'"$(printf '%s' "$bad" | sed 's/"/\\\\"/g')"'\"}" >/dev/null 2>&1
+    printf "%s" "$DEGRADED"')"
+  eq "toolArgs decoding to $bad degrades" "1" "$d"
+done
+okpath="$(bash -c 'source '"$OPT"' --source-only
+  normalize_payload "{\"toolName\":\"view\",\"toolArgs\":\"{\\\"path\\\":\\\"/x/a.tf\\\"}\"}"
+  printf "%s" "$P_PATH"')"
+eq "a JSON object string still yields its path" "/x/a.tf" "$okpath"
+
 echo
 echo "PASS: $PASS   FAIL: $FAIL"
 [[ "$FAIL" -eq 0 ]] || exit 1

--- a/examples/token-optimizer/tests/optimize_test.sh
+++ b/examples/token-optimizer/tests/optimize_test.sh
@@ -292,6 +292,26 @@ malformed="$(bash -c 'source '"$OPT"' --source-only
   printf "%s" "$DEGRADED"')"
 eq "non-JSON string toolArgs degrades rather than passing silently" "1" "$malformed"
 
+echo "=== search output is never sized from unrelated source bytes ==="
+# 40,000 unrelated characters on line 1, then `needle` on line 2. A content search
+# for needle with head_limit 10 returns 7 bytes, but sizing the first 10 SOURCE
+# lines measured 40,008 and denied it.
+{ awk 'BEGIN{s="";for(i=1;i<=40000;i++) s=s "x"; print s}'; echo "needle"; } > "$W/hay.txt"
+hay_payload() { printf '{"tool_name":"Grep","tool_input":{"path":"%s/hay.txt","pattern":"needle","output_mode":"content","head_limit":%s},"session_id":"S-H"}' "$W" "$1"; }
+rm -f .token-optimizer/state/*
+eq "small head_limit on a huge-line file is not denied" "" "$(hook "$(hay_payload 10)" claude redirect.yaml)"
+rm -f .token-optimizer/state/*
+big_hay="$(hook "$(hay_payload 900)" claude redirect.yaml)"
+case "$big_hay" in *'"permissionDecision":"deny"'*) ok "head_limit above max_lines is still denied" ;; *) no "head_limit=900 denied" "deny envelope" "$big_hay" ;; esac
+# the same file read wholesale IS large, and must still be denied on real bytes
+rm -f .token-optimizer/state/*
+hay_read="$(hook "{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$W/hay.txt\"},\"session_id\":\"S-H\"}" claude redirect.yaml)"
+case "$hay_read" in *'"permissionDecision":"deny"'*) ok "a whole-file Read of the same file is denied on real bytes" ;; *) no "whole-file Read denied" "deny envelope" "$hay_read" ;; esac
+# and the line-only classifier must never report source bytes
+lineonly="$(bash -c 'source '"$OPT"' --source-only; MAX_LINES=350; MAX_BYTES=32768
+  classify_lines_only 10 >/dev/null; printf "%s|%s" "$REQ_LINES" "$REQ_BYTES"')"
+eq "classify_lines_only reports no bytes at all" "10|0" "$lineonly"
+
 echo
 echo "PASS: $PASS   FAIL: $FAIL"
 [[ "$FAIL" -eq 0 ]] || exit 1

--- a/examples/token-optimizer/vscode/platform-bulk-reader.agent.md
+++ b/examples/token-optimizer/vscode/platform-bulk-reader.agent.md
@@ -56,3 +56,5 @@ So this frontmatter is a request, not proof. Confirm the model that actually res
 ## Delegation status: unverified
 
 Delegation on this client is not confirmed by a runtime fixture. VS Code documents handoffs as user-selected agent transitions, which save no parent context. Treat this as routing guidance until `doctor` reports otherwise.
+
+**Unverified means not demonstrated — not proven absent.** GitHub documents an `agent` tool alias, and its absence from a given CLI build's `--help` output is not evidence that delegation is unavailable. Check tool availability against the installed client version and the official documentation before concluding anything. Equally, `handoffs` on its own does not demonstrate the opposite: it does not prove a separate worker context or a return to the parent. Neither reading is settled here, which is exactly why nothing claims working delegation or a saving until an authenticated runtime test shows both.

--- a/references/token-optimizer.md
+++ b/references/token-optimizer.md
@@ -172,6 +172,32 @@ An earlier draft used total line count where requested line count was correct, a
 
 2. **Estimated range bytes missed fat-line files.** A file with five 40 KiB lines has 200 KiB in the first five lines, but `total_bytes * (5 / total_lines)` reports a tiny number. The fix is `sed -n` plus `wc -c` on the actual range: measure, never estimate.
 
+## Search classification
+
+A search is sized by **what it will emit**, never by the file it scans. `classify_lines_only` compares the line bound alone and leaves `REQ_BYTES` at 0, because there is no honest way to derive matching-result bytes from unrelated source bytes.
+
+`search_requested_lines` derives that bound **purely from the request**. The file is never opened:
+
+| Request | Bound | Decision |
+|---|---|---|
+| `output_mode: count` or `files_with_matches` | 0 | pass — the result is a number or a path list |
+| `head_limit: N`, no context | `N` | gate on `N` |
+| `head_limit: N` with `-A a` / `-B b` / `-C c` | `N × (1 + b + a) + N` | gate on the expanded bound |
+| `multiline: true` | none | unsizable — pass and log `search_unsizable` |
+| no `head_limit` | none | unsizable — pass and log `search_unsizable` |
+
+`-C` sets both sides when the one-sided flags are absent. The trailing `+ N` covers the `--` separator grep emits between non-contiguous groups.
+
+**Why context expansion counts.** `head_limit` bounds the number of *matches*, not emitted lines. 100 matches with `-C 10` can emit roughly 2,100 lines, which passed a `max_lines: 350` gate classified as "100". Claiming the limit was enforced there was simply false.
+
+**Why unsizable means pass.** When the request does not bound its own output there is nothing to compare, so the call proceeds and the reason lands in the log. Guessing a bound would deny reads that return almost nothing — the failure mode below.
+
+### Two more holes, both from sizing searches wrong
+
+1. **Sizing search output from source bytes.** A file with 40,000 unrelated characters on line 1 and `needle` on line 2 returns 7 bytes for a `head_limit: 10` content search, but measuring the first 10 *source* lines reported 40,008 and denied it. Searches are now sized on the request's own line bound and never touch the file.
+
+2. **Requiring a path before classifying.** `glob`, `list`, `codebase` and `usages` routinely omit a path, and a repository-wide grep does too. A blanket path check ahead of the search branch meant a pathless `head_limit: 900` returned before both the line gate and the `search_unsizable` audit — it logged nothing at all, so the bypass was invisible. The path requirement now sits inside the content-read branch, where it belongs; searches key on a scope label so bounded recovery and the log always have a stable identifier.
+
 ## Shell detection limits
 
 `detect_shell_full_read` recognises `cat`, `less`, `more`, `bat`, and `head`/`tail` with `-n` counts that exceed `max_lines`. The command string is **pattern matched only**, never executed, evaluated, or passed to a subshell.

--- a/references/token-optimizer.md
+++ b/references/token-optimizer.md
@@ -61,6 +61,8 @@ Claude Code is the only client where redirection is architecturally possible. Ev
 
 `handoffs` appears in the Copilot templates as a frontmatter field but is **not** confirmed to be a subagent dispatch. Presence of a field means the field parses, not that an execution model exists. No delegation primitive is verified as working on Copilot CLI or VS Code until a runtime fixture runs and a human confirms the answer-key path list appeared in the parent's context.
 
+Read "unverified" strictly: not demonstrated, not proven absent. GitHub documents an `agent` tool alias, and its absence from a particular CLI build's `--help` output is not evidence that delegation cannot work — tool availability has to be checked against the installed client version and the official documentation. `handoffs` does not settle it in the other direction either, since it does not demonstrate a separate worker context or a return to the parent. Both remain open, which is why no delegation or saving is claimed for these clients.
+
 ## The capability probe gate
 
 Three questions determine whether a client can reach `redirect` mode:


### PR DESCRIPTION
Addresses a review of v1.41.0 at `e8a972c`. Six of the seven findings are fixed; the seventh is answered rather than actioned, with reasoning below.

Both reported bugs were reproduced against merged `main` before being fixed.

## Confirmed bug — a count-only search triggered a delegation

```
Grep {"path": "big.tf", "pattern": "line", "output_mode": "count"}   →  DENIED
```

The core classified the underlying 1000-line file. A count returns **one number**. This is the worst kind of false positive: it spends a delegation on nothing and makes the optimizer look broken on first contact.

Root cause: `is_read_tool` lumped `grep`/`glob`/`find`/`ls` in with `read`/`cat`, and `classify_size` then sized `$P_PATH`. For a search, file size says nothing about output size.

Split into two predicates:

| Tool class | Members | Sized by |
|---|---|---|
| content read | `read`, `view`, `cat`, `readfile`, `notebookread`, `str_replace_editor_view` | the file |
| search | `grep`, `search`, `glob`, `find`, `ls`, `list`, `codebase`, `usages` | its own output |

Search sizing follows the payload's own semantics:

| Case | Outcome |
|---|---|
| `output_mode: count` / `files_with_matches` | pass — the result is a number or a path list |
| `output_mode: content` with `head_limit` | sized by `head_limit` |
| `output_mode: content`, unbounded | pass, with an `audit / search_unsizable` line — not derivable from the file |
| whole-file `Read` (control) | **still denied** |

Verified all five, including the control.

## Confirmed bug — JSON-string tool arguments vanished silently

| Payload | Extracted path | Before | After |
|---|---|---|---|
| object `toolArgs` | `/x/large.tf` | ✅ | ✅ |
| JSON-string `toolArgs` | `/x/large.tf` | **empty, `DEGRADED=0`** | ✅ extracted |
| non-JSON string | — | empty, silent | degrades **and logs** |

The old `def obj(g)` coerced any non-object to `{}`, so a string-encoded argument lost the path and the read passed unclassified *and* unlogged. Silence was the damaging part — it looked like a small read. Now a string is parsed, and genuinely malformed arguments produce:

```
degraded  optimizer_unavailable  tool arguments were neither an object nor valid JSON
```

## `remove` was deleting users' edits

Line 551 said a marked asset whose content differs "is still removed". That loses work to a command whose own wizard promises "owned, **unmodified** assets".

This had become a trap between two reviews. Hashing the *shipped* file made uninstall inert, because `setup` injects an ownership marker and that changes the content — so the hash was dropped, which fixed uninstall and started deleting edited files.

Both properties hold if `setup` hashes **what it generated**:

- `setup` writes `.token-optimizer/installed.sha256` — the SHA-256 of each file *as written*, marker included
- `remove` recomputes: match → delete; mismatch → **preserve** and report `preserved (locally modified): <path>`
- no marker and no manifest entry → never touched

The marker proves ownership. It does not prove deletion is safe.

## The chosen worker model was never wired in

`setup` asked for a model, wrote `worker_model` to the config, then copied templates carrying a fixed `model:` and never reconciled them. Choosing `gpt-5-mini` left a reader pinned to `claude-haiku-4.5` — and on Copilot, where the mode is capped to audit, the redirect reason that would have carried the choice is never emitted either, so nothing surfaced the mismatch.

Added the frontmatter rewrite, scoped to the **reader** only. Coordinators are deliberately excluded: the Copilot CLI coordinator sets no `model:` and inherits the session's, and the VS Code coordinator pins `claude-sonnet-4.6` as the *decision* model, which is not the worker model.

`doctor` also stopped calling a config value "resolved". It now reports **requested** (config, cross-checked against the installed frontmatter, flagging disagreement) and **observed** (only from a recorded probe run) as separate values.

## `doctor` claimed enforcement that does not exist

It stated Claude natively enforces agent-level `max_tokens`, `timeout` and `max_iterations`. Those are not documented subagent frontmatter fields, and the shipped worker sets no limit of any kind. All three budgets are now reported as **instruction-only on every client**, carried to the worker in the redirect reason and enforced by nothing.

## VS Code setup installed no hook

Setup told users to enable `chat.useCustomAgentHooks` while installing nothing for it to load — leaving them believing audit logging was active. Neither VS Code template carries a `hooks` field and no hook file is written for that client. Setup now says so plainly, and points at the repository-scoped Copilot surface if classification is actually wanted.

## The one finding I did not action

**Copilot coordinators lack a delegation tool.** The diagnosis is right and already shipped: both templates carry a "Delegation status: unverified" notice explaining that `handoffs` is a session transition rather than a dispatch that returns, and no cost claim is made for either Copilot client.

The prescribed fix I could not apply honestly:

- I found no `agent` tool alias in Copilot CLI 1.0.59. `--available-tools` and `--excluded-tools` exist; no such alias surfaced in any help topic. Adding one would be inventing a capability, which is the specific failure this feature's whole review history has been about.
- On "IDE-oriented names": the three Copilot agents already on this machine (`~/.copilot/agents/`) use exactly `codebase`, `search`, `usages`, `fetch`, `editFiles`, `runCommands` — the same names these templates use. So that is the convention here, not a defect I can demonstrate.

This is precisely what the shipped probe exists to settle, and it needs an authenticated client. Happy to wire a delegation tool the moment someone names one that exists.

## Validation

```bash
bash examples/token-optimizer/tests/optimize_test.sh      # 75/75
/bin/bash examples/token-optimizer/tests/optimize_test.sh # 75/75 on bash 3.2.57
bash tests/token-optimizer-script.sh                      # 8/8
bash tests/handbook-consistency.sh                        # PASS
bash tests/release-consistency.sh                         # PASS
bash tests/editor-version-consistency.sh                  # PASS
shellcheck -S warning examples/token-optimizer/optimize.sh
```

`tests/website-coverage.sh` is absent on this branch — it ships in #183, unmerged.

The reviewer noted they could not run the full regression suite because `yq` was unavailable. Worth flagging: without `yq` the core cannot read its config at all and fails open by design, so every classification passes. That is intended, but it means a `yq`-less environment cannot exercise the classification paths.

## Rollback

Three files. Reverting restores the previous classification, the silent string-args coercion, and the deleting `remove`.

## Not ready for review yet

Draft.
