### PR TITLE
chore(release): point marketplace source.sha at the 1.41.0 content commit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -194,7 +194,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/nitinjain999/platform-skills.git",
-        "sha": "386426911098ac0640f35146d0173f721a7e5e1f"
+        "sha": "a317b6d70276c58cbc773dc375407521946bf143"
       },
       "homepage": "https://github.com/nitinjain999/platform-skills"
     }


### PR DESCRIPTION
## Problem

`main` pins `source.sha: 3864269` — the **1.40.0** content commit — while `plugin.json` and `marketplace.json` both declare `1.41.0`. Every marketplace install of "1.41.0" therefore receives 1.40.0 content: no `/platform-skills:token-optimizer`, no `examples/token-optimizer/`, none of the website coverage work.

## Change

Repoints `source.sha` to `a317b6d`, the first commit carrying all of the 1.41.0 content:

| PR | Contribution |
|---|---|
| #181 | the command, the `optimize.sh` policy core, agent and hook templates, benchmark fixtures |
| #182 | homepage version derived from `plugin.json` instead of hardcoded |
| #183 | all 44 commands and 63 references in the sidebars, governance/cost section, drift gate |
| #184 | pathless-search classification, context expansion in the line bound, safe and correctly ordered uninstall |

**This PR touches `marketplace.json` and nothing else.** That is deliberate: a pin bundled with content changes excludes its own content from the pinned tree, which is why the repo splits the release into a content PR and this follow-up.

## Validation

Run on a clean worktree of `main` at `a317b6d`:

- `tests/*.sh` — 9 of 11 pass. The 2 failures (`validate-ci.sh`, `validate-skill.sh`) are present identically before this change and are not CI gates; #181–#184 all merged green.
- Validate YAML Files (workflow-only check) — 263 files, 0 invalid
- `tests/validate-terraform.sh` — pass
- `tests/website-coverage.sh` — pass
- `tests/release-consistency.sh` — pass
- `examples/token-optimizer/tests/optimize_test.sh` — 96 assertions, 0 failures, on bash 3.2.57 and 5.3.15

Pin checks:

- `a317b6d` is an ancestor of `main`
- `marketplace.json` is valid JSON, `version` is `1.41.0`, `description` is 729 chars (limit 1024)

## Rollback

Revert this commit. `source.sha` returns to `3864269` and marketplace installs go back to serving 1.40.0 content. No tag, no release asset, and no consumer state depends on it until `v1.41.0` is tagged.

## Note

`v1.41.0` is **not** tagged yet. Tagging is the next and final step, after this merges, so the release points at a tree whose pin is correct.